### PR TITLE
Update English Minecraft Wiki links to new domain

### DIFF
--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -1434,7 +1434,7 @@ public abstract class Block extends Position implements Metadatable, Cloneable, 
         return this.getLevel().setBlock(this, this, true, true);
     }
 
-    //http://minecraft.gamepedia.com/Breaking
+    //http://minecraft.wiki/w/Breaking
     public boolean canHarvestWithHand() {  //used for calculating breaking time
         return true;
     }
@@ -1625,7 +1625,7 @@ public abstract class Block extends Position implements Metadatable, Cloneable, 
         return isSideFull(side);
     }
 
-    // https://minecraft.gamepedia.com/Opacity#Lighting
+    // https://minecraft.wiki/w/Opacity#Lighting
     @PowerNukkitOnly
     public boolean diffusesSkyLight() {
         return false;
@@ -1979,7 +1979,7 @@ public abstract class Block extends Position implements Metadatable, Cloneable, 
                 (blockId == COBWEB && item.isShears());
     }
 
-    //http://minecraft.gamepedia.com/Breaking
+    //http://minecraft.wiki/w/Breaking
     private static double breakTime0(double blockHardness, boolean correctTool, boolean canHarvestWithHand,
                                      int blockId, int toolType, int toolTier, int efficiencyLoreLevel, int hasteEffectLevel,
                                      boolean insideOfWaterWithoutAquaAffinity, boolean outOfWaterButNotOnGround) {
@@ -2102,7 +2102,7 @@ public abstract class Block extends Position implements Metadatable, Cloneable, 
     }
 
     /**
-     * 计算方块挖掘需要多少tick (计算算法来自https://minecraft.fandom.com/wiki/Breaking)
+     * 计算方块挖掘需要多少tick (计算算法来自https://minecraft.wiki/w/Breaking)
      *
      * @param item   挖掘工具
      * @param player 挖掘方块的玩家

--- a/src/main/java/cn/nukkit/block/BlockCaveVines.java
+++ b/src/main/java/cn/nukkit/block/BlockCaveVines.java
@@ -104,7 +104,7 @@ public class BlockCaveVines extends BlockTransparentMeta {
                     }
                 }
             }
-            //random grow feature,according to wiki in https://minecraft.fandom.com/wiki/Glow_Berries#Growth
+            //random grow feature,according to wiki in https://minecraft.wiki/w/Glow_Berries#Growth
             if (down().getId() == AIR && random.nextInt(10) == 0) {
                 BlockCaveVines block;
                 if (this.up() instanceof BlockCaveVines && !(this.down() instanceof BlockCaveVines)) {

--- a/src/main/java/cn/nukkit/block/BlockCropsStem.java
+++ b/src/main/java/cn/nukkit/block/BlockCropsStem.java
@@ -45,7 +45,7 @@ public abstract class BlockCropsStem extends BlockCrops implements Faceable {
     @Since("1.4.0.0-PN")
     public static final BlockProperties PROPERTIES = new BlockProperties(GROWTH, FACING_DIRECTION);
 
-    //https://minecraft.gamepedia.com/Melon_Seeds#Breaking
+    //https://minecraft.wiki/w/Melon_Seeds#Breaking
     private static final double[][] dropChances = new double[][]{
             {.8130,.1742,.0124,.0003}, //0
             {.6510,.3004,.0462,.0024}, //1

--- a/src/main/java/cn/nukkit/block/BlockEndRod.java
+++ b/src/main/java/cn/nukkit/block/BlockEndRod.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.NotNull;
 import javax.annotation.Nullable;
 
 /**
- * http://minecraft.gamepedia.com/End_Rod
+ * http://minecraft.wiki/w/End_Rod
  *
  * @author PikyCZ
  */

--- a/src/main/java/cn/nukkit/block/BlockRail.java
+++ b/src/main/java/cn/nukkit/block/BlockRail.java
@@ -164,7 +164,7 @@ public class BlockRail extends BlockFlowable implements Faceable {
         return this;
     }
 
