### PR TITLE
营火堆叠应为64

### DIFF
--- a/src/main/java/cn/nukkit/item/ItemCampfire.java
+++ b/src/main/java/cn/nukkit/item/ItemCampfire.java
@@ -21,9 +21,4 @@ public class ItemCampfire extends Item {
         super(CAMPFIRE, meta, count, "Campfire");
         this.block = new BlockCampfire();
     }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
-    }
 }


### PR DESCRIPTION
https://minecraft.fandom.com/zh/wiki/%E8%90%A5%E7%81%AB#%E5%8E%86%E5%8F%B2
营火在1.17.30改为可堆叠64个