### PR TITLE
TextFormat.java : not cleaning the new color codes fixed

### DIFF
--- a/src/main/java/cn/nukkit/utils/TextFormat.java
+++ b/src/main/java/cn/nukkit/utils/TextFormat.java
@@ -180,7 +180,7 @@ public enum TextFormat {
      */
     public static final char ESCAPE = '\u00A7';
 
-    private static final Pattern CLEAN_PATTERN = Pattern.compile("(?i)" + ESCAPE + "[0-9A-GK-OR]");
+    private static final Pattern CLEAN_PATTERN = Pattern.compile("(?i)" + ESCAPE + "[0-9A-LO-U]");
     private final static Map<Integer, TextFormat> BY_ID = Maps.newTreeMap();
     private final static Map<Character, TextFormat> BY_CHAR = new HashMap<>();
 


### PR DESCRIPTION
Fixed `CLEAN_PATTERN` in `TEXT_FORAMT`
it's now cleaning the new color codes