### PR TITLE
Fixes server crashing on startup when copying file fails

### DIFF
--- a/src/main/java/cn/nukkit/utils/SparkInstaller.java
+++ b/src/main/java/cn/nukkit/utils/SparkInstaller.java
@@ -26,9 +26,14 @@ public class SparkInstaller {
                 assert in != null;
                 File targetPath = new File(server.getPluginPath(), "spark.jar");
                 if (!targetPath.exists()) {
-                    Files.copy(in, targetPath.toPath());
-                    server.getPluginManager().enablePlugin(server.getPluginManager().loadPlugin(targetPath));
-                    log.info("Spark has been installed.");
+                    //Do not remove this try catch block!!!
+                    try {
+                        Files.copy(in, targetPath.toPath());
+                        server.getPluginManager().enablePlugin(server.getPluginManager().loadPlugin(targetPath));
+                        log.info("Spark has been installed.");
+                    } catch (Exception e)  {
+                        log.warn("Failed to copy spark: {}", Arrays.toString(e.getStackTrace()));
+                    }
                 }
             } catch (IOException e) {
                 log.warn("Failed to download spark: {}", Arrays.toString(e.getStackTrace()));


### PR DESCRIPTION
Server doesn't crash anymore if copying the spark file fails, (which is always the case on some servers)
I added the comment so it wont get removed again.