### PR TITLE
Fixed wrong damagecause

### DIFF
--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentThorns.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentThorns.java
@@ -55,7 +55,7 @@ public class EnchantmentThorns extends Enchantment {
         ThreadLocalRandom random = ThreadLocalRandom.current();
 
         if (shouldHit(random, thornsLevel)) {
-            attacker.attack(new EntityDamageByEntityEvent(entity, attacker, EntityDamageEvent.DamageCause.ENTITY_ATTACK, getDamage(random, level), 0f));
+            attacker.attack(new EntityDamageByEntityEvent(entity, attacker, EntityDamageEvent.DamageCause.THORNS, getDamage(random, level), 0f));
         }
     }
 


### PR DESCRIPTION
Thons damage had the damage reason ENTITY_ATTACK instead of its decicated THORNS cause. This made it nearly impossible to detect thorns damage.