### PR TITLE
Offload packet encoding and decoding from main thread

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -103,6 +103,7 @@ import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -489,9 +490,14 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
     @SneakyThrows
     private List<DataPacket> unpackBatchedPackets(BatchPacket packet) {
+        Executor executor;
+        if (this.networkSession != null)
+            executor = this.networkSession.getPacketProcessingExecutor();
+        else
+            executor = null;
         return this.server.getNetwork().unpackBatchedPackets(packet,
                 this.server.isEnableSnappy() ? CompressionProvider.SNAPPY : CompressionProvider.ZLIB,
-                this.networkSession.getPacketProcessingExecutor());
+                executor);
     }
 
     @PowerNukkitXDifference(since = "1.19.60-r1", info = "Auto-break custom blocks if client doesn't send the break data-pack.")

--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -489,7 +489,9 @@ public class Player extends EntityHuman implements CommandSender, InventoryHolde
 
     @SneakyThrows
     private List<DataPacket> unpackBatchedPackets(BatchPacket packet) {
-        return this.server.getNetwork().unpackBatchedPackets(packet, this.server.isEnableSnappy() ? CompressionProvider.SNAPPY : CompressionProvider.ZLIB);
+        return this.server.getNetwork().unpackBatchedPackets(packet,
+                this.server.isEnableSnappy() ? CompressionProvider.SNAPPY : CompressionProvider.ZLIB,
+                this.networkSession.getPacketProcessingExecutor());
     }
 
     @PowerNukkitXDifference(since = "1.19.60-r1", info = "Auto-break custom blocks if client doesn't send the break data-pack.")

--- a/src/main/java/cn/nukkit/entity/data/EntityMetadata.java
+++ b/src/main/java/cn/nukkit/entity/data/EntityMetadata.java
@@ -5,6 +5,7 @@ import cn.nukkit.item.Item;
 import cn.nukkit.math.Vector3;
 import cn.nukkit.math.Vector3f;
 import cn.nukkit.nbt.tag.CompoundTag;
+import cn.nukkit.utils.collection.nb.Int2ObjectNonBlockingMap;
 import lombok.extern.log4j.Log4j2;
 
 import java.util.HashMap;
