### PR TITLE
fix: set damage to item in NBTIO#getItemHelper()

### DIFF
--- a/src/main/java/cn/nukkit/nbt/NBTIO.java
+++ b/src/main/java/cn/nukkit/nbt/NBTIO.java
@@ -81,7 +81,8 @@ public class NBTIO {
             BlockState blockState = getBlockStateHelper(block);
             if (blockState != null) item.setBlockUnsafe(blockState.toBlock());
         }
-        if (item.getDamage() != 0) {
+
+        if (item.getDamage() == 0 && damage != 0) {
             item.setDamage(damage);
         }
         item.setCount(amount);

--- a/src/main/java/cn/nukkit/nbt/NBTIO.java
+++ b/src/main/java/cn/nukkit/nbt/NBTIO.java
@@ -82,7 +82,7 @@ public class NBTIO {
             if (blockState != null) item.setBlockUnsafe(blockState.toBlock());
         }
 
-        if (item.getDamage() == 0 && damage != 0) {
+        if (damage != 0) {
             item.setDamage(damage);
         }
         item.setCount(amount);


### PR DESCRIPTION
Fixed a bug when an item was dropped or a player left the server (inventory was saved) and its meta was not saved 