### PR TITLE
fix: 彻底移除字符串物品中的自定义Compound

### DIFF
--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -1103,19 +1103,11 @@ public class Item implements Cloneable, BlockID, ItemID {
     }
 
     public Item setCompoundTag(CompoundTag tag) {
-        if (this.id == STRING_IDENTIFIED_ITEM) {
-            return this.setNamedTag(tag.putString("Name", getNamespaceId()));
-        }
-
         this.setNamedTag(tag);
         return this;
     }
 
     public Item setCompoundTag(byte[] tags) {
-        if (this.id == STRING_IDENTIFIED_ITEM) {
-            CompoundTag compoundTag = (tags == null || tags.length == 0) ? new CompoundTag() : parseCompoundTag(tags);
-            return this.setNamedTag(compoundTag);
-        }
         this.tags = tags;
         this.cachedNBT = null;
         return this;
@@ -1652,10 +1644,6 @@ public class Item implements Cloneable, BlockID, ItemID {
             this.cachedNBT.setName("");
         }
 
-        if (this.id == STRING_IDENTIFIED_ITEM) {
-            return this.cachedNBT.putString("Name", getNamespaceId());
-        }
-
         return this.cachedNBT;
     }
 
@@ -1672,10 +1660,6 @@ public class Item implements Cloneable, BlockID, ItemID {
         }
         tag.setName(null);
 
-        if (this.id == STRING_IDENTIFIED_ITEM && !tag.containsString("Name")) {
-            tag.putString("Name", getNamespaceId());
-        }
-
         this.cachedNBT = tag;
         this.tags = writeCompoundTag(tag);
 
@@ -1683,9 +1667,6 @@ public class Item implements Cloneable, BlockID, ItemID {
     }
 
     public Item clearNamedTag() {
-        if (this.id == STRING_IDENTIFIED_ITEM) {
-            return setCompoundTag(new CompoundTag());
-        }
         return this.setCompoundTag(EmptyArrays.EMPTY_BYTES);
     }
 

