### PR TITLE
Fix max sense not taken in action

### DIFF
--- a/src/main/java/cn/nukkit/entity/ai/executor/MeleeAttackExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/MeleeAttackExecutor.java
@@ -101,6 +101,7 @@ public class MeleeAttackExecutor implements EntityControl, IBehaviorExecutor {
 
         //some check
         if (!target.isAlive()) return false;
+        else if (entity.distanceSquared(target) > maxSenseRangeSquared) return false;
         else if (target instanceof Player player) {
             if (player.isCreative() || player.isSpectator() || !player.isOnline() || !entity.level.getName().equals(player.level.getName())) {
                 return false;


### PR DESCRIPTION
When an entity attacks another one and this entity is far away from the attacker, the attacker should stop attacking the entity.
This commit fixes the issue by checking if the entity is far away from the attacker.