### PR TITLE
Fix putPacket using the wrong address when using waterdogPE Login Extras

### DIFF
--- a/src/main/java/cn/nukkit/network/RakNetInterface.java
+++ b/src/main/java/cn/nukkit/network/RakNetInterface.java
@@ -115,7 +115,7 @@ public class RakNetInterface implements RakNetServerListener, AdvancedSourceInte
 
     @Override
     public void close(Player player, String reason) {
-        NetworkPlayerSession playerSession = this.getSession(player.getSocketAddress());
+        NetworkPlayerSession playerSession = this.getSession(player.getRawSocketAddress());
         if (playerSession != null) {
             playerSession.disconnect(reason);
         }
@@ -186,7 +186,7 @@ public class RakNetInterface implements RakNetServerListener, AdvancedSourceInte
 
     @Override
     public Integer putPacket(Player player, DataPacket packet, boolean needACK, boolean immediate) {
-        RakNetPlayerSession session = this.sessions.get(player.getSocketAddress());
+        RakNetPlayerSession session = this.sessions.get(player.getRawSocketAddress());
 
         if (session != null) {
             session.sendPacket(packet);


### PR DESCRIPTION
In #676, putPacket was incorrectly changed to use the "fake" waterdog socket instead of the real socket. This commit reverts that change and fixes #677.