### PR TITLE
修复地狱门维度判断

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -947,7 +947,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                     EntityPortalEnterEvent ev = new EntityPortalEnterEvent(this, PortalType.END);
                     getServer().getPluginManager().callEvent(ev);
 
-                    if (!ev.isCancelled() && (this.getLevel() == EnumLevel.OVERWORLD.getLevel() || this.getLevel() == EnumLevel.THE_END.getLevel())) {
+                    if (!ev.isCancelled()) {
                         final Position newPos = EnumLevel.moveToTheEnd(this);
                         if (newPos != null) {
                             if (newPos.getLevel().getDimension() == Level.DIMENSION_THE_END) {

--- a/src/main/java/cn/nukkit/level/EnumLevel.java
+++ b/src/main/java/cn/nukkit/level/EnumLevel.java
@@ -2,6 +2,7 @@ package cn.nukkit.level;
 
 import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitOnly;
+import cn.nukkit.api.PowerNukkitXDifference;
 import cn.nukkit.api.Since;
 import cn.nukkit.level.generator.Generator;
 import cn.nukkit.math.NukkitMath;
@@ -93,6 +94,7 @@ public enum EnumLevel {
 
     @PowerNukkitOnly
     @Since("1.4.0.0-PN")
+    @PowerNukkitXDifference(since = "1.19.50-r4", info = "Supporting World Dimension Judgment")
     public static Level getOtherTheEndPair(Level current) {
         if (current == OVERWORLD.level || current.getDimension() == Level.DIMENSION_OVERWORLD) {
             return THE_END.level;
@@ -105,6 +107,7 @@ public enum EnumLevel {
 
     @PowerNukkitOnly
     @Since("1.4.0.0-PN")
+    @PowerNukkitXDifference(since = "1.19.50-r4", info = "Supporting World Dimension Judgment")
     public static Position moveToTheEnd(Position current) {
         if (THE_END.level == null) {
             return null;


### PR DESCRIPTION
世界和维度判断已在EnumLevel.moveToTheEnd中判断，这里没必要进行重复判断