### PR TITLE
Fix frequent decompression failures in libdeflate impl.

### DIFF
--- a/src/main/java/cn/nukkit/utils/LibDeflateThreadLocal.java
+++ b/src/main/java/cn/nukkit/utils/LibDeflateThreadLocal.java
@@ -1,5 +1,6 @@
 package cn.nukkit.utils;
 
+import cn.nukkit.Server;
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.nbt.stream.FastByteArrayOutputStream;
@@ -8,6 +9,8 @@ import cn.powernukkitx.libdeflate.LibdeflateCompressor;
 import cn.powernukkitx.libdeflate.LibdeflateDecompressor;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
@@ -19,6 +22,18 @@ public class LibDeflateThreadLocal implements ZlibProvider {
     private static final ThreadLocal<LibdeflateDecompressor> PNX_INFLATER = ThreadLocal.withInitial(PNXLibInflater::new);
     private static final ThreadLocal<LibdeflateCompressor> DEFLATER = ThreadLocal.withInitial(PNXLibDeflater::new);
     private static final ThreadLocal<byte[]> BUFFER = ThreadLocal.withInitial(() -> new byte[8192]);
+    @Since("1.20.0-r2")
+    private static final ThreadLocal<ByteBuffer> DIRECT_BUFFER = ThreadLocal.withInitial(() -> {
+        var maximumSizePerChunk = 1024 * 1024;
+        if (Server.getInstance() != null) {
+            maximumSizePerChunk = Server.getInstance().getMaximumSizePerChunk();
+        }
+        if (maximumSizePerChunk < 8192 || maximumSizePerChunk > 1024 * 1024 * 16) {
+            return null;
+        } else {
+            return ByteBuffer.allocateDirect(maximumSizePerChunk).order(ByteOrder.nativeOrder());
+        }
+    });
 
     // compress
     @Override
@@ -49,16 +64,42 @@ public class LibDeflateThreadLocal implements ZlibProvider {
     @Override
     public byte[] inflate(byte[] data, int maxSize) throws IOException {
         var pnxInflater = PNX_INFLATER.get();
-        byte[] buffer = BUFFER.get();
         try {
-            var result = pnxInflater.decompressUnknownSize(data, 0, data.length, buffer, 0, buffer.length, CompressionType.ZLIB);
+            if (maxSize < 8192) {
+                byte[] buffer = BUFFER.get();
+                var result = pnxInflater.decompressUnknownSize(data, 0, data.length, buffer, 0, buffer.length, CompressionType.ZLIB);
+                if (result == -1) {
+                    return inflateD(data, maxSize);
+                } else if (maxSize > 0 && result >= maxSize) {
+                    throw new IOException("Inflated data exceeds maximum size");
+                }
+                byte[] output = new byte[(int) result];
+                System.arraycopy(buffer, 0, output, 0, output.length);
+                return output;
+            } else {
+                return inflateD(data, maxSize);
+            }
+        } catch (DataFormatException e) {
+            throw new IOException("Unable to inflate zlib stream", e);
+        }
+    }
+
+    public byte[] inflateD(byte[] data, int maxSize) throws IOException {
+        var pnxInflater = PNX_INFLATER.get();
+        try {
+            var directBuffer = DIRECT_BUFFER.get();
+            if (directBuffer == null || directBuffer.capacity() == 0) {
+                return inflate0(data, maxSize);
+            }
+            var result = pnxInflater.decompressUnknownSize(ByteBuffer.wrap(data), directBuffer, CompressionType.ZLIB);
             if (result == -1) {
                 return inflate0(data, maxSize);
             } else if (maxSize > 0 && result >= maxSize) {
                 throw new IOException("Inflated data exceeds maximum size");
             }
             byte[] output = new byte[(int) result];
-            System.arraycopy(buffer, 0, output, 0, output.length);
+            directBuffer.get(0, output, 0, output.length);
+            directBuffer.clear();
             return output;
         } catch (DataFormatException e) {
             throw new IOException("Unable to inflate zlib stream", e);


### PR DESCRIPTION
此PR修复了libdeflate硬件加速解压缩中频繁的失败回退问题。

在一些生存服务器中，区块通常具有大量数据，默认的堆上缓冲区为8192字节，这使得使用libdeflate解压数据时经常出现缓冲区溢出并回退到默认的java实现中。这会导致解压缩性能下降，同时也增加了gc跨native边界追踪引用的工作量。  

此PR进行了更改，若检测到8192字节的默认堆上缓冲区不足，便会在堆外native区创建一个`maximumChunkSize`（默认1MB，最大16MB）大小的缓冲区以供libdeflate实现使用，这几乎不会增加gc负担，因为巨大的缓冲区不在堆内存中。如果此堆外缓冲区仍发生溢出，再回退到java的流式解压实现。

此PR仍保留了8192字节的默认堆上缓冲区，因为在堆内与堆外复制数据有一定开销，观测到超过70%的解压都可以在8192字节的默认缓冲区内完成。
