### PR TITLE
Fix the issue with player kick and server shutdown where the player remains stuck on the server.

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -3352,6 +3352,14 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         if (!this.connected.compareAndSet(true, false) && this.closed) {
             return;
         }
+
+        if(!reason.isEmpty())
+        {
+            DisconnectPacket pk = new DisconnectPacket();
+            pk.message = reason;
+            this.getSession().sendPacketImmediately(pk);
+        }
+
         var scoreboardManager = this.getServer().getScoreboardManager();
         if (scoreboardManager != null) {
             scoreboardManager.beforePlayerQuit(this);
@@ -3374,7 +3382,6 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
             this.save();
         }
         super.close();
-        this.removeAllWindows(false);
         this.removeAllWindows(true);
         this.windows.clear();
         this.hiddenPlayers.clear();
@@ -3421,6 +3428,8 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
 
         assert this.session != null;
         //close player network session
+        log.debug("Closing player network session");
+        log.debug(reason);
         this.session.close(reason);
         this.session = null;
 


### PR DESCRIPTION
It seems like you've found an effective solution to resolve the issue of player kick and server shutdown on a Debian or Linux server. Sometimes, there can be unexpected behaviors or platform-specific bugs. The most important thing is to find a solution that works, even if you don't necessarily have a clear explanation for why it works that way. If this solution resolves the problem, that's what matters most.