-    //Information from http://minecraft.gamepedia.com/Rail
+    //Information from http://minecraft.wiki/w/Rail
     @Override
     public boolean place(@NotNull Item item, @NotNull Block block, @NotNull Block target, @NotNull BlockFace face, double fx, double fy, double fz, Player player) {
         Block down = this.down();

--- a/src/main/java/cn/nukkit/block/BlockTallGrass.java
+++ b/src/main/java/cn/nukkit/block/BlockTallGrass.java
@@ -154,7 +154,7 @@ public class BlockTallGrass extends BlockFlowable implements BlockFlowerPot.Flow
 
     @Override
     public Item[] getDrops(Item item) {
-        // https://minecraft.gamepedia.com/Fortune#Grass_and_ferns
+        // https://minecraft.wiki/w/Fortune#Grass_and_ferns
         List<Item> drops = new ArrayList<>(2);
         if (item.isShears()) {
             drops.add(getCurrentState().asItemBlock());

--- a/src/main/java/cn/nukkit/block/BlockWheat.java
+++ b/src/main/java/cn/nukkit/block/BlockWheat.java
@@ -38,7 +38,7 @@ public class BlockWheat extends BlockCrops {
 
     @Override
     public Item[] getDrops(Item item) {
-        // https://minecraft.gamepedia.com/Fortune#Seeds
+        // https://minecraft.wiki/w/Fortune#Seeds
         if (!isFullyGrown()) {
             return new Item[]{ new ItemSeedsWheat() };
         }

--- a/src/main/java/cn/nukkit/entity/item/EntityMinecartAbstract.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityMinecartAbstract.java
@@ -562,7 +562,7 @@ public abstract class EntityMinecartAbstract extends EntityVehicle {
             }
         }
 
-        //http://minecraft.gamepedia.com/Powered_Rail#Rail
+        //http://minecraft.wiki/w/Powered_Rail#Rail
         if (isSlowed) {
             expectedSpeed = Math.sqrt(motionX * motionX + motionZ * motionZ);
             if (expectedSpeed < 0.03D) {

--- a/src/main/java/cn/nukkit/entity/passive/EntityCat.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityCat.java
@@ -87,7 +87,7 @@ public class EntityCat extends EntityAnimal implements EntityWalkable, EntityOwn
                                 ),
                                 1, 1
                         ),
-                        //"流浪猫会寻找并攻击15格内的鸡[仅Java版]、兔子和幼年海龟" --- 来自Wiki https://minecraft.fandom.com/wiki/Cat#Bedrock_Edition
+                        //"流浪猫会寻找并攻击15格内的鸡[仅Java版]、兔子和幼年海龟" --- 来自Wiki https://minecraft.wiki/w/Cat#Bedrock_Edition
                         new Behavior(
                                 entity -> {
                                     if (this.hasOwner(false)) return false;
@@ -148,7 +148,7 @@ public class EntityCat extends EntityAnimal implements EntityWalkable, EntityOwn
         );
     }
 
-    //猫咪身体大小来自Wiki https://minecraft.fandom.com/wiki/Cat
+    //猫咪身体大小来自Wiki https://minecraft.wiki/w/Cat
     @Override
     public float getWidth() {
         return this.isBaby() ? 0.24f : 0.48f;

--- a/src/main/java/cn/nukkit/item/enchantment/Enchantment.java
+++ b/src/main/java/cn/nukkit/item/enchantment/Enchantment.java
@@ -711,7 +711,7 @@ public abstract class Enchantment implements Cloneable {
     }
 
     /**
-     * The minimum enchantability for the given level as described in https://minecraft.gamepedia.com/Enchanting/Levels
+     * The minimum enchantability for the given level as described in https://minecraft.wiki/w/Enchanting/Levels
      *
      * @param level The level being checked
      * @return The minimum value
@@ -721,7 +721,7 @@ public abstract class Enchantment implements Cloneable {
     }
 
     /**
-     * The maximum enchantability for the given level as described in https://minecraft.gamepedia.com/Enchanting/Levels
+     * The maximum enchantability for the given level as described in https://minecraft.wiki/w/Enchanting/Levels
      *
      * @param level The level being checked
      * @return The maximum value

--- a/src/main/java/cn/nukkit/level/biome/impl/forest/FlowerForestBiome.java
+++ b/src/main/java/cn/nukkit/level/biome/impl/forest/FlowerForestBiome.java
@@ -15,7 +15,7 @@ public class FlowerForestBiome extends ForestBiome {
     public FlowerForestBiome(int type) {
         super(type);
 
-        //see https://minecraft.gamepedia.com/Flower#Flower_biomes
+        //see https://minecraft.wiki/w/Flower#Flower_biomes
         PopulatorFlower flower = new PopulatorFlower();
         flower.setBaseAmount(10);
         flower.addType(DANDELION, 0);

--- a/src/main/java/cn/nukkit/level/biome/impl/savanna/SavannaPlateauMBiome.java
+++ b/src/main/java/cn/nukkit/level/biome/impl/savanna/SavannaPlateauMBiome.java
@@ -4,7 +4,7 @@ package cn.nukkit.level.biome.impl.savanna;
  * @author DaPorkchop_
  */
 //porktodo: this is just like savanna plateau with individual spikes
-//see https://minecraft.gamepedia.com/Biome#Plateau_M
+//see https://minecraft.wiki/w/Biome#Plateau_M
 public class SavannaPlateauMBiome extends SavannaPlateauBiome {
 
     public SavannaPlateauMBiome() {

--- a/src/main/java/cn/nukkit/nbt/package-info.java
+++ b/src/main/java/cn/nukkit/nbt/package-info.java
@@ -1,6 +1,6 @@
 /**
- * 与<a href="https://minecraft.fandom.com/wiki/NBT_format">NBT格式</a>相关的类.
+ * 与<a href="https://minecraft.wiki/w/NBT_format">NBT格式</a>相关的类.
  * <p>
- * Classes relevant to <a href="https://minecraft.fandom.com/wiki/NBT_format">NBT format</a>.
+ * Classes relevant to <a href="https://minecraft.wiki/w/NBT_format">NBT format</a>.
  */
 package cn.nukkit.nbt;


### PR DESCRIPTION
The English Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all English wiki URLs accordingly.