### PR TITLE
Fix EntityIntelligent and EmptyBehaviorGroup from causing NPEs

### DIFF
--- a/src/main/java/cn/nukkit/entity/EntityIntelligent.java
+++ b/src/main/java/cn/nukkit/entity/EntityIntelligent.java
@@ -29,7 +29,6 @@ import java.util.Objects;
 @PowerNukkitXOnly
 @Since("1.6.0.0-PNX")
 public abstract class EntityIntelligent extends EntityPhysical implements LogicalUtils, EntityControlUtils {
-    public static final IBehaviorGroup EMPTY_BEHAVIOR_GROUP = new EmptyBehaviorGroup();
 
     @Since("1.19.60-r1")
     protected IBehaviorGroup behaviorGroup;
@@ -79,7 +78,7 @@ public abstract class EntityIntelligent extends EntityPhysical implements Logica
      */
     @Since("1.19.60-r1")
     protected IBehaviorGroup requireBehaviorGroup() {
-        return EMPTY_BEHAVIOR_GROUP;
+        return new EmptyBehaviorGroup(this);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/ai/behaviorgroup/EmptyBehaviorGroup.java
+++ b/src/main/java/cn/nukkit/entity/ai/behaviorgroup/EmptyBehaviorGroup.java
@@ -21,9 +21,11 @@ import java.util.Set;
 public class EmptyBehaviorGroup implements IBehaviorGroup {
 
     protected EntityIntelligent entity;
+    protected MemoryStorage memoryStorage;
 
     public EmptyBehaviorGroup(EntityIntelligent entity) {
         this.entity = entity;
+        this.memoryStorage = new MemoryStorage(entity);
     }
     
     
@@ -99,7 +101,7 @@ public class EmptyBehaviorGroup implements IBehaviorGroup {
 
     @Override
     public IMemoryStorage getMemoryStorage() {
-        return new MemoryStorage(entity);
+        return this.memoryStorage;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/ai/behaviorgroup/EmptyBehaviorGroup.java
+++ b/src/main/java/cn/nukkit/entity/ai/behaviorgroup/EmptyBehaviorGroup.java
@@ -6,6 +6,7 @@ import cn.nukkit.entity.EntityIntelligent;
 import cn.nukkit.entity.ai.behavior.IBehavior;
 import cn.nukkit.entity.ai.controller.IController;
 import cn.nukkit.entity.ai.memory.IMemoryStorage;
+import cn.nukkit.entity.ai.memory.MemoryStorage;
 import cn.nukkit.entity.ai.route.finder.IRouteFinder;
 import cn.nukkit.entity.ai.sensor.ISensor;
 
@@ -18,6 +19,14 @@ import java.util.Set;
 @PowerNukkitXOnly
 @Since("1.6.0.0-PNX")
 public class EmptyBehaviorGroup implements IBehaviorGroup {
+
+    protected EntityIntelligent entity;
+
+    public EmptyBehaviorGroup(EntityIntelligent entity) {
+        this.entity = entity;
+    }
+    
+    
     @Override
     public void evaluateBehaviors(EntityIntelligent entity) {
 
@@ -90,7 +99,7 @@ public class EmptyBehaviorGroup implements IBehaviorGroup {
 
     @Override
     public IMemoryStorage getMemoryStorage() {
-        return null;
+        return new MemoryStorage(entity);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/ai/behaviorgroup/EmptyBehaviorGroup.java
+++ b/src/main/java/cn/nukkit/entity/ai/behaviorgroup/EmptyBehaviorGroup.java
@@ -21,7 +21,7 @@ import java.util.Set;
 public class EmptyBehaviorGroup implements IBehaviorGroup {
 
     protected EntityIntelligent entity;
-    protected MemoryStorage memoryStorage;
+    protected IMemoryStorage memoryStorage;
 
     public EmptyBehaviorGroup(EntityIntelligent entity) {
         this.entity = entity;


### PR DESCRIPTION
Hello! Attacking a hostile mob causes an NPE to be thrown. Spawn something like a guardian and try attacking it. cn.nukkit.entity.EntityMob on line 126 tries to make a mob "hate" the player upon being attacked, however, all mobs implement the EmptyBehaviorGroup class which returns a null IMemoryStorage making the server not have a good time. I don't know how the AI is implemented in the background, though here's a PR that I made that seems to fix the issue, attacking a hostile mob no longer throws an NPE. An interesting note I saw is that it looked like by default mobs should have no AI, however they do, it's not directly related to this though something I realized was weird. If there are any problems with it, let me know!