### PR TITLE
Try to optimize hopper's performance

### DIFF
--- a/src/main/java/cn/nukkit/api/DoNotModify.java
+++ b/src/main/java/cn/nukkit/api/DoNotModify.java
@@ -1,0 +1,16 @@
+package cn.nukkit.api;
+
+import java.lang.annotation.*;
+
+/**
+ * DoNotModify is used to indicate that the return value of method, variables, etc. should not be modified
+ * <p/>
+ * DoNotModify注解用于标明方法的返回值，变量等不应该被修改
+ */
+@PowerNukkitXOnly
+@Since("1.19.50-r4")
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+public @interface DoNotModify {
+}

--- a/src/main/java/cn/nukkit/block/BlockComposter.java
+++ b/src/main/java/cn/nukkit/block/BlockComposter.java
@@ -3,6 +3,7 @@ package cn.nukkit.block;
 import cn.nukkit.Player;
 import cn.nukkit.api.PowerNukkitDifference;
 import cn.nukkit.api.PowerNukkitOnly;
+import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.blockproperty.BlockProperties;
 import cn.nukkit.blockproperty.IntBlockProperty;
@@ -31,6 +32,9 @@ public class BlockComposter extends BlockSolidMeta implements ItemID {
     @PowerNukkitOnly
     @Since("1.4.0.0-PN")
     public static final BlockProperties PROPERTIES = new BlockProperties(COMPOSTER_FILL_LEVEL);
+    @PowerNukkitXOnly
+    @Since("1.19.50-r4")
+    public static final Item OUTPUT_ITEM = new ItemDye(DyeColor.BONE_MEAL, 1);
 
     static {
         registerDefaults();
@@ -192,6 +196,12 @@ public class BlockComposter extends BlockSolidMeta implements ItemID {
             return event.getDrop();
         }
         return null;
+    }
+
+    @PowerNukkitXOnly
+    @Since("1.19.50-r4")
+    public Item getOutPutItem() {
+        return OUTPUT_ITEM.clone();
     }
 
     @PowerNukkitOnly

--- a/src/main/java/cn/nukkit/block/BlockHopper.java
+++ b/src/main/java/cn/nukkit/block/BlockHopper.java
@@ -288,17 +288,18 @@ public class BlockHopper extends BlockTransparentMeta implements RedstoneCompone
                 }
             } else if (blockSide instanceof BlockComposter blockComposter) {
                 if (blockComposter.isFull()) {
+                    //检查是否能输入
+                    if (!hopperInv.canAddItem(blockComposter.getOutPutItem()))
+                        return false;
+
                     //Will call BlockComposterEmptyEvent
-                    Item item = blockComposter.empty();
+                    var item = blockComposter.empty();
 
                     if (item == null || item.isNull())
                         return false;
 
                     Item itemToAdd = item.clone();
                     itemToAdd.count = 1;
-
-                    if (!hopperInv.canAddItem(itemToAdd))
-                        return false;
 
                     Item[] items = hopperInv.addItem(itemToAdd);
 

--- a/src/main/java/cn/nukkit/block/BlockHopper.java
+++ b/src/main/java/cn/nukkit/block/BlockHopper.java
@@ -247,7 +247,7 @@ public class BlockHopper extends BlockTransparentMeta implements RedstoneCompone
             if (hopperInv.isFull())
                 return false;
 
-            Block blockSide = hopperPos.getSide(BlockFace.UP).getLevelBlock();
+            Block blockSide = hopperPos.getSide(BlockFace.UP).getTickCachedLevelBlock();
             BlockEntity blockEntity = hopperPos.level.getBlockEntity(new Vector3().setComponentsAdding(hopperPos, BlockFace.UP));
 
             if (blockEntity instanceof BlockEntityHopper) {

--- a/src/main/java/cn/nukkit/block/BlockHopper.java
+++ b/src/main/java/cn/nukkit/block/BlockHopper.java
@@ -1,19 +1,27 @@
 package cn.nukkit.block;
 
 import cn.nukkit.Player;
-import cn.nukkit.api.DeprecationDetails;
-import cn.nukkit.api.PowerNukkitDifference;
-import cn.nukkit.api.PowerNukkitOnly;
-import cn.nukkit.api.Since;
+import cn.nukkit.Server;
+import cn.nukkit.api.*;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.blockentity.BlockEntityHopper;
 import cn.nukkit.blockproperty.BlockProperties;
+import cn.nukkit.entity.Entity;
+import cn.nukkit.entity.item.EntityItem;
+import cn.nukkit.event.block.ComposterEmptyEvent;
+import cn.nukkit.event.inventory.InventoryMoveItemEvent;
 import cn.nukkit.inventory.ContainerInventory;
+import cn.nukkit.inventory.Inventory;
+import cn.nukkit.inventory.InventoryHolder;
+import cn.nukkit.inventory.RecipeInventoryHolder;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemHopper;
 import cn.nukkit.item.ItemTool;
 import cn.nukkit.level.Level;
+import cn.nukkit.level.Position;
+import cn.nukkit.math.AxisAlignedBB;
 import cn.nukkit.math.BlockFace;
+import cn.nukkit.math.Vector3;
 import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.nbt.tag.ListTag;
 import cn.nukkit.utils.Faceable;
@@ -228,5 +236,119 @@ public class BlockHopper extends BlockTransparentMeta implements RedstoneCompone
     @Override
     public boolean isSolid(BlockFace side) {
         return side == BlockFace.UP;
+    }
+
+    @PowerNukkitXOnly
+    @Since("1.19.50-r4")
+    public interface IHopper {
+        default boolean pullItems(InventoryHolder hopperHolder, Position hopperPos) {
+            var hopperInv = hopperHolder.getInventory();
+
+            if (hopperInv.isFull())
+                return false;
+
+            Block blockSide = hopperPos.getSide(BlockFace.UP).getLevelBlock();
+            BlockEntity blockEntity = hopperPos.level.getBlockEntity(new Vector3().setComponentsAdding(hopperPos, BlockFace.UP));
+
+            if (blockEntity instanceof BlockEntityHopper) {
+                BlockEntityHopper hopper = (BlockEntityHopper) blockEntity;
+                if (hopper.isDisabled())
+                    return false;
+            }
+
+            if (blockEntity instanceof InventoryHolder) {
+                Inventory inv = blockEntity instanceof RecipeInventoryHolder recipeInventoryHolder ? recipeInventoryHolder.getProductView() : ((InventoryHolder) blockEntity).getInventory();
+
+                for (int i = 0; i < inv.getSize(); i++) {
+                    Item item = inv.getItem(i);
+
+                    if (!item.isNull()) {
+                        Item itemToAdd = item.clone();
+                        itemToAdd.count = 1;
+
+                        if (!hopperInv.canAddItem(itemToAdd))
+                            continue;
+
+                        InventoryMoveItemEvent ev = new InventoryMoveItemEvent(inv, hopperInv, hopperHolder, itemToAdd, InventoryMoveItemEvent.Action.SLOT_CHANGE);
+                        Server.getInstance().getPluginManager().callEvent(ev);
+
+                        if (ev.isCancelled())
+                            continue;
+
+                        Item[] items = hopperInv.addItem(itemToAdd);
+
+                        if (items.length >= 1)
+                            continue;
+
+                        item.count--;
+
+                        inv.setItem(i, item);
+                        return true;
+                    }
+                }
+            } else if (blockSide instanceof BlockComposter blockComposter) {
+                if (blockComposter.isFull()) {
+                    //Will call BlockComposterEmptyEvent
+                    Item item = blockComposter.empty();
+
+                    if (item == null || item.isNull())
+                        return false;
+
+                    Item itemToAdd = item.clone();
+                    itemToAdd.count = 1;
+
+                    if (!hopperInv.canAddItem(itemToAdd))
+                        return false;
+
+                    Item[] items = hopperInv.addItem(itemToAdd);
+
+                    return items.length < 1;
+                }
+            }
+            return false;
+        }
+
+        default boolean pickupItems(InventoryHolder hopperHolder, Position hopperPos, AxisAlignedBB pickupArea) {
+            var hopperInv = hopperHolder.getInventory();
+
+            if (hopperInv.isFull())
+                return false;
+
+            boolean pickedUpItem = false;
+
+            for (Entity entity : hopperPos.level.getCollidingEntities(pickupArea)) {
+                //                                                                                      needn't?
+                if (entity.isClosed() || !(entity instanceof EntityItem itemEntity)/* || pushArea.intersectsWith(entity.getBoundingBox())*/)
+                    continue;
+
+                Item item = itemEntity.getItem();
+
+                if (item.isNull() || !hopperInv.canAddItem(item))
+                    continue;
+
+                int originalCount = item.getCount();
+
+                InventoryMoveItemEvent ev = new InventoryMoveItemEvent(null, hopperInv, hopperHolder, item, InventoryMoveItemEvent.Action.PICKUP);
+                Server.getInstance().getPluginManager().callEvent(ev);
+
+                if (ev.isCancelled())
+                    continue;
+
+                Item[] items = hopperInv.addItem(item);
+
+                if (items.length == 0) {
+                    entity.close();
+                    pickedUpItem = true;
+                    continue;
+                }
+
+                if (items[0].getCount() != originalCount) {
+                    pickedUpItem = true;
+                    item.setCount(items[0].getCount());
+                }
+            }
+
+            return pickedUpItem;
+        }
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockHopper.java
+++ b/src/main/java/cn/nukkit/block/BlockHopper.java
@@ -318,8 +318,7 @@ public class BlockHopper extends BlockTransparentMeta implements RedstoneCompone
             boolean pickedUpItem = false;
 
             for (Entity entity : hopperPos.level.getCollidingEntities(pickupArea)) {
-                //                                                                                      needn't?
-                if (entity.isClosed() || !(entity instanceof EntityItem itemEntity)/* || pushArea.intersectsWith(entity.getBoundingBox())*/)
+                if (entity.isClosed() || !(entity instanceof EntityItem itemEntity))
                     continue;
 
                 Item item = itemEntity.getItem();

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityHopper.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityHopper.java
@@ -358,7 +358,7 @@ public class BlockEntityHopper extends BlockEntitySpawnable implements Inventory
         }
 
         BlockFace side = levelBlockState.getPropertyValue(CommonBlockProperties.FACING_DIRECTION);
-        Block blockSide = this.getBlock().getSide(side);
+        Block blockSide = this.getSide(side).getTickCachedLevelBlock();
         BlockEntity be = this.level.getBlockEntity(temporalVector.setComponentsAdding(this, side));
 
         if (be instanceof BlockEntityHopper && levelBlockState.isDefaultState() || !(be instanceof InventoryHolder) && !(blockSide instanceof BlockComposter)) {

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityHopper.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityHopper.java
@@ -224,7 +224,7 @@ public class BlockEntityHopper extends BlockEntitySpawnable implements Inventory
             return false;
         }
 
-        Block blockSide = this.getBlock().getSide(BlockFace.UP);
+        Block blockSide = this.getSide(BlockFace.UP).getTickCachedLevelBlock();
         BlockEntity blockEntity = this.level.getBlockEntity(temporalVector.setComponentsAdding(this, BlockFace.UP));
 
         boolean changed = pushItems() || pushItemsIntoMinecart();

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityHopper.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityHopper.java
@@ -263,28 +263,20 @@ public class BlockEntityHopper extends BlockEntitySpawnable implements Inventory
                 if (!item.isNull()) {
                     Item itemToAdd = item.clone();
                     itemToAdd.count = 1;
-
-                    if (!this.inventory.canAddItem(itemToAdd)) {
+                    if (!this.inventory.canAddItem(itemToAdd))
                         continue;
-                    }
 
                     InventoryMoveItemEvent ev = new InventoryMoveItemEvent(inv, this.inventory, this, itemToAdd, InventoryMoveItemEvent.Action.SLOT_CHANGE);
                     this.server.getPluginManager().callEvent(ev);
-
-                    if (ev.isCancelled()) {
+                    if (ev.isCancelled())
                         continue;
-                    }
 
                     Item[] items = this.inventory.addItem(itemToAdd);
-
-                    if (items.length >= 1) {
+                    if (items.length >= 1)
                         continue;
-                    }
 
                     item.count--;
-
                     inv.setItem(i, item);
-
                     pickedUpItem = true;
                 }
             }
@@ -316,12 +308,12 @@ public class BlockEntityHopper extends BlockEntitySpawnable implements Inventory
     @Since("1.19.21-r3")
     public boolean pushItemsIntoMinecart() {
         for (var entity : this.level.getCollidingEntities(this.pushArea)) {
+            //漏斗矿车会自动吸取物品
             if (entity instanceof EntityMinecartAbstract && !(entity instanceof EntityMinecartHopper) && entity instanceof InventoryHolder holder) {
                 Inventory holderInventory = holder.getInventory();
 
-                if (holderInventory.isFull()) {
+                if (holderInventory.isFull())
                     return false;
-                }
 
                 for (int i = 0; i < this.inventory.getSize(); i++) {
                     Item item = this.inventory.getItem(i);
@@ -330,22 +322,19 @@ public class BlockEntityHopper extends BlockEntitySpawnable implements Inventory
                         Item itemToAdd = item.clone();
                         itemToAdd.setCount(1);
 
-                        if (!holderInventory.canAddItem(itemToAdd)) {
+                        if (!holderInventory.canAddItem(itemToAdd))
                             continue;
-                        }
 
                         InventoryMoveItemEvent ev = new InventoryMoveItemEvent(this.inventory, holderInventory, this, itemToAdd, InventoryMoveItemEvent.Action.SLOT_CHANGE);
                         this.server.getPluginManager().callEvent(ev);
 
-                        if (ev.isCancelled()) {
+                        if (ev.isCancelled())
                             continue;
-                        }
 
                         Item[] items = holderInventory.addItem(itemToAdd);
 
-                        if (items.length > 0) {
+                        if (items.length > 0)
                             continue;
-                        }
 
                         item.count--;
                         this.inventory.setItem(i, item);

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityHopper.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityHopper.java
@@ -231,7 +231,6 @@ public class BlockEntityHopper extends BlockEntitySpawnable implements Inventory
             setDirty();
         }
 
-
         return true;
     }
 

--- a/src/main/java/cn/nukkit/entity/item/EntityMinecartAbstract.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityMinecartAbstract.java
@@ -396,6 +396,9 @@ public abstract class EntityMinecartAbstract extends EntityVehicle {
         return maxSpeed;
     }
 
+    protected void activate(int x, int y, int z, boolean flag) {
+    }
+
     /**
      * 检查邻近的漏斗并通知它输出物品
      * @param pushArea 漏斗输出范围
@@ -403,7 +406,7 @@ public abstract class EntityMinecartAbstract extends EntityVehicle {
      */
     @PowerNukkitXOnly
     @Since("1.19.50-r4")
-    protected boolean checkPushHopper(AxisAlignedBB pushArea, InventoryHolder holder) {
+    private boolean checkPushHopper(AxisAlignedBB pushArea, InventoryHolder holder) {
         var hopperPushArray = this.level.getTickCachedCollisionBlocks(pushArea, true, false, b -> b instanceof BlockHopper);
         if (hopperPushArray.length >= 1) {
             ((BlockEntityHopper) hopperPushArray[0].getLevelBlockEntity()).setMinecartInvPushTo(holder);
@@ -417,6 +420,8 @@ public abstract class EntityMinecartAbstract extends EntityVehicle {
      * @param pickupArea 漏斗拉取范围
      * @return 是否有漏斗被通知
      */
+    @PowerNukkitXOnly
+    @Since("1.19.50-r4")
     private boolean checkPickupHopper(AxisAlignedBB pickupArea, InventoryHolder holder) {
         var hopperPickupArray = this.level.getTickCachedCollisionBlocks(pickupArea, true, false, b -> b instanceof BlockHopper);
         if (hopperPickupArray.length >= 1) {
@@ -424,9 +429,6 @@ public abstract class EntityMinecartAbstract extends EntityVehicle {
             return true;
         }
         return false;
-    }
-
-    protected void activate(int x, int y, int z, boolean flag) {
     }
 
     private void setFalling() {

--- a/src/main/java/cn/nukkit/entity/item/EntityMinecartAbstract.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityMinecartAbstract.java
@@ -5,7 +5,10 @@ import cn.nukkit.api.API;
 import cn.nukkit.api.API.Definition;
 import cn.nukkit.api.API.Usage;
 import cn.nukkit.api.PowerNukkitDifference;
+import cn.nukkit.api.PowerNukkitXOnly;
+import cn.nukkit.api.Since;
 import cn.nukkit.block.*;
+import cn.nukkit.blockentity.BlockEntityHopper;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.entity.EntityHuman;
 import cn.nukkit.entity.EntityLiving;
@@ -15,14 +18,13 @@ import cn.nukkit.event.entity.EntityDamageByEntityEvent;
 import cn.nukkit.event.entity.EntityDamageEvent;
 import cn.nukkit.event.vehicle.VehicleMoveEvent;
 import cn.nukkit.event.vehicle.VehicleUpdateEvent;
+import cn.nukkit.inventory.InventoryHolder;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemMinecart;
 import cn.nukkit.level.GameRule;
 import cn.nukkit.level.Location;
 import cn.nukkit.level.format.FullChunk;
-import cn.nukkit.math.MathHelper;
-import cn.nukkit.math.NukkitMath;
-import cn.nukkit.math.Vector3;
+import cn.nukkit.math.*;
 import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.utils.MinecartType;
 import cn.nukkit.utils.Rail;
@@ -217,6 +219,18 @@ public abstract class EntityMinecartAbstract extends EntityVehicle {
                 }
             }
 
+            //使矿车通知漏斗更新而不是漏斗来检测矿车
+            //通常情况下，矿车的数量远远少于漏斗，所以说此举能大福提高性能
+            if (this instanceof InventoryHolder holder) {
+                var pickupArea = new SimpleAxisAlignedBB(this.x, this.y - 1, this.z, this.x + 1, this.y, this.z + 1);
+                checkPickupHopper(pickupArea, holder);
+                //漏斗矿车会自行拉取物品!
+                if (!(this instanceof EntityMinecartHopper)) {
+                    var pushArea = new SimpleAxisAlignedBB(this.x, this.y, this.z, this.x + 1, this.y + 2, this.z + 1);
+                    checkPushHopper(pushArea, holder);
+                }
+            }
+
             // No need to onGround or Motion diff! This always have an update
             return true;
         }
@@ -380,6 +394,36 @@ public abstract class EntityMinecartAbstract extends EntityVehicle {
 
     public double getMaxSpeed() {
         return maxSpeed;
+    }
+
+    /**
+     * 检查邻近的漏斗并通知它输出物品
+     * @param pushArea 漏斗输出范围
+     * @return 是否有漏斗被通知
+     */
+    @PowerNukkitXOnly
+    @Since("1.19.50-r4")
+    protected boolean checkPushHopper(AxisAlignedBB pushArea, InventoryHolder holder) {
+        var hopperPushArray = this.level.getTickCachedCollisionBlocks(pushArea, true, false, b -> b instanceof BlockHopper);
+        if (hopperPushArray.length >= 1) {
+            ((BlockEntityHopper) hopperPushArray[0].getLevelBlockEntity()).setMinecartInvPushTo(holder);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * 检查邻近的漏斗并通知它获取物品
+     * @param pickupArea 漏斗拉取范围
+     * @return 是否有漏斗被通知
+     */
+    private boolean checkPickupHopper(AxisAlignedBB pickupArea, InventoryHolder holder) {
+        var hopperPickupArray = this.level.getTickCachedCollisionBlocks(pickupArea, true, false, b -> b instanceof BlockHopper);
+        if (hopperPickupArray.length >= 1) {
+            ((BlockEntityHopper) hopperPickupArray[0].getLevelBlockEntity()).setMinecartInvPickupFrom(holder);
+            return true;
+        }
+        return false;
     }
 
     protected void activate(int x, int y, int z, boolean flag) {

--- a/src/main/java/cn/nukkit/entity/item/EntityMinecartHopper.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityMinecartHopper.java
@@ -55,7 +55,7 @@ public class EntityMinecartHopper extends EntityMinecartAbstract implements Inve
 
         this.updatePickupArea();
 
-        Block blockSide = this.getLevelBlock().getSide(BlockFace.UP);
+        Block blockSide = this.getSide(BlockFace.UP).getTickCachedLevelBlock();
         BlockEntity blockEntity = this.level.getBlockEntity(temporalVector.setComponentsAdding(this, BlockFace.UP));
 
         boolean changed;

--- a/src/main/java/cn/nukkit/entity/item/EntityMinecartHopper.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityMinecartHopper.java
@@ -6,16 +6,13 @@ import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockComposter;
+import cn.nukkit.block.BlockHopper;
 import cn.nukkit.block.BlockRailActivator;
 import cn.nukkit.blockentity.BlockEntity;
-import cn.nukkit.blockentity.BlockEntityHopper;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.event.entity.EntityDamageByEntityEvent;
-import cn.nukkit.event.inventory.InventoryMoveItemEvent;
-import cn.nukkit.inventory.Inventory;
 import cn.nukkit.inventory.InventoryHolder;
 import cn.nukkit.inventory.MinecartHopperInventory;
-import cn.nukkit.inventory.RecipeInventoryHolder;
 import cn.nukkit.item.Item;
 import cn.nukkit.level.format.FullChunk;
 import cn.nukkit.math.*;
@@ -24,7 +21,7 @@ import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.nbt.tag.ListTag;
 import cn.nukkit.utils.MinecartType;
 
-public class EntityMinecartHopper extends EntityMinecartAbstract implements InventoryHolder {
+public class EntityMinecartHopper extends EntityMinecartAbstract implements InventoryHolder, BlockHopper.IHopper {
 
     public static final int NETWORK_ID = 96;
     private final BlockVector3 temporalVector = new BlockVector3();
@@ -43,160 +40,37 @@ public class EntityMinecartHopper extends EntityMinecartAbstract implements Inve
     @Since("1.19.21-r3")
     @Override
     public boolean onUpdate(int currentTick) {
-        if (super.onUpdate(currentTick)) {
-            if (isOnTransferCooldown()) {
-                this.transferCooldown--;
-                return true;
-            }
+        if (!super.onUpdate(currentTick)) return false;
 
-            checkDisabled();
-
-            if (isDisabled()) {
-                return false;
-            }
-
-            this.updatePickupArea();
-
-            Block blockSide = this.getLevelBlock().getSide(BlockFace.UP);
-            BlockEntity blockEntity = this.level.getBlockEntity(temporalVector.setComponentsAdding(this, BlockFace.UP));
-
-            boolean changed;
-
-            if (blockEntity instanceof InventoryHolder || blockSide instanceof BlockComposter) {
-                changed = pullItems();
-            } else {
-                changed = pickupItems();
-            }
-
-            if (changed) {
-                this.setTransferCooldown(1);
-            }
-
+        if (isOnTransferCooldown()) {
+            this.transferCooldown--;
             return true;
-        } else {
-            return false;
         }
-    }
 
-    @PowerNukkitXOnly
-    @Since("1.19.21-r3")
-    public boolean pullItems() {
-        if (this.inventory.isFull()) {
+        checkDisabled();
+
+        if (isDisabled()) {
             return false;
         }
+
+        this.updatePickupArea();
 
         Block blockSide = this.getLevelBlock().getSide(BlockFace.UP);
         BlockEntity blockEntity = this.level.getBlockEntity(temporalVector.setComponentsAdding(this, BlockFace.UP));
 
-        if (blockEntity instanceof BlockEntityHopper hopper) {
-            if (hopper.isDisabled())
-                return false;
+        boolean changed;
+
+        if (blockEntity instanceof InventoryHolder || blockSide instanceof BlockComposter) {
+            changed = pullItems(this, this);
+        } else {
+            changed = pickupItems(this, this, pickupArea);
         }
 
-        if (blockEntity instanceof InventoryHolder) {
-            Inventory inv = blockEntity instanceof RecipeInventoryHolder recipeInventoryHolder ? recipeInventoryHolder.getProductView() : ((InventoryHolder) blockEntity).getInventory();
-
-            for (int i = 0; i < inv.getSize(); i++) {
-                Item item = inv.getItem(i);
-
-                if (!item.isNull()) {
-                    Item itemToAdd = item.clone();
-                    itemToAdd.count = 1;
-
-                    if (!this.inventory.canAddItem(itemToAdd)) {
-                        continue;
-                    }
-
-                    InventoryMoveItemEvent ev = new InventoryMoveItemEvent(inv, this.inventory, this, itemToAdd, InventoryMoveItemEvent.Action.SLOT_CHANGE);
-                    this.server.getPluginManager().callEvent(ev);
-
-                    if (ev.isCancelled()) {
-                        continue;
-                    }
-
-                    Item[] items = this.inventory.addItem(itemToAdd);
-
-                    if (items.length >= 1) {
-                        continue;
-                    }
-
-                    item.count--;
-
-                    inv.setItem(i, item);
-                    return true;
-                }
-            }
-        } else if (blockSide instanceof BlockComposter blockComposter) {
-            if (blockComposter.isFull()) {
-                Item item = blockComposter.empty();
-
-                if (item == null || item.isNull()) {
-                    return false;
-                }
-
-                Item itemToAdd = item.clone();
-                itemToAdd.count = 1;
-
-                if (!this.inventory.canAddItem(itemToAdd)) {
-                    return false;
-                }
-
-                Item[] items = this.inventory.addItem(itemToAdd);
-
-                return items.length < 1;
-            }
-        }
-        return false;
-    }
-
-    @PowerNukkitXOnly
-    @Since("1.19.21-r3")
-    public boolean pickupItems() {
-        if (this.inventory.isFull()) {
-            return false;
+        if (changed) {
+            this.setTransferCooldown(1);
         }
 
-        boolean pickedUpItem = false;
-
-        for (Entity entity : this.level.getCollidingEntities(this.pickupArea)) {
-            if (entity.isClosed() || !(entity instanceof EntityItem itemEntity)) {
-                continue;
-            }
-
-            Item item = itemEntity.getItem();
-
-            if (item.isNull()) {
-                continue;
-            }
-
-            int originalCount = item.getCount();
-
-            if (!this.inventory.canAddItem(item)) {
-                continue;
-            }
-
-            InventoryMoveItemEvent ev = new InventoryMoveItemEvent(null, this.inventory, this, item, InventoryMoveItemEvent.Action.PICKUP);
-            this.server.getPluginManager().callEvent(ev);
-
-            if (ev.isCancelled()) {
-                continue;
-            }
-
-            Item[] items = this.inventory.addItem(item);
-
-            if (items.length == 0) {
-                entity.close();
-                pickedUpItem = true;
-                continue;
-            }
-
-            if (items[0].getCount() != originalCount) {
-                pickedUpItem = true;
-                item.setCount(items[0].getCount());
-            }
-        }
-
-        return pickedUpItem;
+        return true;
     }
 
     @PowerNukkitXOnly

--- a/src/main/java/cn/nukkit/entity/item/EntityMinecartHopper.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityMinecartHopper.java
@@ -61,8 +61,10 @@ public class EntityMinecartHopper extends EntityMinecartAbstract implements Inve
         boolean changed;
 
         if (blockEntity instanceof InventoryHolder || blockSide instanceof BlockComposter) {
+            //从容器中拉取物品
             changed = pullItems(this, this);
         } else {
+            //收集掉落物
             changed = pickupItems(this, this, pickupArea);
         }
 

--- a/src/main/java/cn/nukkit/inventory/BaseInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BaseInventory.java
@@ -2,10 +2,7 @@ package cn.nukkit.inventory;
 
 import cn.nukkit.Player;
 import cn.nukkit.Server;
-import cn.nukkit.api.PowerNukkitOnly;
-import cn.nukkit.api.PowerNukkitXDifference;
-import cn.nukkit.api.PowerNukkitXOnly;
-import cn.nukkit.api.Since;
+import cn.nukkit.api.*;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockID;
 import cn.nukkit.blockentity.BlockEntity;

--- a/src/main/java/cn/nukkit/inventory/BaseInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BaseInventory.java
@@ -294,7 +294,7 @@ public abstract class BaseInventory implements Inventory {
 
     @Override
     public Item[] addItem(Item... slots) {
-        List<Item> itemSlots = new LinkedList<>();
+        List<Item> itemSlots = new ArrayList<>();
         for (Item slot : slots) {
             if (slot.getId() != 0 && slot.getCount() > 0) {
                 //todo: clone only if necessary
@@ -362,7 +362,7 @@ public abstract class BaseInventory implements Inventory {
 
     @Override
     public Item[] removeItem(Item... slots) {
-        List<Item> itemSlots = new LinkedList<>();
+        List<Item> itemSlots = new ArrayList<>();
         for (Item slot : slots) {
             if (slot.getId() != 0 && slot.getCount() > 0) {
                 itemSlots.add(slot.clone());

--- a/src/main/java/cn/nukkit/inventory/BaseInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BaseInventory.java
@@ -19,7 +19,6 @@ import cn.nukkit.network.protocol.InventoryContentPacket;
 import cn.nukkit.network.protocol.InventorySlotPacket;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
-import it.unimi.dsi.fastutil.ints.IntLists;
 
 import java.util.*;
 
@@ -295,7 +294,7 @@ public abstract class BaseInventory implements Inventory {
 
     @Override
     public Item[] addItem(Item... slots) {
-        List<Item> itemSlots = new ArrayList<>();
+        List<Item> itemSlots = new LinkedList<>();
         for (Item slot : slots) {
             if (slot.getId() != 0 && slot.getCount() > 0) {
                 //todo: clone only if necessary
@@ -363,7 +362,7 @@ public abstract class BaseInventory implements Inventory {
 
     @Override
     public Item[] removeItem(Item... slots) {
-        List<Item> itemSlots = new ArrayList<>();
+        List<Item> itemSlots = new LinkedList<>();
         for (Item slot : slots) {
             if (slot.getId() != 0 && slot.getCount() > 0) {
                 itemSlots.add(slot.clone());

--- a/src/main/java/cn/nukkit/inventory/BaseInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BaseInventory.java
@@ -110,12 +110,9 @@ public abstract class BaseInventory implements Inventory {
         return this.slots.containsKey(index) ? this.slots.get(index).clone() : AIR_ITEM;
     }
 
-    /**
-     * 获得未克隆的Item对象<p/>
-     * 若调用方保证不会修改此方法返回的Item对象，则使用此方法将降低特定场景下的性能开销
-     */
     @PowerNukkitXOnly
     @Since("1.19.50-r4")
+    @Override
     public Item getUnclonedItem(int index) {
         return this.slots.getOrDefault(index, AIR_ITEM);
     }

--- a/src/main/java/cn/nukkit/inventory/BaseInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BaseInventory.java
@@ -3,6 +3,9 @@ package cn.nukkit.inventory;
 import cn.nukkit.Player;
 import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitOnly;
+import cn.nukkit.api.PowerNukkitXDifference;
+import cn.nukkit.api.PowerNukkitXOnly;
+import cn.nukkit.api.Since;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockID;
 import cn.nukkit.blockentity.BlockEntity;
@@ -105,6 +108,16 @@ public abstract class BaseInventory implements Inventory {
     @Override
     public Item getItem(int index) {
         return this.slots.containsKey(index) ? this.slots.get(index).clone() : AIR_ITEM;
+    }
+
+    /**
+     * 获得未克隆的Item对象<p/>
+     * 若调用方保证不会修改此方法返回的Item对象，则使用此方法将降低特定场景下的性能开销
+     */
+    @PowerNukkitXOnly
+    @Since("1.19.50-r4")
+    public Item getUnclonedItem(int index) {
+        return this.slots.getOrDefault(index, AIR_ITEM);
     }
 
     @Override
@@ -254,13 +267,14 @@ public abstract class BaseInventory implements Inventory {
         }
     }
 
+    @PowerNukkitXDifference(info = "Using BaseInventory::getUnclonedItem() to improve performance", since = "1.19.50-r4")
     @Override
     public boolean canAddItem(Item item) {
         item = item.clone();
         boolean checkDamage = item.hasMeta();
         boolean checkTag = item.getCompoundTag() != null;
         for (int i = 0; i < this.getSize(); ++i) {
-            Item slot = this.getItem(i);
+            Item slot = this.getUnclonedItem(i);
             if (item.equals(slot, checkDamage, checkTag)) {
                 int diff;
                 if ((diff = Math.min(slot.getMaxStackSize(), this.getMaxStackSize()) - slot.getCount()) > 0) {

--- a/src/main/java/cn/nukkit/inventory/BaseInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BaseInventory.java
@@ -595,7 +595,7 @@ public abstract class BaseInventory implements Inventory {
     public void sendSlot(int index, Player... players) {
         InventorySlotPacket pk = new InventorySlotPacket();
         pk.slot = index;
-        pk.item = this.getUnclonedItem(index).clone();
+        pk.item = this.getUnclonedItem(index);
 
         for (Player player : players) {
             int id = player.getWindowId(this);

--- a/src/main/java/cn/nukkit/inventory/BaseInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BaseInventory.java
@@ -183,7 +183,7 @@ public abstract class BaseInventory implements Inventory {
             ((BlockEntity) holder).setDirty();
         }
 
-        Item old = this.getItem(index);
+        Item old = this.getUnclonedItem(index);
         this.slots.put(index, item.clone());
         this.onSlotChange(index, old, send);
 
@@ -249,7 +249,7 @@ public abstract class BaseInventory implements Inventory {
     @Override
     public int firstEmpty(Item item) {
         for (int i = 0; i < this.size; ++i) {
-            if (this.getItem(i).getId() == Item.AIR) {
+            if (this.getUnclonedItem(i).getId() == Item.AIR) {
                 return i;
             }
         }
@@ -259,9 +259,10 @@ public abstract class BaseInventory implements Inventory {
 
     @Override
     public void decreaseCount(int slot) {
-        Item item = this.getItem(slot);
+        Item item = this.getUnclonedItem(slot);
 
         if (item.getCount() > 0) {
+            item = item.clone();
             item.count--;
             this.setItem(slot, item);
         }
@@ -487,7 +488,7 @@ public abstract class BaseInventory implements Inventory {
             ((BlockEntity) holder).setDirty();
         }
 
-        if (before.getId() == ItemID.LODESTONE_COMPASS || getItem(index).getId() == ItemID.LODESTONE_COMPASS) {
+        if (before.getId() == ItemID.LODESTONE_COMPASS || getUnclonedItem(index).getId() == ItemID.LODESTONE_COMPASS) {
             if (holder instanceof Player) {
                 ((Player) holder).updateTrackingPositions(true);
             }
@@ -513,7 +514,7 @@ public abstract class BaseInventory implements Inventory {
         InventoryContentPacket pk = new InventoryContentPacket();
         pk.slots = new Item[this.getSize()];
         for (int i = 0; i < this.getSize(); ++i) {
-            pk.slots[i] = this.getItem(i);
+            pk.slots[i] = this.getUnclonedItem(i);
         }
 
         for (Player player : players) {
@@ -595,7 +596,7 @@ public abstract class BaseInventory implements Inventory {
     public void sendSlot(int index, Player... players) {
         InventorySlotPacket pk = new InventorySlotPacket();
         pk.slot = index;
-        pk.item = this.getItem(index).clone();
+        pk.item = this.getUnclonedItem(index).clone();
 
         for (Player player : players) {
             int id = player.getWindowId(this);

--- a/src/main/java/cn/nukkit/inventory/BaseInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BaseInventory.java
@@ -297,6 +297,7 @@ public abstract class BaseInventory implements Inventory {
         List<Item> itemSlots = new ArrayList<>();
         for (Item slot : slots) {
             if (slot.getId() != 0 && slot.getCount() > 0) {
+                //todo: clone only if necessary
                 itemSlots.add(slot.clone());
             }
         }
@@ -369,19 +370,22 @@ public abstract class BaseInventory implements Inventory {
         }
 
         for (int i = 0; i < this.size; ++i) {
-            Item item = this.getItem(i);
+            Item item = this.getUnclonedItem(i);
             if (item.getId() == Item.AIR || item.getCount() <= 0) {
                 continue;
             }
 
-            for (Item slot : new ArrayList<>(itemSlots)) {
+            for (Iterator<Item> iterator = itemSlots.iterator(); iterator.hasNext(); ) {
+                Item slot = iterator.next();
                 if (slot.equals(item, item.hasMeta(), item.getCompoundTag() != null)) {
+                    item = item.clone();
                     int amount = Math.min(item.getCount(), slot.getCount());
                     slot.setCount(slot.getCount() - amount);
                     item.setCount(item.getCount() - amount);
                     this.setItem(i, item);
                     if (slot.getCount() <= 0) {
-                        itemSlots.remove(slot);
+//                        itemSlots.remove(slot);
+                        iterator.remove();
                     }
 
                 }

--- a/src/main/java/cn/nukkit/inventory/DoubleChestInventory.java
+++ b/src/main/java/cn/nukkit/inventory/DoubleChestInventory.java
@@ -2,6 +2,8 @@ package cn.nukkit.inventory;
 
 import cn.nukkit.Player;
 import cn.nukkit.api.PowerNukkitDifference;
+import cn.nukkit.api.PowerNukkitXOnly;
+import cn.nukkit.api.Since;
 import cn.nukkit.blockentity.BlockEntityChest;
 import cn.nukkit.item.Item;
 import cn.nukkit.level.Level;
@@ -60,6 +62,13 @@ public class DoubleChestInventory extends ContainerInventory implements Inventor
     @Override
     public Item getItem(int index) {
         return index < this.left.getSize() ? this.left.getItem(index) : this.right.getItem(index - this.right.getSize());
+    }
+
+    @PowerNukkitXOnly
+    @Since("1.19.50-r4")
+    @Override
+    public Item getUnclonedItem(int index) {
+        return index < this.left.getSize() ? this.left.getUnclonedItem(index) : this.right.getUnclonedItem(index - this.right.getSize());
     }
 
     @Override
@@ -188,7 +197,7 @@ public class DoubleChestInventory extends ContainerInventory implements Inventor
     public void sendSlot(Inventory inv, int index, Player... players) {
         InventorySlotPacket pk = new InventorySlotPacket();
         pk.slot = inv == this.right ? this.left.getSize() + index : index;
-        pk.item = inv.getItem(index).clone();
+        pk.item = inv.getUnclonedItem(index);
 
         for (Player player : players) {
             int id = player.getWindowId(this);

--- a/src/main/java/cn/nukkit/inventory/GrindstoneInventory.java
+++ b/src/main/java/cn/nukkit/inventory/GrindstoneInventory.java
@@ -3,6 +3,7 @@ package cn.nukkit.inventory;
 import cn.nukkit.Player;
 import cn.nukkit.api.API;
 import cn.nukkit.api.PowerNukkitOnly;
+import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemID;
@@ -226,8 +227,22 @@ public class GrindstoneInventory extends FakeBlockUIComponent {
         if (index == 2) {
             index = SLOT_RESULT;
         }
-        
+
         return super.getItem(index);
+    }
+
+    @PowerNukkitXOnly
+    @Since("1.19.50-r4")
+    @Override
+    public Item getUnclonedItem(int index) {
+        if (index < 0 || index > 3) {
+            return Item.get(0);
+        }
+        if (index == 2) {
+            index = SLOT_RESULT;
+        }
+
+        return super.getUnclonedItem(index);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/inventory/Inventory.java
+++ b/src/main/java/cn/nukkit/inventory/Inventory.java
@@ -51,6 +51,20 @@ public interface Inventory {
     Item getItem(int index);
 
     /**
+     * 获取该库存指定索引处的未克隆的物品<p/>
+     * 若调用方保证不会修改此方法返回的Item对象，则使用此方法将降低特定场景下Item::clone()造成的性能开销
+     *
+     * @param index the index
+     * @return the item
+     */
+    @PowerNukkitXOnly
+    @Since("1.19.50-r4")
+    default Item getUnclonedItem(int index) {
+        //你需要覆写它来实现
+        return getItem(index);
+    }
+
+    /**
      * 设置该库存指定索引处的物品
      *
      * @param index the index

--- a/src/main/java/cn/nukkit/inventory/Inventory.java
+++ b/src/main/java/cn/nukkit/inventory/Inventory.java
@@ -1,6 +1,7 @@
 package cn.nukkit.inventory;
 
 import cn.nukkit.Player;
+import cn.nukkit.api.DoNotModify;
 import cn.nukkit.api.PowerNukkitOnly;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
@@ -59,6 +60,7 @@ public interface Inventory {
      */
     @PowerNukkitXOnly
     @Since("1.19.50-r4")
+    @DoNotModify
     default Item getUnclonedItem(int index) {
         //你需要覆写它来实现
         return getItem(index);


### PR DESCRIPTION
此PR为Inventory增加了一个接口getUnclonedItem()用于获取未克隆的原始Item对象
对于只读逻辑，应尽量使用此新接口减少gc/clone耗时

修改了漏斗的部分逻辑，现在由矿车检查漏斗，大幅降低漏斗更新开销