### PR TITLE
Fix Serverbound Diagnostics Packet not registered

### DIFF
--- a/src/main/java/cn/nukkit/registry/PacketRegistry.java
+++ b/src/main/java/cn/nukkit/registry/PacketRegistry.java
@@ -257,6 +257,7 @@ public class PacketRegistry implements IRegistry<Integer, DataPacket, Class<? ex
         this.register0(ProtocolInfo.SETTINGS_COMMAND_PACKET, SettingsCommandPacket.class);
         this.register0(ProtocolInfo.CLIENTBOUND_CLOSE_FORM_PACKET, ClientboundCloseFormPacket.class);
         this.register0(ProtocolInfo.SERVERBOUND_LOADING_SCREEN_PACKET, ServerboundLoadingScreenPacket.class);
+        this.register0(ProtocolInfo.SERVERBOUND_DIAGNOSTICS_PACKET, ServerboundDiagnosticsPacket.class);
         this.PACKET_POOL.trim();
     }
 }


### PR DESCRIPTION
If you join a new PNX Server you keep getting the error in console "Failed to decode packet for packetId 315".
Fixed it by registering the packet.