### PR TITLE
WaterdogPE fix

### DIFF
--- a/src/main/java/cn/nukkit/network/protocol/StartGamePacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/StartGamePacket.java
@@ -183,7 +183,7 @@ public class StartGamePacket extends DataPacket {
         this.putBoolean(this.commandsEnabled);
         this.putBoolean(this.isTexturePacksRequired);
         this.putGameRules(this.gameRules);
-        if (Server.getInstance().isEnableExperimentMode()) {
+        if (Server.getInstance().isEnableExperimentMode() && !Server.getInstance().isWaterdogCapable()) {
             this.putLInt(4); // Experiment count
             {
                 this.putString("data_driven_items");
@@ -224,7 +224,12 @@ public class StartGamePacket extends DataPacket {
         this.putBoolean(false); // Nether type
         this.putString(""); // EduSharedUriResource buttonName
         this.putString(""); // EduSharedUriResource linkUri
-        this.putBoolean(Server.getInstance().isEnableExperimentMode()); // force Experimental Gameplay
+        if (Server.getInstance().isEnableExperimentMode()) { // force Experimental Gameplay
+            this.putBoolean(Server.getInstance().isEnableExperimentMode()); // force Experimental Gameplay
+            this.putBoolean(!Server.getInstance().getConfig("settings.waterdogpe", false)); // Why WaterDogPE require an extra optional boolean if this is set to true? I don't know.
+        } else {
+            this.putBoolean(false);
+        }
         this.putByte(this.chatRestrictionLevel);
         this.putBoolean(this.disablePlayerInteractions);
         /* Level settings end */

--- a/src/main/java/cn/nukkit/network/protocol/v575/StartGamePacket_v575.java
+++ b/src/main/java/cn/nukkit/network/protocol/v575/StartGamePacket_v575.java
@@ -164,7 +164,7 @@ public class StartGamePacket_v575 extends DataPacket {
         this.putBoolean(this.commandsEnabled);
         this.putBoolean(this.isTexturePacksRequired);
         this.putGameRules(this.gameRules);
-        if (Server.getInstance().isEnableExperimentMode()) {
+        if (Server.getInstance().isEnableExperimentMode() && !Server.getInstance().isWaterdogCapable()) {
             this.putLInt(3); // Experiment count
             {
                 this.putString("data_driven_items");
@@ -203,7 +203,12 @@ public class StartGamePacket_v575 extends DataPacket {
         this.putBoolean(false); // Nether type
         this.putString(""); // EduSharedUriResource buttonName
         this.putString(""); // EduSharedUriResource linkUri
-        this.putBoolean(Server.getInstance().isEnableExperimentMode()); // force Experimental Gameplay
+        if (Server.getInstance().isEnableExperimentMode()) { // force Experimental Gameplay
+            this.putBoolean(Server.getInstance().isEnableExperimentMode()); // force Experimental Gameplay
+            this.putBoolean(!Server.getInstance().getConfig("settings.waterdogpe", false)); // Why WaterDogPE require an extra optional boolean if this is set to true? I don't know.
+        } else {
+            this.putBoolean(false);
+        }
         this.putByte(this.chatRestrictionLevel);
         this.putBoolean(this.disablePlayerInteractions);
         /* Level settings end */

--- a/src/main/java/cn/nukkit/network/protocol/v582/StartGamePacket_v582.java
+++ b/src/main/java/cn/nukkit/network/protocol/v582/StartGamePacket_v582.java
@@ -180,7 +180,7 @@ public class StartGamePacket_v582 extends DataPacket {
         this.putBoolean(this.commandsEnabled);
         this.putBoolean(this.isTexturePacksRequired);
         this.putGameRules(this.gameRules);
-        if (Server.getInstance().isEnableExperimentMode()) {
+        if (Server.getInstance().isEnableExperimentMode() && !Server.getInstance().isWaterdogCapable()) {
             this.putLInt(3); // Experiment count
             {
                 this.putString("data_driven_items");
@@ -219,7 +219,12 @@ public class StartGamePacket_v582 extends DataPacket {
         this.putBoolean(false); // Nether type
         this.putString(""); // EduSharedUriResource buttonName
         this.putString(""); // EduSharedUriResource linkUri
-        this.putBoolean(Server.getInstance().isEnableExperimentMode()); // force Experimental Gameplay
+        if (Server.getInstance().isEnableExperimentMode()) { // force Experimental Gameplay
+            this.putBoolean(Server.getInstance().isEnableExperimentMode()); // force Experimental Gameplay
+            this.putBoolean(!Server.getInstance().getConfig("settings.waterdogpe", false)); // Why WaterDogPE require an extra optional boolean if this is set to true? I don't know.
+        } else {
+            this.putBoolean(false);
+        }
         this.putByte(this.chatRestrictionLevel);
         this.putBoolean(this.disablePlayerInteractions);
         /* Level settings end */


### PR DESCRIPTION
Undid StartGamePacket Changes made in ([#1357](https://github.com/PowerNukkitX/PowerNukkitX/pull/1357))
The protocol library used in WaterdogPE cannot deserialize the custom data. 
Custom Blocks and items are working anyways without sending thie data in the StartGamePacket.

![grafik](https://github.com/PowerNukkitX/PowerNukkitX/assets/44944269/27520bd8-78c1-4d31-a229-61434ab717b9)