--- a/src/main/java/cn/nukkit/item/ItemID.java
+++ b/src/main/java/cn/nukkit/item/ItemID.java
@@ -9,7 +9,6 @@ import static cn.nukkit.utils.Utils.dynamic;
 
 public interface ItemID {
     @PowerNukkitOnly
-    @Since("FUTURE")
     int STRING_IDENTIFIED_ITEM = dynamic(255);
     int IRON_SHOVEL = 256;
     int IRON_PICKAXE = 257;

--- a/src/main/java/cn/nukkit/item/StringItem.java
+++ b/src/main/java/cn/nukkit/item/StringItem.java
@@ -8,7 +8,7 @@ import cn.nukkit.api.PowerNukkitXDifference;
  * @since 2021-06-12
  */
 @PowerNukkitOnly
-@PowerNukkitXDifference(info = "Change to interface")
+@PowerNukkitXDifference(info = "Change to interface,Remove CustomCompound from StringItem")
 public interface StringItem {
     String getNamespaceId();
 

--- a/src/main/java/cn/nukkit/nbt/NBTIO.java
+++ b/src/main/java/cn/nukkit/nbt/NBTIO.java
@@ -37,6 +37,7 @@ public class NBTIO {
         return putItemHelper(item, null);
     }
 
+    @PowerNukkitXDifference(info = "Remove the name from the tag, this function will be removed in the future")
     public static CompoundTag putItemHelper(Item item, Integer slot) {
         CompoundTag tag = new CompoundTag((String) null)
                 .putByte("Count", item.getCount())
@@ -65,6 +66,7 @@ public class NBTIO {
         return tag;
     }
 
+    @PowerNukkitXDifference(info = "Remove the name from the tag, this function will be removed in the future")
     @PowerNukkitXDifference(info = "not limit name and id because the return value of fromString not null")
     public static Item getItemHelper(CompoundTag tag) {
         if (!tag.containsByte("Count")) {

--- a/src/main/java/cn/nukkit/nbt/NBTIO.java
+++ b/src/main/java/cn/nukkit/nbt/NBTIO.java
@@ -53,7 +53,7 @@ public class NBTIO {
 
         if (item.hasCompoundTag()) {
             if (id == ItemID.STRING_IDENTIFIED_ITEM) {
-                CompoundTag realCompound = item.getNamedTag().clone().remove("Name");
+                CompoundTag realCompound = item.getNamedTag().clone().remove("Name");//todo 未来移除
                 if (!realCompound.isEmpty()) {
                     tag.putCompound("tag", realCompound);
                 }
@@ -97,8 +97,11 @@ public class NBTIO {
         }
 
         Tag tagTag = tag.get("tag");
-        if (tagTag instanceof CompoundTag) {
-            item.setNamedTag((CompoundTag) tagTag);
+        if (tagTag instanceof CompoundTag compoundTag) {//todo 临时修复物品NBT，未来移除
+            if (compoundTag.containsString("Name")) {
+                compoundTag.remove("Name");
+            }
+            item.setNamedTag(compoundTag);
         }
 
         return item;

--- a/src/main/java/cn/nukkit/utils/BinaryStream.java
+++ b/src/main/java/cn/nukkit/utils/BinaryStream.java
@@ -1,9 +1,6 @@
 package cn.nukkit.utils;
 
-import cn.nukkit.api.DeprecationDetails;
-import cn.nukkit.api.PowerNukkitOnly;
-import cn.nukkit.api.PowerNukkitXOnly;
-import cn.nukkit.api.Since;
+import cn.nukkit.api.*;
 import cn.nukkit.block.Block;
 import cn.nukkit.blockstate.BlockState;
 import cn.nukkit.blockstate.BlockStateRegistry;
@@ -397,6 +394,7 @@ public class BinaryStream {
         return new SerializedImage(width, height, data);
     }
 
+    @PowerNukkitXDifference(info = "Remove the name from the tag, this function will be removed in the future")
     public Item getSlot() {
         int networkId = getVarInt();
         if (networkId == 0) {
@@ -598,6 +596,7 @@ public class BinaryStream {
         this.putSlot(item, false);
     }
 
+    @PowerNukkitXDifference(info = "Remove the name from the tag, this function will be removed in the future")
     @Since("1.4.0.0-PN")
     public void putSlot(Item item, boolean instanceItem) {
         if (item == null || item.getId() == 0) {

--- a/src/main/java/cn/nukkit/utils/BinaryStream.java
+++ b/src/main/java/cn/nukkit/utils/BinaryStream.java
@@ -522,6 +522,10 @@ public class BinaryStream {
                 namedTag.put("CanPlaceOn", listTag);
             }
 
+            if (namedTag.containsString("Name")) {//todo 临时修复物品NBT，未来移除
+                namedTag.remove("Name");
+            }
+
             item.setNamedTag(namedTag);
         }
 
@@ -647,7 +651,7 @@ public class BinaryStream {
                     tag = NBTIO.read(nbt, ByteOrder.LITTLE_ENDIAN);
                 }
 
-                if (tag.containsString("Name")) tag.remove("Name");
+                if (tag.containsString("Name")) tag.remove("Name");//todo 未来移除
 
                 if (tag.contains("Damage")) {
                     tag.put("__DamageConflict__", tag.removeAndGet("Damage"));
@@ -660,7 +664,7 @@ public class BinaryStream {
                 stream.writeShort(-1);
                 stream.writeByte(1); // Hardcoded in current version
                 var tag = item.getNamedTag();
-                if (tag.containsString("Name")) tag.remove("Name");
+                if (tag.containsString("Name")) tag.remove("Name");//todo 未来移除
                 stream.write(NBTIO.write(tag, ByteOrder.LITTLE_ENDIAN));
             } else {
                 userDataBuf.writeShortLE(0);


### PR DESCRIPTION
当前master最新版本中出现巨大bug，字符串物品在退出游戏重进后无法扔出，原因是字符串物品nametag中添加了`Name`的字段，而`NBTIO#putItemHelper`持久化物品时又会将`Name`移除，玩家重进游戏读取物品后，getCompound又会重新写入`Name`的字段。导致比较失败。
我认为`Name`不仅没有作用，还会导致使用时混淆，这个Name并不是物品的名字，而是Tag中的子字段，字符串物品NBT结构是
```
{
Count:int
Damage:int
Name:string
Slot:int
tag:Compound
}
```
物品getCompound获取的就是上述的tag