### PR TITLE
Manage UnConfirmed request issues

### DIFF
--- a/.github/workflows/unconfirmed.yml
+++ b/.github/workflows/unconfirmed.yml
@@ -1,0 +1,22 @@
+name: 'Manage UnConfirmed request issues'
+
+on:
+  issues:
+    types: [labeled, unlabeled, reopened]
+
+jobs:
+  support:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/support-requests@v2
+        with:
+          github-token: ${{ github.token }}
+          support-label:  "Unconfirmed | 未确认"
+          issue-comment: >
+            :wave: @{issue-author} We have taken your problem into account. However, we are unable to confirm this at this time. This could be due to several potential issues, including a lack of image or screenshot evidence of the issue. Therefore, your issue has been closed. However, we invite you to [recreate a new issue](https://github.com/PowerNukkitX/PowerNukkitX/issues/new/choose) if you are able to provide more substantial evidence.
+            Thank you for your understanding and continued cooperation.
+
+            [Docs](https://powernukkitx.com/doc/index.html) | [Discord](https://discord.gg/9ygGndMvaB)
+
+          close-issue: false
+          lock-issue: false


### PR DESCRIPTION
Before authorizing this pull request you must put the `github.token` in this repo in secret as I show you here me as a developer at PowerNukkitX I have no access to this, I mention the right line below https://github.com/PowerNukkitX/PowerNukkitX/blob/51cbef2f6311a29f052968f36bd801fb69080636/.github/workflows/unconfirmed.yml#L13

the 2nd parameter to update if you wish and the parameter
  ``close-issue`` which I also mention just below this parameter as the name suggests allows you to close the issue directly if the tag ``Unconfirmed | 未确认`` and assign to outcome

https://github.com/PowerNukkitX/PowerNukkitX/blob/51cbef2f6311a29f052968f36bd801fb69080636/.github/workflows/unconfirmed.yml#L21

Why do this ?
Personally, I find that there are too many issues with the tag ``Unconfirmed | 未确认`` to too many issues that no longer respond or are just inactive this allows us to do a lot of sorting in the issues of our PowerNukkitX Project

@AzaleeX Developer for PowerNukkitX ❤