### PR TITLE
fix: 修复玩家游泳时穿过一格高度水卡墙的bug

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3681,7 +3681,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                         break;
                     }
                     MovePlayerPacket movePlayerPacket = (MovePlayerPacket) packet;
-                    Vector3 newPos = new Vector3(movePlayerPacket.x, movePlayerPacket.y - this.getEyeHeight(), movePlayerPacket.z);
+                    Vector3 newPos = new Vector3(movePlayerPacket.x, movePlayerPacket.y - getBaseOffset(), movePlayerPacket.z);
                     double dist = newPos.distanceSquared(this);
                     movePlayerPacket.yaw %= 360;
                     movePlayerPacket.headYaw %= 360;
@@ -3820,7 +3820,7 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
                             this.setGliding(false);
                         }
                     }
-                    Vector3 clientPosition = authPacket.getPosition().asVector3().subtract(0, this.getEyeHeight(), 0);
+                    Vector3 clientPosition = authPacket.getPosition().asVector3().subtract(0, getBaseOffset(), 0);
                     double distSqrt = clientPosition.distanceSquared(this);
                     float yaw = authPacket.getYaw() % 360;
                     float pitch = authPacket.getPitch() % 360;

--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -2001,7 +2001,7 @@ public abstract class Entity extends Location implements Metadatable {
         pk.x = this.x;
         //因为以前处理MOVE_PLAYER_PACKET的时候是y - this.getBaseOffset()
         //现在统一 MOVE_PLAYER_PACKET和PLAYER_AUTH_INPUT_PACKET 均为this.y - this.getEyeHeight()，所以这里不再需要对两种移动方式分别处理
-        pk.y = isSwimming() ? this.y + getSwimmingHeight() : this.y + this.getEyeHeight();
+        pk.y = this.y + this.getBaseOffset();
         pk.z = this.z;
         pk.headYaw = yaw;
         pk.pitch = pitch;

--- a/src/main/java/cn/nukkit/entity/EntityHuman.java
+++ b/src/main/java/cn/nukkit/entity/EntityHuman.java
@@ -72,6 +72,11 @@ public class EntityHuman extends EntityHumanType {
         return (float) (boundingBox.getMaxY() - boundingBox.getMinY() - 0.18);
     }
 
+    /**
+     * 偏移客户端传输玩家位置的y轴误差
+     *
+     * @return the base offset
+     */
     @Override
     protected float getBaseOffset() {
         return 1.62f;


### PR DESCRIPTION
由于之前的y轴偏差计算错误导致，现已修复