### PR TITLE
弃用BlockEntityContainer接口

### DIFF
--- a/src/main/java/cn/nukkit/blockentity/BlockEntityContainer.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityContainer.java
@@ -1,5 +1,6 @@
 package cn.nukkit.blockentity;
 
+import cn.nukkit.api.DeprecationDetails;
 import cn.nukkit.item.Item;
 
 /**
@@ -15,6 +16,8 @@ import cn.nukkit.item.Item;
  * @see BlockEntityFurnace
  * @since Nukkit 1.0 | Nukkit API 1.0.0
  */
+@Deprecated(since = "1.19.50-r3", forRemoval = true)
+@DeprecationDetails(since = "1.19.50-r3", reason = "No usage at all & Confuse devs.", replaceWith = "cn.nukkit.inventory.InventoryHolder")
 public interface BlockEntityContainer {
 
     /**


### PR DESCRIPTION
BlockEntityContainer接口没有任何实际用途，其所有接口方法都没有在类外部调用过，且易造成混淆和误用。
目前可以确定此接口的所有用法都可以使用更好的API代替，出于兼容性考虑，做弃用处理。