### PR TITLE
fix: 不移除BlockEntityContainer

### DIFF
--- a/src/main/java/cn/nukkit/blockentity/BlockEntityContainer.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityContainer.java
@@ -16,8 +16,6 @@ import cn.nukkit.item.Item;
  * @see BlockEntityFurnace
  * @since Nukkit 1.0 | Nukkit API 1.0.0
  */
-@Deprecated(since = "1.19.50-r3", forRemoval = true)
-@DeprecationDetails(since = "1.19.50-r3", reason = "No usage at all & Confuse devs.", replaceWith = "cn.nukkit.inventory.InventoryHolder")
 public interface BlockEntityContainer {
 
     /**
@@ -28,6 +26,8 @@ public interface BlockEntityContainer {
      * @return 这个物品的 {@code Item}对象。<br>An {@code Item} object for this item.
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
+    @Deprecated(since = "1.19.50-r3")
+    @DeprecationDetails(since = "1.19.50-r3", reason = "No usage at all & Confuse devs.", replaceWith = "cn.nukkit.inventory.InventoryHolder#getInventory().getItem()")
     Item getItem(int index);
 
     /**
@@ -41,6 +41,8 @@ public interface BlockEntityContainer {
      * @param item  描述这个物品的 {@code Item}对象。<br>The {@code Item} object that describes this item.
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
+    @Deprecated(since = "1.19.50-r3")
+    @DeprecationDetails(since = "1.19.50-r3", reason = "No usage at all & Confuse devs.", replaceWith = "cn.nukkit.inventory.InventoryHolder#getInventory().setItem()")
     void setItem(int index, Item item);
 
     /**
@@ -50,5 +52,7 @@ public interface BlockEntityContainer {
      * @return 最多能包含的物品数量。<br>The max number.
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
+    @Deprecated(since = "1.19.50-r3")
+    @DeprecationDetails(since = "1.19.50-r3", reason = "No usage at all & Confuse devs.", replaceWith = "cn.nukkit.inventory.InventoryHolder#getInventory().getSize()")
     int getSize();
 }


### PR DESCRIPTION
它可以用于表达一个带有容器的实体，而实现InventoryHolder接口的实体不一定带有容器