### PR TITLE
Updated lightning strike chance

### DIFF
--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -1058,7 +1058,7 @@ public class Level implements Metadatable {
 
     private void performThunder(long index, IChunk chunk) {
         if (areNeighboringChunksLoaded(index)) return;
-        if (ThreadLocalRandom.current().nextInt(10000) == 0) {
+        if (ThreadLocalRandom.current().nextInt(100000) == 0) {
             int LCG = this.getUpdateLCG() >> 2;
 
             int chunkX = chunk.getX() * 16;


### PR DESCRIPTION
Lightning strike chance was 1/10,000 when it should be 1/100,000, explains the crazy amount of strikes in a world during a storm.