### PR TITLE
清理滥用的lombok注解

### DIFF
--- a/src/main/java/cn/nukkit/inventory/recipe/DefaultDescriptor.java
+++ b/src/main/java/cn/nukkit/inventory/recipe/DefaultDescriptor.java
@@ -4,13 +4,15 @@ import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.inventory.CraftingManager;
 import cn.nukkit.item.Item;
-import lombok.Value;
 
 @PowerNukkitXOnly
 @Since("1.19.50-r2")
-@Value
 public class DefaultDescriptor implements ItemDescriptor {
-    Item item;
+    private final Item item;
+
+    public DefaultDescriptor(Item item) {
+        this.item = item;
+    }
 
     @Override
     public ItemDescriptorType getType() {
@@ -40,5 +42,13 @@ public class DefaultDescriptor implements ItemDescriptor {
     @Override
     public int hashCode() {
         return CraftingManager.getFullItemHash(item);
+    }
+
+    public Item getItem() {
+        return this.item;
+    }
+
+    public String toString() {
+        return "DefaultDescriptor(item=" + this.getItem() + ")";
     }
 }

--- a/src/main/java/cn/nukkit/inventory/recipe/DeferredDescriptor.java
+++ b/src/main/java/cn/nukkit/inventory/recipe/DeferredDescriptor.java
@@ -3,15 +3,21 @@ package cn.nukkit.inventory.recipe;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.item.Item;
-import lombok.Value;
+
+import java.util.Objects;
 
 @PowerNukkitXOnly
 @Since("Future")
-@Value
 public class DeferredDescriptor implements ItemDescriptor {
-    String fullName;
-    int auxValue;
-    int count;
+    private final String fullName;
+    private final int auxValue;
+    private final int count;
+
+    public DeferredDescriptor(String fullName, int auxValue, int count) {
+        this.fullName = fullName;
+        this.auxValue = auxValue;
+        this.count = count;
+    }
 
     @Override
     public ItemDescriptorType getType() {
@@ -26,5 +32,41 @@ public class DeferredDescriptor implements ItemDescriptor {
     @Override
     public ItemDescriptor clone() throws CloneNotSupportedException {
         return (ItemDescriptor) super.clone();
+    }
+
+    public String getFullName() {
+        return this.fullName;
+    }
+
+    public int getAuxValue() {
+        return this.auxValue;
+    }
+
+    public int getCount() {
+        return this.count;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof final DeferredDescriptor other)) return false;
+        final Object this$fullName = this.getFullName();
+        final Object other$fullName = other.getFullName();
+        if (!Objects.equals(this$fullName, other$fullName)) return false;
+        if (this.getAuxValue() != other.getAuxValue()) return false;
+        return this.getCount() == other.getCount();
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $fullName = this.getFullName();
+        result = result * PRIME + ($fullName == null ? 43 : $fullName.hashCode());
+        result = result * PRIME + this.getAuxValue();
+        result = result * PRIME + this.getCount();
+        return result;
+    }
+
+    public String toString() {
+        return "DeferredDescriptor(fullName=" + this.getFullName() + ", auxValue=" + this.getAuxValue() + ", count=" + this.getCount() + ")";
     }
 }

--- a/src/main/java/cn/nukkit/inventory/recipe/InvalidDescriptor.java
+++ b/src/main/java/cn/nukkit/inventory/recipe/InvalidDescriptor.java
@@ -3,18 +3,16 @@ package cn.nukkit.inventory.recipe;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.item.Item;
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
 
 @PowerNukkitXOnly
 @Since("1.19.50-r2")
-@ToString
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class InvalidDescriptor implements ItemDescriptor {
     int count = 0;
 
     public static final InvalidDescriptor INSTANCE = new InvalidDescriptor();
+
+    private InvalidDescriptor() {
+    }
 
     @Override
     public ItemDescriptorType getType() {
@@ -34,5 +32,9 @@ public class InvalidDescriptor implements ItemDescriptor {
     @Override
     public int getCount() {
         return count;
+    }
+
+    public String toString() {
+        return "InvalidDescriptor(count=" + this.getCount() + ")";
     }
 }

--- a/src/main/java/cn/nukkit/inventory/recipe/ItemTagDescriptor.java
+++ b/src/main/java/cn/nukkit/inventory/recipe/ItemTagDescriptor.java
@@ -4,14 +4,19 @@ import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.inventory.ItemTag;
 import cn.nukkit.item.Item;
-import lombok.Value;
+
+import java.util.Objects;
 
 @PowerNukkitXOnly
 @Since("1.19.50-r2")
-@Value
 public class ItemTagDescriptor implements ItemDescriptor {
-    String itemTag;
-    int count;
+    private final String itemTag;
+    private final int count;
+
+    public ItemTagDescriptor(String itemTag, int count) {
+        this.itemTag = itemTag;
+        this.count = count;
+    }
 
     @Override
     public ItemDescriptorType getType() {
@@ -31,5 +36,35 @@ public class ItemTagDescriptor implements ItemDescriptor {
     @Override
     public ItemDescriptor clone() throws CloneNotSupportedException {
         return (ItemDescriptor) super.clone();
+    }
+
+    public String getItemTag() {
+        return this.itemTag;
+    }
+
+    public int getCount() {
+        return this.count;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof final ItemTagDescriptor other)) return false;
+        final Object this$itemTag = this.getItemTag();
+        final Object other$itemTag = other.getItemTag();
+        if (!Objects.equals(this$itemTag, other$itemTag)) return false;
+        return this.getCount() == other.getCount();
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $itemTag = this.getItemTag();
+        result = result * PRIME + ($itemTag == null ? 43 : $itemTag.hashCode());
+        result = result * PRIME + this.getCount();
+        return result;
+    }
+
+    public String toString() {
+        return "ItemTagDescriptor(itemTag=" + this.getItemTag() + ", count=" + this.getCount() + ")";
     }
 }

--- a/src/main/java/cn/nukkit/inventory/recipe/MolangDescriptor.java
+++ b/src/main/java/cn/nukkit/inventory/recipe/MolangDescriptor.java
@@ -3,15 +3,21 @@ package cn.nukkit.inventory.recipe;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.item.Item;
-import lombok.Value;
+
+import java.util.Objects;
 
 @PowerNukkitXOnly
 @Since("Future")
-@Value
 public class MolangDescriptor implements ItemDescriptor {
-    String tagExpression;
-    int molangVersion;
-    int count;
+    private final String tagExpression;
+    private final int molangVersion;
+    private final int count;
+
+    public MolangDescriptor(String tagExpression, int molangVersion, int count) {
+        this.tagExpression = tagExpression;
+        this.molangVersion = molangVersion;
+        this.count = count;
+    }
 
     @Override
     public ItemDescriptorType getType() {
@@ -26,5 +32,42 @@ public class MolangDescriptor implements ItemDescriptor {
     @Override
     public ItemDescriptor clone() throws CloneNotSupportedException {
         return (ItemDescriptor) super.clone();
+    }
+
+    public String getTagExpression() {
+        return this.tagExpression;
+    }
+
+    public int getMolangVersion() {
+        return this.molangVersion;
+    }
+
+    public int getCount() {
+        return this.count;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof final MolangDescriptor other)) return false;
+        final Object this$tagExpression = this.getTagExpression();
+        final Object other$tagExpression = other.getTagExpression();
+        if (!Objects.equals(this$tagExpression, other$tagExpression))
+            return false;
+        if (this.getMolangVersion() != other.getMolangVersion()) return false;
+        return this.getCount() == other.getCount();
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $tagExpression = this.getTagExpression();
+        result = result * PRIME + ($tagExpression == null ? 43 : $tagExpression.hashCode());
+        result = result * PRIME + this.getMolangVersion();
+        result = result * PRIME + this.getCount();
+        return result;
+    }
+
+    public String toString() {
+        return "MolangDescriptor(tagExpression=" + this.getTagExpression() + ", molangVersion=" + this.getMolangVersion() + ", count=" + this.getCount() + ")";
     }
 }

--- a/src/main/java/cn/nukkit/level/DimensionData.java
+++ b/src/main/java/cn/nukkit/level/DimensionData.java
@@ -1,11 +1,9 @@
 package cn.nukkit.level;
 
-import lombok.Data;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
-@Data
 public class DimensionData {
     private final String dimensionName;
     private final int dimensionId;
@@ -43,5 +41,65 @@ public class DimensionData {
         this.height = height;
 
         this.chunkSectionCount = Objects.requireNonNullElseGet(chunkSectionCount, () -> this.height >> 4 + ((this.height & 15) == 0 ? 0 : 1));
+    }
+
+    public String getDimensionName() {
+        return this.dimensionName;
+    }
+
+    public int getDimensionId() {
+        return this.dimensionId;
+    }
+
+    public int getMinHeight() {
+        return this.minHeight;
+    }
+
+    public int getMaxHeight() {
+        return this.maxHeight;
+    }
+
+    public int getHeight() {
+        return this.height;
+    }
+
+    public int getChunkSectionCount() {
+        return this.chunkSectionCount;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof final DimensionData other)) return false;
+        if (!other.canEqual(this)) return false;
+        final Object this$dimensionName = this.getDimensionName();
+        final Object other$dimensionName = other.getDimensionName();
+        if (!Objects.equals(this$dimensionName, other$dimensionName))
+            return false;
+        if (this.getDimensionId() != other.getDimensionId()) return false;
+        if (this.getMinHeight() != other.getMinHeight()) return false;
+        if (this.getMaxHeight() != other.getMaxHeight()) return false;
+        if (this.getHeight() != other.getHeight()) return false;
+        return this.getChunkSectionCount() == other.getChunkSectionCount();
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof DimensionData;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        final Object $dimensionName = this.getDimensionName();
+        result = result * PRIME + ($dimensionName == null ? 43 : $dimensionName.hashCode());
+        result = result * PRIME + this.getDimensionId();
+        result = result * PRIME + this.getMinHeight();
+        result = result * PRIME + this.getMaxHeight();
+        result = result * PRIME + this.getHeight();
+        result = result * PRIME + this.getChunkSectionCount();
+        return result;
+    }
+
+    public String toString() {
+        return "DimensionData(dimensionName=" + this.getDimensionName() + ", dimensionId=" + this.getDimensionId() + ", minHeight=" + this.getMinHeight() + ", maxHeight=" + this.getMaxHeight() + ", height=" + this.getHeight() + ", chunkSectionCount=" + this.getChunkSectionCount() + ")";
     }
 }

--- a/src/main/java/cn/nukkit/level/DimensionData.java
+++ b/src/main/java/cn/nukkit/level/DimensionData.java
@@ -67,36 +67,11 @@ public class DimensionData {
         return this.chunkSectionCount;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof final DimensionData other)) return false;
-        if (!other.canEqual(this)) return false;
-        final Object this$dimensionName = this.getDimensionName();
-        final Object other$dimensionName = other.getDimensionName();
-        if (!Objects.equals(this$dimensionName, other$dimensionName))
-            return false;
-        if (this.getDimensionId() != other.getDimensionId()) return false;
-        if (this.getMinHeight() != other.getMinHeight()) return false;
-        if (this.getMaxHeight() != other.getMaxHeight()) return false;
-        if (this.getHeight() != other.getHeight()) return false;
-        return this.getChunkSectionCount() == other.getChunkSectionCount();
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof DimensionData;
-    }
-
-    public int hashCode() {
-        final int PRIME = 59;
-        int result = 1;
-        final Object $dimensionName = this.getDimensionName();
-        result = result * PRIME + ($dimensionName == null ? 43 : $dimensionName.hashCode());
-        result = result * PRIME + this.getDimensionId();
-        result = result * PRIME + this.getMinHeight();
-        result = result * PRIME + this.getMaxHeight();
-        result = result * PRIME + this.getHeight();
-        result = result * PRIME + this.getChunkSectionCount();
-        return result;
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DimensionData that)) return false;
+        return dimensionId == that.dimensionId && minHeight == that.minHeight && maxHeight == that.maxHeight && height == that.height && chunkSectionCount == that.chunkSectionCount && dimensionName.equals(that.dimensionName);
     }
 
     public String toString() {

--- a/src/main/java/cn/nukkit/network/protocol/ItemStackRequestPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/ItemStackRequestPacket.java
@@ -36,13 +36,13 @@ public class ItemStackRequestPacket extends DataPacket {
     }
 
     @Since("1.4.0.0-PN")
-        public record ItemStackAction(byte type, boolean bool0, byte byte0, int varInt0, int varInt1, byte baseByte0,
-                                      byte baseByte1, byte baseByte2, int baseVarInt0, byte flagsByte0, byte flagsByte1,
-                                      int flagsVarInt0, List<Item> items) {
+    public record ItemStackAction(byte type, boolean bool0, byte byte0, int varInt0, int varInt1, byte baseByte0,
+                                  byte baseByte1, byte baseByte2, int baseVarInt0, byte flagsByte0, byte flagsByte1,
+                                  int flagsVarInt0, List<Item> items) {
         @Override
-            public String toString() {
-                StringJoiner joiner = new StringJoiner(", ");
-                joiner.add("type=" + type);
+        public String toString() {
+            StringJoiner joiner = new StringJoiner(", ");
+            joiner.add("type=" + type);
 
             switch (type) {
                 case 0, 1, 2 -> joiner.add("baseByte0=" + baseByte0)
@@ -67,7 +67,7 @@ public class ItemStackRequestPacket extends DataPacket {
                 case 10, 11, 12, 13, 14, 15 -> joiner.add("varInt0=" + varInt0);
                 case 17 -> joiner.add("items=" + items);
             }
-                return "ItemStackAction(" + joiner + ")";
-            }
+            return "ItemStackAction(" + joiner + ")";
         }
+    }
 }

--- a/src/main/java/cn/nukkit/network/protocol/ItemStackRequestPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/ItemStackRequestPacket.java
@@ -3,7 +3,6 @@ package cn.nukkit.network.protocol;
 import cn.nukkit.api.Since;
 import cn.nukkit.item.Item;
 import lombok.ToString;
-import lombok.Value;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,82 +29,45 @@ public class ItemStackRequestPacket extends DataPacket {
     public void encode() {
 
     }
-    
-    @Since("1.4.0.0-PN")
-    @Value
-    public static class Request {
-        private final int requestId;
-        private final List<ItemStackAction> actions;
-    }
-    
-    @Since("1.4.0.0-PN")
-    @Value
-    public static class ItemStackAction {
-        private final byte type;
-        private final boolean bool0;
-        private final byte byte0;
-        private final int varInt0;
-        private final int varInt1;
-        private final byte baseByte0;
-        private final byte baseByte1;
-        private final byte baseByte2;
-        private final int baseVarInt0;
-        private final byte flagsByte0;
-        private final byte flagsByte1;
-        private final int flagsVarInt0;
-        private final List<Item> items;
 
+    @Since("1.4.0.0-PN")
+    public record Request(int requestId, List<ItemStackAction> actions) {
+
+    }
+
+    @Since("1.4.0.0-PN")
+        public record ItemStackAction(byte type, boolean bool0, byte byte0, int varInt0, int varInt1, byte baseByte0,
+                                      byte baseByte1, byte baseByte2, int baseVarInt0, byte flagsByte0, byte flagsByte1,
+                                      int flagsVarInt0, List<Item> items) {
         @Override
-        public String toString() {
-            StringJoiner joiner = new StringJoiner(", ");
-            joiner.add("type=" + type);
+            public String toString() {
+                StringJoiner joiner = new StringJoiner(", ");
+                joiner.add("type=" + type);
 
             switch (type) {
-                case 0:
-                case 1:
-                case 2:
-                    joiner.add("baseByte0=" + baseByte0)
-                            .add("baseByte1=" + baseByte1)
-                            .add("baseByte2=" + baseByte2)
-                            .add("baseVarInt0=" + baseVarInt0)
-                            .add("flagsByte0=" + flagsByte0)
-                            .add("flagsByte1=" + flagsByte1)
-                            .add("flagsVarInt0=" + flagsVarInt0);
-                    break;
-                case 3:
-                    joiner.add("bool0=" + bool0)
-                            .add("baseByte0=" + baseByte0)
-                            .add("baseByte1=" + baseByte1)
-                            .add("baseByte2=" + baseByte2)
-                            .add("baseVarInt0=" + baseVarInt0);
-                    break;
-                case 4:
-                case 5:
-                    joiner.add("baseByte0=" + baseByte0)
-                            .add("baseByte1=" + baseByte1)
-                            .add("baseByte2=" + baseByte2)
-                            .add("baseVarInt0=" + baseVarInt0);
-                    break;
-                case 6:
-                    joiner.add("byte0=" + byte0);
-                    break;
-                case 8:
-                    joiner.add("varInt0=" + varInt0)
-                            .add("varInt1=" + varInt1);
-                    break;
-                case 10:
-                case 11:
-                case 12:
-                case 13:
-                case 14:
-                case 15:
-                    joiner.add("varInt0=" + varInt0);
-                    break;
-                case 17:
-                    joiner.add("items=" + items);
-                    break;
+                case 0, 1, 2 -> joiner.add("baseByte0=" + baseByte0)
+                        .add("baseByte1=" + baseByte1)
+                        .add("baseByte2=" + baseByte2)
+                        .add("baseVarInt0=" + baseVarInt0)
+                        .add("flagsByte0=" + flagsByte0)
+                        .add("flagsByte1=" + flagsByte1)
+                        .add("flagsVarInt0=" + flagsVarInt0);
+                case 3 -> joiner.add("bool0=" + bool0)
+                        .add("baseByte0=" + baseByte0)
+                        .add("baseByte1=" + baseByte1)
+                        .add("baseByte2=" + baseByte2)
+                        .add("baseVarInt0=" + baseVarInt0);
+                case 4, 5 -> joiner.add("baseByte0=" + baseByte0)
+                        .add("baseByte1=" + baseByte1)
+                        .add("baseByte2=" + baseByte2)
+                        .add("baseVarInt0=" + baseVarInt0);
+                case 6 -> joiner.add("byte0=" + byte0);
+                case 8 -> joiner.add("varInt0=" + varInt0)
+                        .add("varInt1=" + varInt1);
+                case 10, 11, 12, 13, 14, 15 -> joiner.add("varInt0=" + varInt0);
+                case 17 -> joiner.add("items=" + items);
             }
-            return "ItemStackAction(" + joiner.toString() + ")";
+                return "ItemStackAction(" + joiner + ")";
+            }
         }
-    }
 }

--- a/src/main/java/cn/nukkit/network/protocol/UpdateSubChunkBlocksPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/UpdateSubChunkBlocksPacket.java
@@ -4,24 +4,24 @@ import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.network.protocol.types.BlockChangeEntry;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
-import lombok.Value;
 
 import java.util.List;
 
 @PowerNukkitXOnly
 @Since("1.6.0.0-PNX")
-@EqualsAndHashCode(doNotUseGetters = true, callSuper = false)
-@ToString(doNotUseGetters = true)
-@Value
 public class UpdateSubChunkBlocksPacket extends DataPacket {
-    public int chunkX;
-    public int chunkY;
-    public int chunkZ;
+    public final int chunkX;
+    public final int chunkY;
+    public final int chunkZ;
 
-    public List<BlockChangeEntry> standardBlocks = new ObjectArrayList<>();
-    public List<BlockChangeEntry> extraBlocks = new ObjectArrayList<>();
+    public final List<BlockChangeEntry> standardBlocks = new ObjectArrayList<>();
+    public final List<BlockChangeEntry> extraBlocks = new ObjectArrayList<>();
+
+    public UpdateSubChunkBlocksPacket(int chunkX, int chunkY, int chunkZ) {
+        this.chunkX = chunkX;
+        this.chunkY = chunkY;
+        this.chunkZ = chunkZ;
+    }
 
     @Override
     public byte pid() {
@@ -53,5 +53,56 @@ public class UpdateSubChunkBlocksPacket extends DataPacket {
             putUnsignedVarLong(each.messageEntityID());
             putUnsignedVarInt(each.messageType().ordinal());
         }
+    }
+
+    public int getChunkX() {
+        return this.chunkX;
+    }
+
+    public int getChunkY() {
+        return this.chunkY;
+    }
+
+    public int getChunkZ() {
+        return this.chunkZ;
+    }
+
+    public List<BlockChangeEntry> getStandardBlocks() {
+        return this.standardBlocks;
+    }
+
+    public List<BlockChangeEntry> getExtraBlocks() {
+        return this.extraBlocks;
+    }
+
+    public boolean equals(final Object o) {
+        if (o == this) return true;
+        if (!(o instanceof final UpdateSubChunkBlocksPacket other)) return false;
+        if (!other.canEqual(this)) return false;
+        if (this.chunkX != other.chunkX) return false;
+        if (this.chunkY != other.chunkY) return false;
+        if (this.chunkZ != other.chunkZ) return false;
+        if (!((Object) this.standardBlocks).equals(other.standardBlocks))
+            return false;
+        return ((Object) this.extraBlocks).equals(other.extraBlocks);
+    }
+
+    protected boolean canEqual(final Object other) {
+        return other instanceof UpdateSubChunkBlocksPacket;
+    }
+
+    public int hashCode() {
+        final int PRIME = 59;
+        int result = 1;
+        result = result * PRIME + this.chunkX;
+        result = result * PRIME + this.chunkY;
+        result = result * PRIME + this.chunkZ;
+        result = result * PRIME + ((Object) this.standardBlocks).hashCode();
+        result = result * PRIME + ((Object) this.extraBlocks).hashCode();
+        return result;
+    }
+
+    public String toString() {
+        return "UpdateSubChunkBlocksPacket(chunkX=" + this.chunkX + ", chunkY=" + this.chunkY + ", chunkZ=" + this.chunkZ + ", standardBlocks=" + this.standardBlocks + ", extraBlocks=" + this.extraBlocks + ")";
     }
 }

--- a/src/main/java/cn/nukkit/network/protocol/UpdateSubChunkBlocksPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/UpdateSubChunkBlocksPacket.java
@@ -39,14 +39,14 @@ public class UpdateSubChunkBlocksPacket extends DataPacket {
         putUnsignedVarInt(chunkY);
         putVarInt(chunkZ);
         putVarInt(standardBlocks.size());
-        for(final var each : standardBlocks) {
+        for (final var each : standardBlocks) {
             putBlockVector3(each.blockPos());
             putUnsignedVarInt(each.runtimeID());
             putUnsignedVarInt(each.updateFlags());
             putUnsignedVarLong(each.messageEntityID());
             putUnsignedVarInt(each.messageType().ordinal());
         }
-        for(final var each : extraBlocks) {
+        for (final var each : extraBlocks) {
             putBlockVector3(each.blockPos());
             putUnsignedVarInt(each.runtimeID());
             putUnsignedVarInt(each.updateFlags());
@@ -75,20 +75,11 @@ public class UpdateSubChunkBlocksPacket extends DataPacket {
         return this.extraBlocks;
     }
 
-    public boolean equals(final Object o) {
-        if (o == this) return true;
-        if (!(o instanceof final UpdateSubChunkBlocksPacket other)) return false;
-        if (!other.canEqual(this)) return false;
-        if (this.chunkX != other.chunkX) return false;
-        if (this.chunkY != other.chunkY) return false;
-        if (this.chunkZ != other.chunkZ) return false;
-        if (!((Object) this.standardBlocks).equals(other.standardBlocks))
-            return false;
-        return ((Object) this.extraBlocks).equals(other.extraBlocks);
-    }
-
-    protected boolean canEqual(final Object other) {
-        return other instanceof UpdateSubChunkBlocksPacket;
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UpdateSubChunkBlocksPacket that)) return false;
+        return chunkX == that.chunkX && chunkY == that.chunkY && chunkZ == that.chunkZ && standardBlocks.equals(that.standardBlocks) && extraBlocks.equals(that.extraBlocks);
     }
 
     public int hashCode() {


### PR DESCRIPTION
滥用lombok注解显然不是什么好事，这些清理掉的注解都是改变了这些类应有的语义或者是给插件开发带来困难的滥用注解