### PR TITLE
Fix block air interact

### DIFF
--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -1271,7 +1271,9 @@ public abstract class Item implements Cloneable, ItemID {
     }
 
     public final boolean equals(Item item, boolean checkDamage, boolean checkCompound) {
-        if (!Objects.equals(this.getId(), item.getId())) return false;
+        if (!Objects.equals(this.getId(), item.getId())) {
+            return false;
+        }
         if (checkDamage && this.hasMeta() && item.hasMeta() && this.getDamage() != item.getDamage()) {
             return false;
         }

--- a/src/main/java/cn/nukkit/network/process/processor/InventoryTransactionProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/InventoryTransactionProcessor.java
@@ -332,10 +332,17 @@ public class InventoryTransactionProcessor extends DataPacketProcessor<Inventory
             }
             case InventoryTransactionPacket.USE_ITEM_ACTION_CLICK_AIR -> {
                 Item item;
+                Item useItemDataItem = useItemData.itemInHand;
                 Vector3 directionVector = player.getDirectionVector();
+                //Removing the only clientsided NBT Tag
+                if(useItemDataItem instanceof ItemBlock) {
+                    if(Objects.requireNonNull(useItemDataItem.getNamedTag()).containsInt("Damage")) {
+                        useItemDataItem.getNamedTag().remove("Damage");
+                    }
+                }
                 if (player.isCreative()) {
                     item = player.getInventory().getItemInHand();
-                } else if (!player.getInventory().getItemInHand().equals(useItemData.itemInHand)) {
+                } else if (!player.getInventory().getItemInHand().equals(useItemDataItem)) {
                     player.getInventory().sendHeldItem(player);
                     return;
                 } else {


### PR DESCRIPTION
Fixes that Block Air Interacts are not called because NamedTag is not the same.

Bug was caused by #1676 .