### PR TITLE
fix: changed default friction factor for custom blocks

### DIFF
--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -45,7 +45,7 @@ import java.util.function.Predicate;
 @Slf4j
 public abstract class Block extends Position implements Metadatable, AxisAlignedBB, BlockID {
     public static final Block[] EMPTY_ARRAY = new Block[0];
-    public static final double DEFAULT_FRICTION_FACTOR = 0.6;
+    public static final double DEFAULT_FRICTION_FACTOR = 0.4;
     public static final double DEFAULT_AIR_FLUID_FRICTION = 0.95;
     protected static final Long2ObjectOpenHashMap<BlockColor> VANILLA_BLOCK_COLOR_MAP = new Long2ObjectOpenHashMap<>();
     protected BlockState blockstate;


### PR DESCRIPTION
Changed default friction factor for custom blocks
![image](https://github.com/PowerNukkitX/PowerNukkitX/assets/83061703/100b70d8-74c1-43c0-b109-52e382bf461d)
https://bedrock.dev/docs/stable/Blocks#Block%20Components