### PR TITLE
fix spawn point error

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockBed.java
+++ b/src/main/java/cn/nukkit/block/BlockBed.java
@@ -189,7 +189,6 @@ public class BlockBed extends BlockTransparentMeta implements Faceable, BlockEnt
 
         Location spawn = Location.fromObject(head.add(0.5, 0.5, 0.5), player.getLevel(), player.getYaw(), player.getPitch());
         if (!player.getSpawn().equals(spawn)) {
-            player.setSpawn(spawn);
             player.setSpawnBlock(this);
         }
         player.sendMessage(new TranslationContainer(TextFormat.GRAY + "%tile.bed.respawnSet"));

--- a/src/main/java/cn/nukkit/block/BlockRespawnAnchor.java
+++ b/src/main/java/cn/nukkit/block/BlockRespawnAnchor.java
@@ -123,7 +123,6 @@ public class BlockRespawnAnchor extends BlockMeta {
         }
         
         player.setSpawnBlock(this);
-        player.setSpawn(player);
         getLevel().addSound(this, Sound.RESPAWN_ANCHOR_SET_SPAWN);
         player.sendMessage(new TranslationContainer(TextFormat.GRAY + "%tile.respawn_anchor.respawnSet"));
         return true;

--- a/src/main/java/cn/nukkit/event/player/PlayerRespawnEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerRespawnEvent.java
@@ -13,16 +13,17 @@ public class PlayerRespawnEvent extends PlayerEvent {
         return handlers;
     }
 
-    private Position position;
-    
+    private Position position;//Respawn Position
+
     private Position spawnBlock;
-    
+
+    @Deprecated
     private Position originalSpawnPosition;
-    
+
     private boolean spawnBlockAvailable;
 
     private boolean firstSpawn;
-    
+
     private boolean keepRespawnBlockPosition;
     private boolean keepRespawnPosition;
     private boolean sendInvalidRespawnBlockMessage = true;
@@ -68,18 +69,25 @@ public class PlayerRespawnEvent extends PlayerEvent {
         return spawnBlockAvailable;
     }
 
+    /**
+     * Plugins not suggest use
+     *
+     * @param spawnBlockAvailable the spawn block available
+     */
     @PowerNukkitOnly
     @Since("1.4.0.0-PN")
     public void setRespawnBlockAvailable(boolean spawnBlockAvailable) {
         this.spawnBlockAvailable = spawnBlockAvailable;
     }
 
+    @Deprecated
     @PowerNukkitOnly
     @Since("1.4.0.0-PN")
     public Position getOriginalRespawnPosition() {
         return originalSpawnPosition;
     }
 
+    @Deprecated
     @PowerNukkitOnly
     @Since("1.4.0.0-PN")
     public void setOriginalRespawnPosition(Position originalSpawnPosition) {


### PR DESCRIPTION
### 这个PR将玩家复活的逻辑修复为匹配原版

### 关于玩家复活点优先级:
世界复活点 < 玩家复活点 < 重生类方块复活点(例如床 重生锚)

### 关于复活点数据的存储
世界复活点数据保存在每个世界中，玩家复活点和重生类方块复活点保存在每个玩家自身

### 简述玩家重生选择复活点的逻辑
- 当玩家重生时，首先会检测玩家当前世界是否存在该玩家的重生方块，如果重生方块存在且有效，则玩家重生到重生方块复活点处。
- 如果该玩家不存在重生方块，则检测是否存在玩家复活点，如果存在，则重生到玩家复活点处
- 如果该玩家不存在重生方块复活点和玩家复活点，则该玩家重生到世界复活点处

### 简述玩家复活点改变的逻辑
- 当玩家第一次进入服务器时，会设置对应世界的世界复活点
- 当使用/setworldspawn 命令时，世界复活点将会被设置
- 当玩家使用重生类方块时，重生类方块复活点将会被设置
- 当使用/spawnpoint 命令时，玩家复活点将会被设置
- 当使用/clearspawnpoint 命令时，玩家复活点将会被移除
- 当重生类方块丢失(例如床被拆除，重生锚失去能量) 玩家复活点和重生方块复活点都将被移除，此时玩家将会被重生到世界复活点

### Tips
由于玩家复活点的优先级高于世界复活点，而以前版本的PNX是会在玩家第一次加入服务器时，把玩家复活点设置为与世界复活点相同，故如果你想使用世界复活点，可能需要使用/clearspawnpoint 命令清除所有玩家的玩家复活点，这样才会生效