### PR TITLE
Minor JavaDoc Organizing and Typo Fixes

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -673,7 +673,7 @@ public abstract class Entity extends Location implements Metadatable {
     }
 
     /**
-     * @see #registerEntity(String, Class<? extends Entity>, boolean)
+     * @see #registerEntity(String, Class, boolean)
      */
     @Nullable
     public static Entity createEntity(@NotNull String name, @NotNull FullChunk chunk, @NotNull CompoundTag nbt, @Nullable Object... args) {
@@ -725,7 +725,7 @@ public abstract class Entity extends Location implements Metadatable {
     }
 
     /**
-     * @see #registerEntity(EntityProvider<? extends Entity>, boolean)
+     * @see #registerEntity(EntityProvider, boolean)
      */
     @PowerNukkitXOnly
     @Since("1.19.21-r2")
@@ -974,7 +974,7 @@ public abstract class Entity extends Location implements Metadatable {
     }
 
     /**
-     * @see #playAnimationOnEntities(AnimateEntityPacket.Animation, Collection<Entity>, Collection<Player>)
+     * @see #playAnimationOnEntities(AnimateEntityPacket.Animation, Collection, Collection)
      */
     @PowerNukkitXOnly
     @Since("1.19.50-r3")

--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -19,7 +19,6 @@ import cn.nukkit.inventory.ItemTag;
 import cn.nukkit.item.customitem.CustomItem;
 import cn.nukkit.item.customitem.CustomItemDefinition;
 import cn.nukkit.item.enchantment.Enchantment;
-import cn.nukkit.item.randomitem.ItemEchoShard;
 import cn.nukkit.level.Level;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.math.Vector3;

--- a/src/main/java/cn/nukkit/item/ItemEchoShard.java
+++ b/src/main/java/cn/nukkit/item/ItemEchoShard.java
@@ -1,9 +1,8 @@
-package cn.nukkit.item.randomitem;
+package cn.nukkit.item;
 
 
 import cn.nukkit.api.PowerNukkitXOnly;
 import cn.nukkit.api.Since;
-import cn.nukkit.item.Item;
 
 @PowerNukkitXOnly
 @Since("1.19.50-r1")

--- a/src/main/java/cn/nukkit/nbt/snbt/SNBTLexer.java
+++ b/src/main/java/cn/nukkit/nbt/snbt/SNBTLexer.java
@@ -100,7 +100,7 @@ public class SNBTLexer implements SNBTConstants {
     }
 
     /**
-     * @param inputSource just the naem of the input source (typically the filename)
+     * @param inputSource just the name of the input source (typically the filename)
      *                    that will be used in error messages and so on.
      * @param input       the input
      */
@@ -112,10 +112,13 @@ public class SNBTLexer implements SNBTConstants {
      * @param inputSource just the name of the input source (typically the filename) that
      *                    will be used in error messages and so on.
      * @param input       the input
-     * @param line        The line number at which we are starting for the purposes of location/error messages. In most
-     *                    normal usage, this is 1.
-     * @param column      number at which we are starting for the purposes of location/error messages. In most normal
-     *                    usages this is 1.
+     * @param lexState    the lexical state to use
+     * @param startingLine
+     * The line number at which we are starting for the purposes of location/error messages.
+     * In most normal usage, this is 1.
+     * @param startingColumn
+     * The column number at which we are starting for the purposes of location/error messages.
+     * In most normal usages this is 1.
      */
     public SNBTLexer(String inputSource, CharSequence input, LexicalState lexState, int startingLine, int startingColumn) {
         this.inputSource = inputSource;
@@ -130,25 +133,28 @@ public class SNBTLexer implements SNBTConstants {
     }
 
     /**
-     * @Deprecated Preferably use the constructor that takes a #java.nio.files.Path or simply a String,
+     * Preferably use the constructor that takes a #java.nio.files.Path or simply a String,
      * depending on your use case
      */
+    @Deprecated
     public SNBTLexer(Reader reader) {
         this("input", reader, LexicalState.SNBT, 1, 1);
     }
 
     /**
-     * @Deprecated Preferably use the constructor that takes a #java.nio.files.Path or simply a String,
+     * Preferably use the constructor that takes a #java.nio.files.Path or simply a String,
      * depending on your use case
      */
+    @Deprecated
     public SNBTLexer(String inputSource, Reader reader) {
         this(inputSource, reader, LexicalState.SNBT, 1, 1);
     }
 
     /**
-     * @Deprecated Preferably use the constructor that takes a #java.nio.files.Path or simply a String,
+     * Preferably use the constructor that takes a #java.nio.files.Path or simply a String,
      * depending on your use case
      */
+    @Deprecated
     public SNBTLexer(String inputSource, Reader reader, LexicalState lexState, int line, int column) {
         this(inputSource, readToEnd(reader), lexState, line, column);
         switchTo(lexState);
@@ -686,7 +692,7 @@ public class SNBTLexer implements SNBTConstants {
      * @param bytes   the raw byte array
      * @param charset The encoding to use to decode the bytes. If this is null, we check for the
      *                initial byte order mark (used by Microsoft a lot seemingly)
-     *                See: https://docs.microsoft.com/es-es/globalization/encoding/byte-order-markc
+     *        See: <a href="https://docs.microsoft.com/es-es/globalization/encoding/byte-order-markc">Microsoft docs</a>
      * @return A String taking into account the encoding passed in or in the byte order mark (if it was present).
      * And if no encoding was passed in and no byte-order mark was present, we assume the raw input
      * is in UTF-8.

--- a/src/main/java/cn/nukkit/nbt/snbt/SNBTNfaData.java
+++ b/src/main/java/cn/nukkit/nbt/snbt/SNBTNfaData.java
@@ -28,7 +28,7 @@ class SNBTNfaData implements SNBTConstants {
     }
 
     /**
-     * @param the lexical state
+     * @param lexicalState the lexical state
      * @return the table of function pointers that implement the lexical state
      */
     static final NfaFunction[] getFunctionTableMap(LexicalState lexicalState) {

--- a/src/main/java/cn/nukkit/nbt/snbt/SNBTParserImplement.java
+++ b/src/main/java/cn/nukkit/nbt/snbt/SNBTParserImplement.java
@@ -79,17 +79,19 @@ public class SNBTParserImplement implements SNBTConstants {
     }
 
     /**
-     * @Deprecated Use the constructor that takes a #java.nio.files.Path or just
+     * Use the constructor that takes a #java.nio.files.Path or just
      * a String (i.e. CharSequence) directly.
      */
+    @Deprecated
     public SNBTParserImplement(InputStream stream) {
         this(new InputStreamReader(stream));
     }
 
     /**
-     * @Deprecated Use the constructor that takes a #java.nio.files.Path or just
+     * Use the constructor that takes a #java.nio.files.Path or just
      * a String (i.e. CharSequence) directly.
      */
+    @Deprecated
     public SNBTParserImplement(Reader reader) {
         this(new SNBTLexer("input", reader));
     }


### PR DESCRIPTION
Moves a misplaced class out of the wrong package, fixes a typo regarding usage of `Deprecated` annotation, and some minor JavaDoc organization.