### PR TITLE
Add support for WaterdogPE login extras.

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -228,7 +228,8 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
     protected Vector3 teleportPosition = null;
 
     protected boolean connected = true;
-    protected final InetSocketAddress socketAddress;
+    protected final InetSocketAddress rawSocketAddress;
+    protected InetSocketAddress socketAddress;
     protected boolean removeFormat = true;
 
     protected String username;
@@ -719,6 +720,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         this.perm = new PermissibleBase(this);
         this.server = Server.getInstance();
         this.lastBreak = -1;
+        this.rawSocketAddress = socketAddress;
         this.socketAddress = socketAddress;
         this.clientID = clientID;
         this.loaderId = Level.generateChunkLoaderId(this);
@@ -795,6 +797,18 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
         if (this.spawned) {
             this.server.updatePlayerListData(this.getUniqueId(), this.getId(), this.getDisplayName(), skin, this.getLoginChainData().getXUID());
         }
+    }
+
+    public String getRawAddress() {
+        return this.rawSocketAddress.getAddress().getHostAddress();
+    }
+
+    public int getRawPort() {
+        return this.rawSocketAddress.getPort();
+    }
+
+    public InetSocketAddress getRawSocketAddress() {
+        return this.rawSocketAddress;
     }
 
     public String getAddress() {
@@ -2606,6 +2620,10 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
                     if (this.server.getOnlinePlayers().size() >= this.server.getMaxPlayers() && this.kick(PlayerKickEvent.Reason.SERVER_FULL, "disconnectionScreen.serverFull", false)) {
                         break;
+                    }
+
+                    if (this.server.isWaterdogCapable() && loginChainData.getWaterdogIP() != null) {
+                        this.socketAddress = new InetSocketAddress(this.loginChainData.getWaterdogIP(), this.getRawPort());
                     }
 
                     this.randomClientId = loginPacket.clientId;

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -993,7 +993,7 @@ public class Server {
         List<InetSocketAddress> targets = new ArrayList<>();
         for (Player p : players) {
             if (p.isConnected()) {
-                targets.add(p.getSocketAddress());
+                targets.add(p.getRawSocketAddress());
             }
         }
 
@@ -2208,7 +2208,7 @@ public class Server {
     }
 
     public void removePlayer(Player player) {
-        Player toRemove = this.players.remove(player.getSocketAddress());
+        Player toRemove = this.players.remove(player.getRawSocketAddress());
         if (toRemove != null) {
             return;
         }
@@ -2863,6 +2863,12 @@ public class Server {
     @Since("1.6.0.0-PNX")
     public boolean isEnableExperimentMode() {
         return this.enableExperimentMode;
+    }
+
+    @PowerNukkitOnly
+    @Since("1.6.1.0-PN")
+    public boolean isWaterdogCapable() {
+        return this.getConfig("settings.waterdogpe", false);
     }
 
     private class ConsoleThread extends Thread implements InterruptibleThread {

--- a/src/main/java/cn/nukkit/network/RakNetInterface.java
+++ b/src/main/java/cn/nukkit/network/RakNetInterface.java
@@ -133,7 +133,7 @@ public class RakNetInterface implements RakNetServerListener, AdvancedSourceInte
 
     @Override
     public int getNetworkLatency(Player player) {
-        RakNetServerSession session = this.raknet.getSession(player.getSocketAddress());
+        RakNetServerSession session = this.raknet.getSession(player.getRawSocketAddress());
         return session == null ? -1 : (int) session.getPing();
     }
 
@@ -144,7 +144,7 @@ public class RakNetInterface implements RakNetServerListener, AdvancedSourceInte
 
     @Override
     public void close(Player player, String reason) {
-        RakNetServerSession session = this.raknet.getSession(player.getSocketAddress());
+        RakNetServerSession session = this.raknet.getSession(player.getRawSocketAddress());
         if (session != null) {
             session.close();
         }
@@ -215,7 +215,7 @@ public class RakNetInterface implements RakNetServerListener, AdvancedSourceInte
 
     @Override
     public Integer putPacket(Player player, DataPacket packet, boolean needACK, boolean immediate) {
-        NukkitRakNetSession session = this.sessions.get(player.getSocketAddress());
+        NukkitRakNetSession session = this.sessions.get(player.getRawSocketAddress());
 
         if (session != null) {
             packet.tryEncode();
@@ -256,12 +256,12 @@ public class RakNetInterface implements RakNetServerListener, AdvancedSourceInte
     public void onUnhandledDatagram(ChannelHandlerContext ctx, DatagramPacket datagramPacket) {
         this.server.handlePacket(datagramPacket.sender(), datagramPacket.content());
     }
-    
+
     @PowerNukkitOnly
     @Since("1.5.2.0-PN")
     @Override
     public Integer putResourcePacket(Player player, DataPacket packet) {
-        NukkitRakNetSession session = this.sessions.get(player.getSocketAddress());
+        NukkitRakNetSession session = this.sessions.get(player.getRawSocketAddress());
 
         if (session != null) {
             packet.tryEncode();
@@ -270,7 +270,7 @@ public class RakNetInterface implements RakNetServerListener, AdvancedSourceInte
 
         return null;
     }
-    
+
     @RequiredArgsConstructor
     private class NukkitRakNetSession implements RakNetSessionListener {
         private final RakNetServerSession raknet;
@@ -363,7 +363,7 @@ public class RakNetInterface implements RakNetServerListener, AdvancedSourceInte
             byteBuf.writeBytes(payload);
             this.raknet.send(byteBuf);
         }
-        
+
         private void sendPacketImmediately(DataPacket packet) {
             BinaryStream batched = new BinaryStream();
             Preconditions.checkArgument(!(packet instanceof BatchPacket), "Cannot batch BatchPacket");
@@ -381,7 +381,7 @@ public class RakNetInterface implements RakNetServerListener, AdvancedSourceInte
                 log.error("Error occured while sending a packet immediately", e);
             }
         }
-        
+
         private void sendResourcePacket(DataPacket packet) {
             BinaryStream batched = new BinaryStream();
             Preconditions.checkArgument(!(packet instanceof BatchPacket), "Cannot batch BatchPacket");

--- a/src/main/java/cn/nukkit/utils/ClientChainData.java
+++ b/src/main/java/cn/nukkit/utils/ClientChainData.java
@@ -1,5 +1,6 @@
 package cn.nukkit.utils;
 
+import cn.nukkit.Server;
 import cn.nukkit.network.protocol.LoginPacket;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -108,7 +109,11 @@ public final class ClientChainData implements LoginChainData {
 
     @Override
     public String getXUID() {
-        return xuid;
+        if (this.isWaterdog()) {
+            return waterdogXUID;
+        } else {
+            return xuid;
+        }
     }
 
     private boolean xboxAuthed;
@@ -137,8 +142,26 @@ public final class ClientChainData implements LoginChainData {
     }
 
     @Override
+    public String getWaterdogXUID() {
+        return waterdogXUID;
+    }
+
+    @Override
+    public String getWaterdogIP() {
+        return waterdogIP;
+    }
+
+    @Override
     public JsonObject getRawData() {
         return rawData;
+    }
+
+    private boolean isWaterdog() {
+        if (waterdogXUID == null || Server.getInstance() == null) {
+            return false;
+        }
+
+        return Server.getInstance().isWaterdogCapable();
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -179,6 +202,8 @@ public final class ClientChainData implements LoginChainData {
     private String languageCode;
     private int currentInputMode;
     private int defaultInputMode;
+    private String waterdogIP;
+    private String waterdogXUID;
 
     private int UIProfile;
 
@@ -214,6 +239,12 @@ public final class ClientChainData implements LoginChainData {
         if (skinToken.has("DefaultInputMode")) this.defaultInputMode = skinToken.get("DefaultInputMode").getAsInt();
         if (skinToken.has("UIProfile")) this.UIProfile = skinToken.get("UIProfile").getAsInt();
         if (skinToken.has("CapeData")) this.capeData = skinToken.get("CapeData").getAsString();
+        if (skinToken.has("Waterdog_IP")) this.waterdogIP = skinToken.get("Waterdog_IP").getAsString();
+        if (skinToken.has("Waterdog_XUID")) this.waterdogXUID = skinToken.get("Waterdog_XUID").getAsString();
+
+        if (this.isWaterdog()) {
+            xboxAuthed = true;
+        }
 
         this.rawData = skinToken;
     }

--- a/src/main/java/cn/nukkit/utils/LoginChainData.java
+++ b/src/main/java/cn/nukkit/utils/LoginChainData.java
@@ -44,6 +44,10 @@ public interface LoginChainData {
 
     int getUIProfile();
 
+    String getWaterdogXUID();
+
+    String getWaterdogIP();
+
     @Since("1.2.1.0-PN")
     JsonObject getRawData();
 }

--- a/src/main/resources/default-nukkit.yml
+++ b/src/main/resources/default-nukkit.yml
@@ -6,6 +6,7 @@ settings:
  deprecated-verbose: true
  async-workers: auto
  safe-spawn: true
+ waterdogpe: false
 
 network:
  batch-threshold: 256

--- a/src/test/java/cn/nukkit/network/RakNetInterfaceTest.java
+++ b/src/test/java/cn/nukkit/network/RakNetInterfaceTest.java
@@ -39,7 +39,7 @@ class RakNetInterfaceTest {
     @Test
     void noSession() {
         InetSocketAddress socketAddress = new InetSocketAddress("127.0.0.1", 3222);
-        when(player.getSocketAddress()).thenReturn(socketAddress);
+        when(player.getRawSocketAddress()).thenReturn(socketAddress);
         DataPacket packet = new ResourcePackChunkRequestPacket();
         rakNetInterface.putResourcePacket(player, packet);
         assertFalse(packet.isEncoded);


### PR DESCRIPTION
This PR adds support for the `Waterdog_XUID` and `Waterdog_IP` fields in the ClientChainData when settings.waterdogpe is true. The functionality is similar to how Spigot deals with Bungeecord.

Closes #646

Implementation taken from PowerNukkit/PowerNukkit#1356 and PowerNukkit/PowerNukkit#1370

To test, enable `waterdogpe` in your `nukkit.yml`, then in waterdogpe's `config.yml`, enable `use_login_extras`.