### PR TITLE
添加js跨插件互操作

### DIFF
--- a/src/main/java/cn/nukkit/plugin/CommonJSPlugin.java
+++ b/src/main/java/cn/nukkit/plugin/CommonJSPlugin.java
@@ -6,6 +6,7 @@ import cn.nukkit.command.Command;
 import cn.nukkit.command.CommandSender;
 import cn.nukkit.event.Listener;
 import cn.nukkit.plugin.js.ESMFileSystem;
+import cn.nukkit.plugin.js.JSExternal;
 import cn.nukkit.plugin.js.JSIInitiator;
 import cn.nukkit.plugin.js.JSProxyLogger;
 import cn.nukkit.utils.Config;
@@ -18,10 +19,12 @@ import org.graalvm.polyglot.Value;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class CommonJSPlugin implements Plugin, Listener {
 
     public static final Int2ObjectOpenHashMap<CommonJSPlugin> jsPluginIdMap = new Int2ObjectOpenHashMap<>();
+    public static final ConcurrentHashMap<String, JSExternal> jsExternalMap = new ConcurrentHashMap<>();
     public static int globalMaxId = 0;
 
     protected String pluginName;

--- a/src/main/java/cn/nukkit/plugin/js/JSExternal.java
+++ b/src/main/java/cn/nukkit/plugin/js/JSExternal.java
@@ -1,0 +1,11 @@
+package cn.nukkit.plugin.js;
+
+import lombok.Data;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+
+@Data
+public abstract class JSExternal {
+    protected final Context sourceContext;
+    protected final Value value;
+}

--- a/src/main/java/cn/nukkit/plugin/js/external/ExternalArray.java
+++ b/src/main/java/cn/nukkit/plugin/js/external/ExternalArray.java
@@ -1,0 +1,47 @@
+package cn.nukkit.plugin.js.external;
+
+import cn.nukkit.plugin.js.JSExternal;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+import org.graalvm.polyglot.proxy.ProxyArray;
+
+public final class ExternalArray extends JSExternal implements ProxyArray {
+    public ExternalArray(Context sourceContext, Value value) {
+        super(sourceContext, value);
+    }
+
+    @Override
+    public Object get(long index) {
+        synchronized (sourceContext) {
+            return value.getArrayElement(index);
+        }
+    }
+
+    @Override
+    public void set(long index, Value value) {
+        synchronized (sourceContext) {
+            value.setArrayElement(index, value);
+        }
+    }
+
+    @Override
+    public boolean remove(long index) {
+        synchronized (sourceContext) {
+            return value.removeArrayElement(index);
+        }
+    }
+
+    @Override
+    public long getSize() {
+        synchronized (sourceContext) {
+            return value.getArraySize();
+        }
+    }
+
+    @Override
+    public Object getIterator() {
+        synchronized (sourceContext) {
+            return value.getIterator();
+        }
+    }
+}

--- a/src/main/java/cn/nukkit/plugin/js/external/ExternalFunction.java
+++ b/src/main/java/cn/nukkit/plugin/js/external/ExternalFunction.java
@@ -1,0 +1,21 @@
+package cn.nukkit.plugin.js.external;
+
+import cn.nukkit.plugin.js.JSExternal;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+import org.graalvm.polyglot.proxy.ProxyExecutable;
+
+public final class ExternalFunction extends JSExternal implements ProxyExecutable {
+    public ExternalFunction(Context sourceContext, Value value) {
+        super(sourceContext, value);
+    }
+
+    @Override
+    public Object execute(Value... arguments) {
+        synchronized (sourceContext) {
+            if(value.canExecute())
+                return value.execute((Object[]) arguments);
+            return null;
+        }
+    }
+}

--- a/src/main/java/cn/nukkit/plugin/js/external/ExternalObject.java
+++ b/src/main/java/cn/nukkit/plugin/js/external/ExternalObject.java
@@ -1,0 +1,49 @@
+package cn.nukkit.plugin.js.external;
+
+import cn.nukkit.plugin.js.JSExternal;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Value;
+import org.graalvm.polyglot.proxy.ProxyObject;
+
+public final class ExternalObject extends JSExternal implements ProxyObject {
+    public ExternalObject(Context sourceContext, Value value) {
+        super(sourceContext, value);
+    }
+
+    @Override
+    public Object getMember(String key) {
+        synchronized (sourceContext) {
+            return value.getMember(key);
+        }
+    }
+
+    @Override
+    public Object getMemberKeys() {
+        synchronized (sourceContext) {
+            return value.getMemberKeys();
+        }
+
+    }
+
+    @Override
+    public boolean hasMember(String key) {
+        synchronized (sourceContext) {
+            return value.hasMember(key);
+        }
+
+    }
+
+    @Override
+    public void putMember(String key, Value value) {
+        synchronized (sourceContext) {
+            value.putMember(key, value);
+        }
+    }
+
+    @Override
+    public boolean removeMember(String key) {
+        synchronized (sourceContext) {
+            return value.removeMember(key);
+        }
+    }
+}


### PR DESCRIPTION
此PR添加了四个全局函数：  
- exposeFunction(exportName, jsFunction)
- exposeObject(exportName, jsObject)
- exposeArray(exportName, jsArray)
- contain(...names)

前三个函数用于将插件自身内部值导出到公有导出区，第四个函数用于从公有导出区获取引用，可以接受多个名称，返回数组。