@@ -16,15 +17,15 @@ import java.util.Map;
 @Log4j2
 public class EntityMetadata {
 
-    private final Map<Integer, EntityData> map = new HashMap<>();
+    private final Int2ObjectNonBlockingMap<EntityData<?>> map = new Int2ObjectNonBlockingMap<>();
 
-    public EntityData get(int id) {
+    public EntityData<?> get(int id) {
         return this.getOrDefault(id, null);
     }
 
     @PowerNukkitDifference(info = "Reduce a lot of hidden NullPointerExceptions", since = "1.3.1.2-PN")
-    public EntityData getOrDefault(int id, EntityData defaultValue) {
-        EntityData data = this.map.getOrDefault(id, defaultValue);
+    public EntityData<?> getOrDefault(int id, EntityData<?> defaultValue) {
+        var data = this.map.getOrDefault(id, defaultValue);
         if (data == null) {
             return null;
         }
@@ -36,7 +37,7 @@ public class EntityMetadata {
         return this.map.containsKey(id);
     }
 
-    public EntityMetadata put(EntityData data) {
+    public EntityMetadata put(EntityData<?> data) {
         this.map.put(data.getId(), data);
         //log.info("Updated entity data {}", this::toString);
         return this;
@@ -119,7 +120,7 @@ public class EntityMetadata {
         return this.put(new StringEntityData(id, value));
     }
 
-    public Map<Integer, EntityData> getMap() {
+    public Map<Integer, EntityData<?>> getMap() {
         return new HashMap<>(map);
     }
 

--- a/src/main/java/cn/nukkit/entity/data/EntityMetadata.java
+++ b/src/main/java/cn/nukkit/entity/data/EntityMetadata.java
@@ -5,7 +5,9 @@ import cn.nukkit.item.Item;
 import cn.nukkit.math.Vector3;
 import cn.nukkit.math.Vector3f;
 import cn.nukkit.nbt.tag.CompoundTag;
-import cn.nukkit.utils.collection.nb.Int2ObjectNonBlockingMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import lombok.extern.log4j.Log4j2;
 
 import java.util.HashMap;
@@ -17,7 +19,7 @@ import java.util.Map;
 @Log4j2
 public class EntityMetadata {
 
-    private final Int2ObjectNonBlockingMap<EntityData<?>> map = new Int2ObjectNonBlockingMap<>();
+    private final Int2ObjectMap<EntityData<?>> map = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
 
     public EntityData<?> get(int id) {
         return this.getOrDefault(id, null);

--- a/src/main/java/cn/nukkit/network/Network.java
+++ b/src/main/java/cn/nukkit/network/Network.java
@@ -313,8 +313,11 @@ public class Network {
 
     public void processBatch(BatchPacket packet, Player player) {
         try {
-            unpackBatchedPackets(packet, player.getNetworkSession().getCompression(),
-                    player.getNetworkSession().getPacketProcessingExecutor());
+            if (player.getNetworkSession() != null)
+                unpackBatchedPackets(packet, player.getNetworkSession().getCompression(),
+                        player.getNetworkSession().getPacketProcessingExecutor());
+            else
+                unpackBatchedPackets(packet, CompressionProvider.ZLIB, player.getNetworkSession().getPacketProcessingExecutor());
         } catch (ProtocolException e) {
             player.close("", e.getMessage());
             log.error("Unable to process player packets ", e);

--- a/src/main/java/cn/nukkit/network/RakNetInterface.java
+++ b/src/main/java/cn/nukkit/network/RakNetInterface.java
@@ -251,8 +251,10 @@ public class RakNetInterface implements RakNetServerListener, AdvancedSourceInte
     @Override
     public Integer putResourcePacket(Player player, DataPacket packet) {
         RakNetPlayerSession session = this.sessions.get(player.getRawSocketAddress());
-        packet.tryEncode();
-        session.sendResourcePacket(packet.clone());
+        if (session != null) {
+            packet.tryEncode();
+            session.sendResourcePacket(packet.clone());
+        }
         return null;
     }
 

--- a/src/main/java/cn/nukkit/network/RakNetInterface.java
+++ b/src/main/java/cn/nukkit/network/RakNetInterface.java
@@ -29,8 +29,10 @@ import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.util.*;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author MagicDroidX (Nukkit Project)
@@ -252,12 +254,8 @@ public class RakNetInterface implements RakNetServerListener, AdvancedSourceInte
     @Override
     public Integer putResourcePacket(Player player, DataPacket packet) {
         RakNetPlayerSession session = this.sessions.get(player.getRawSocketAddress());
-        if (session != null) {
-            getPacketProcessingThreadPool().execute(() -> {
-                packet.tryEncode();
-                session.sendResourcePacket(packet.clone());
-            });
-        }
+        packet.tryEncode();
+        session.sendResourcePacket(packet.clone());
         return null;
     }
 

--- a/src/main/java/cn/nukkit/network/protocol/DataPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/DataPacket.java
@@ -51,7 +51,7 @@ public abstract class DataPacket extends BinaryStream implements Cloneable {
 
     public final void tryEncode() {
         if (!this.isEncoded) {
-            this.isEncoded = true;
+            this.isEncoded = true; // StoreLoad fence
             this.encode();
         }
     }

--- a/src/main/java/cn/nukkit/network/session/NetworkPlayerSession.java
+++ b/src/main/java/cn/nukkit/network/session/NetworkPlayerSession.java
@@ -5,9 +5,11 @@ import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
 import cn.nukkit.network.CompressionProvider;
 import cn.nukkit.network.protocol.DataPacket;
+import org.jetbrains.annotations.Nullable;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
+import java.util.concurrent.Executor;
 
 @Since("1.19.30-r1")
 @PowerNukkitXOnly
@@ -28,5 +30,11 @@ public interface NetworkPlayerSession {
 
     default void setEncryption(SecretKey agreedKey, Cipher encryptionCipher, Cipher decryptionCipher) {
 
+    }
+
+    @Since("1.20.0-r3")
+    @PowerNukkitXOnly
+    default @Nullable Executor getPacketProcessingExecutor() {
+        return null;
     }
 }

--- a/src/main/java/cn/nukkit/network/session/RakNetPlayerSession.java
+++ b/src/main/java/cn/nukkit/network/session/RakNetPlayerSession.java
@@ -114,7 +114,7 @@ public class RakNetPlayerSession implements NetworkPlayerSession, RakNetSessionL
             buffer.readBytes(packetBuffer);
 
             try {
-                this.server.getNetwork().processBatch(packetBuffer, this.inbound, this.getCompression());
+                this.server.getNetwork().processBatch(packetBuffer, this.inbound, this.getCompression(), getPacketProcessingExecutor());
             } catch (ProtocolException e) {
                 this.disconnect("Sent malformed packet");
                 log.error("Unable to process batch packet", e);

--- a/src/main/java/cn/nukkit/utils/Binary.java
+++ b/src/main/java/cn/nukkit/utils/Binary.java
@@ -101,10 +101,10 @@ public class Binary {
 
     public static byte[] writeMetadata(EntityMetadata metadata) {
         BinaryStream stream = new BinaryStream();
-        Map<Integer, EntityData> map = metadata.getMap();
+        Map<Integer, EntityData<?>> map = metadata.getMap();
         stream.putUnsignedVarInt(map.size());
         for (int id : map.keySet()) {
-            EntityData d = map.get(id);
+            EntityData<?> d = map.get(id);
             stream.putUnsignedVarInt(id);
             stream.putUnsignedVarInt(d.getType());
             switch (d.getType()) {
@@ -161,7 +161,7 @@ public class Binary {
         for (int i = 0; i < count; i++) {
             int key = (int) stream.getUnsignedVarInt();
             int type = (int) stream.getUnsignedVarInt();
-            EntityData value = null;
+            EntityData<?> value = null;
             switch (type) {
                 case Entity.DATA_TYPE_BYTE:
                     value = new ByteEntityData(key, stream.getByte());

--- a/src/main/java/cn/nukkit/utils/BinaryStream.java
+++ b/src/main/java/cn/nukkit/utils/BinaryStream.java
@@ -31,10 +31,13 @@ import lombok.val;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.lang.reflect.Array;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -49,7 +52,7 @@ public class BinaryStream {
 
     public int offset;
     private byte[] buffer;
-    protected int count;
+    protected volatile int count;
 
     private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
 
@@ -94,7 +97,9 @@ public class BinaryStream {
     }
 
     public byte[] getBuffer() {
-        return Arrays.copyOf(buffer, count);
+        VarHandle.fullFence(); // ensure volatile read of array content
+        var tmp = buffer;
+        return Arrays.copyOf(tmp, count);
     }
 
     public int getCount() {


### PR DESCRIPTION
In situations where there are many entities, players, or particles, a large number of data packets are all piled up on the main thread for encoding and decoding, which will seriously affect performance.

This PR adds PacketProcessingThread. Most data packets will be encoded and decoded using this Thread. According to the test, the load of the main thread can be reduced by 30% under the condition of about 100 entities+players.

Because the MemoryBarriers is used to synchronize packet data between multiple threads, the performance on single core and dual core CPUs decreases slightly.

More measured results are needed to demonstrate the absence of potential concurrent errors.

-------

Bugs:
- [x] EntityMetaData does not support concurrent access.
- [x] Inbound datapacket sometimes are parsed in wrong orders.
- [x] Outbound datapacket sometimes are sent in wrong orders.
- [x] Concurrent encrypting is not supported.