### PR TITLE
Fixing the recipe conventions for block_states

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockWood.java
+++ b/src/main/java/cn/nukkit/block/BlockWood.java
@@ -20,15 +20,10 @@ import static cn.nukkit.blockproperty.CommonBlockProperties.PILLAR_AXIS;
  */
 @PowerNukkitDifference(info = "Extends BlockLog instead of BlockSolidMeta only in PowerNukkit", since = "1.4.0.0-PN")
 public class BlockWood extends BlockLog {
-    @PowerNukkitOnly
-    @Since("1.4.0.0-PN")
-    public static final BlockProperty<WoodType> OLD_LOG_TYPE = new ArrayBlockProperty<>("old_log_type", true, new WoodType[]{
-            WoodType.OAK, WoodType.SPRUCE, WoodType.BIRCH, WoodType.JUNGLE
-    });
 
     @PowerNukkitOnly
     @Since("1.4.0.0-PN")
-    public static final BlockProperties PROPERTIES = new BlockProperties(OLD_LOG_TYPE, PILLAR_AXIS);
+    public static final BlockProperties PROPERTIES = new BlockProperties(WoodType.PROPERTY, PILLAR_AXIS);
     
     public static final int OAK = 0;
     public static final int SPRUCE = 1;
@@ -70,13 +65,13 @@ public class BlockWood extends BlockLog {
     @PowerNukkitOnly
     @Since("1.4.0.0-PN")
     public WoodType getWoodType() {
-        return getPropertyValue(OLD_LOG_TYPE);
+        return getPropertyValue(WoodType.PROPERTY);
     }
     
     @PowerNukkitOnly
     @Since("1.4.0.0-PN")
     public void setWoodType(WoodType woodType) {
-        setPropertyValue(OLD_LOG_TYPE, woodType);
+        setPropertyValue(WoodType.PROPERTY, woodType);
     }
     
     @Override


### PR DESCRIPTION
(OLD_LOG_TYPE was deprecated)

Changes:
- Made BlockWood use the same WoodType Block state as the other blocks