### PR TITLE
Enhancement: Ability to limit the obtainability of enchants

### DIFF
--- a/src/main/java/cn/nukkit/item/enchantment/Enchantment.java
+++ b/src/main/java/cn/nukkit/item/enchantment/Enchantment.java
@@ -478,7 +478,7 @@ public abstract class Enchantment implements Cloneable {
     protected final Identifier identifier;
 
     protected boolean fishable = true;
-    protected boolean isObtainableFromEnchantingTable = true;
+    protected boolean obtainableFromEnchantingTable = true;
 
     /**
      * Constructs this instance using the given data and with level 1.
@@ -679,7 +679,7 @@ public abstract class Enchantment implements Cloneable {
      * @return true if it can be obtained
      */
     public boolean isObtainableFromEnchantingTable() {
-        return isObtainableFromEnchantingTable;
+        return obtainableFromEnchantingTable;
     }
 
     /**
@@ -688,7 +688,7 @@ public abstract class Enchantment implements Cloneable {
      * @param obtainableFromEnchantingTable true if it is obtainable
      */
     public void setObtainableFromEnchantingTable(boolean obtainableFromEnchantingTable) {
-        this.isObtainableFromEnchantingTable = obtainableFromEnchantingTable;
+        this.obtainableFromEnchantingTable = obtainableFromEnchantingTable;
     }
 
     /**

--- a/src/main/java/cn/nukkit/item/enchantment/Enchantment.java
+++ b/src/main/java/cn/nukkit/item/enchantment/Enchantment.java
@@ -477,8 +477,8 @@ public abstract class Enchantment implements Cloneable {
     @Nullable
     protected final Identifier identifier;
 
-    protected boolean fishable;
-    protected boolean isObtainableFromEnchantingTable;
+    protected boolean fishable = true;
+    protected boolean isObtainableFromEnchantingTable = true;
 
     /**
      * Constructs this instance using the given data and with level 1.

--- a/src/main/java/cn/nukkit/item/enchantment/Enchantment.java
+++ b/src/main/java/cn/nukkit/item/enchantment/Enchantment.java
@@ -477,6 +477,9 @@ public abstract class Enchantment implements Cloneable {
     @Nullable
     protected final Identifier identifier;
 
+    protected boolean fishable;
+    protected boolean isObtainableFromEnchantingTable;
+
     /**
      * Constructs this instance using the given data and with level 1.
      *
@@ -649,6 +652,43 @@ public abstract class Enchantment implements Cloneable {
 
     public double getDamageBonus(Entity target, Entity damager) {
         return 0;
+    }
+
+    /**
+     * This value is for treasures of {@link cn.nukkit.item.randomitem.Fishing}, specifically {@link cn.nukkit.item.randomitem.EnchantmentItemSelector}
+     * If false, this enchantment cannot be fished using a {@link cn.nukkit.item.ItemFishingRod}
+     *
+     * @return whether this enchantment can be fished or not
+     */
+    public boolean isFishable() {
+        return fishable;
+    }
+
+    /**
+     * Decides whether this enchantment can be fished ({@link cn.nukkit.item.randomitem.EnchantmentItemSelector}) using a {@link cn.nukkit.item.ItemFishingRod}
+     *
+     * @param fishable true if it is fishable
+     */
+    public void setFishable(boolean fishable) {
+        this.fishable = fishable;
+    }
+
+    /**
+     * This value is used for deciding which enchantments can be obtained within the {@link cn.nukkit.block.BlockEnchantingTable}, used within {@link EnchantmentHelper}
+     *
+     * @return true if it can be obtained
+     */
+    public boolean isObtainableFromEnchantingTable() {
+        return isObtainableFromEnchantingTable;
+    }
+
+    /**
+     * Decides whether this enchantment can be obtained from a {@link cn.nukkit.block.BlockEnchantingTable}
+     *
+     * @param obtainableFromEnchantingTable true if it is obtainable
+     */
+    public void setObtainableFromEnchantingTable(boolean obtainableFromEnchantingTable) {
+        this.isObtainableFromEnchantingTable = obtainableFromEnchantingTable;
     }
 
     /**

--- a/src/main/java/cn/nukkit/item/enchantment/Enchantment.java
+++ b/src/main/java/cn/nukkit/item/enchantment/Enchantment.java
@@ -655,7 +655,7 @@ public abstract class Enchantment implements Cloneable {
     }
 
     /**
-     * This value is for treasures of {@link cn.nukkit.item.randomitem.Fishing}, specifically {@link cn.nukkit.item.randomitem.EnchantmentItemSelector}
+     * This value is for treasures of {@link cn.nukkit.item.randomitem.Fishing}, specifically {@link cn.nukkit.item.randomitem.fishing.FishingEnchantmentItemSelector}
      * If false, this enchantment cannot be fished using a {@link cn.nukkit.item.ItemFishingRod}
      *
      * @return whether this enchantment can be fished or not
@@ -665,7 +665,7 @@ public abstract class Enchantment implements Cloneable {
     }
 
     /**
-     * Decides whether this enchantment can be fished ({@link cn.nukkit.item.randomitem.EnchantmentItemSelector}) using a {@link cn.nukkit.item.ItemFishingRod}
+     * Decides whether this enchantment can be fished ({@link cn.nukkit.item.randomitem.fishing.FishingEnchantmentItemSelector}) using a {@link cn.nukkit.item.ItemFishingRod}
      *
      * @param fishable true if it is fishable
      */

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentBindingCurse.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentBindingCurse.java
@@ -3,6 +3,8 @@ package cn.nukkit.item.enchantment;
 public class EnchantmentBindingCurse extends Enchantment {
     protected EnchantmentBindingCurse() {
         super(ID_BINDING_CURSE, "curse.binding", Rarity.VERY_RARE, EnchantmentType.WEARABLE);
+
+        this.setObtainableFromEnchantingTable(false);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentFrostWalker.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentFrostWalker.java
@@ -3,6 +3,8 @@ package cn.nukkit.item.enchantment;
 public class EnchantmentFrostWalker extends Enchantment {
     protected EnchantmentFrostWalker() {
         super(ID_FROST_WALKER, "frostwalker", Rarity.VERY_RARE, EnchantmentType.ARMOR_FEET);
+
+        this.setObtainableFromEnchantingTable(false);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentHelper.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentHelper.java
@@ -121,10 +121,8 @@ public final class EnchantmentHelper {
 
             for (int lvl = enchantment.getMaxLevel(); lvl > 0; lvl--) {
                 if (enchantingPower >= enchantment.getMinEnchantAbility(lvl) && enchantingPower <= enchantment.getMaxEnchantAbility(lvl)) {
-                    if(!(enchantment.getId() == Enchantment.ID_MENDING)) {
-                        list.add(enchantment.setLevel(lvl));
-                        break;
-                    }
+                    list.add(enchantment.setLevel(lvl));
+                    break;
                 }
             }
         }

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentHelper.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentHelper.java
@@ -115,6 +115,10 @@ public final class EnchantmentHelper {
     private static List<Enchantment> getAvailableEnchantments(int enchantingPower, Item item) {
         List<Enchantment> list = new ArrayList<>();
         for (Enchantment enchantment : getPrimaryEnchantmentsForItem(item)) {
+            if (!enchantment.isObtainableFromEnchantingTable()) {
+                continue;
+            }
+
             for (int lvl = enchantment.getMaxLevel(); lvl > 0; lvl--) {
                 if (enchantingPower >= enchantment.getMinEnchantAbility(lvl) && enchantingPower <= enchantment.getMaxEnchantAbility(lvl)) {
                     if(!(enchantment.getId() == Enchantment.ID_MENDING)) {

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentMending.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentMending.java
@@ -6,6 +6,8 @@ package cn.nukkit.item.enchantment;
 public class EnchantmentMending extends Enchantment {
     protected EnchantmentMending() {
         super(ID_MENDING, "mending", Rarity.RARE, EnchantmentType.BREAKABLE);
+
+        this.setObtainableFromEnchantingTable(false);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentSoulSpeed.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentSoulSpeed.java
@@ -6,6 +6,8 @@ public class EnchantmentSoulSpeed extends Enchantment {
 
     protected EnchantmentSoulSpeed() {
         super(ID_SOUL_SPEED, "soul_speed", Rarity.VERY_RARE, EnchantmentType.ARMOR_FEET);
+
+        this.setObtainableFromEnchantingTable(false);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentSwiftSneak.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentSwiftSneak.java
@@ -3,6 +3,8 @@ package cn.nukkit.item.enchantment;
 public class EnchantmentSwiftSneak extends Enchantment{
     protected EnchantmentSwiftSneak(){
         super(ID_SWIFT_SNEAK,NAME_SWIFT_SNEAK,Rarity.VERY_RARE,EnchantmentType.ARMOR_LEGS);
+
+        this.setObtainableFromEnchantingTable(false);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentVanishingCurse.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentVanishingCurse.java
@@ -7,6 +7,8 @@ import cn.nukkit.item.ItemID;
 public class EnchantmentVanishingCurse extends Enchantment {
     protected EnchantmentVanishingCurse() {
         super(ID_VANISHING_CURSE, "curse.vanishing", Rarity.VERY_RARE, EnchantmentType.BREAKABLE);
+
+        this.setObtainableFromEnchantingTable(false);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/item/randomitem/EnchantmentItemSelector.java
+++ b/src/main/java/cn/nukkit/item/randomitem/EnchantmentItemSelector.java
@@ -51,7 +51,7 @@ public class EnchantmentItemSelector extends ConstantItemSelector {
     public List<Enchantment> getSupportEnchantments(Item item) {
         ArrayList<Enchantment> enchantments = new ArrayList<>();
         for (Enchantment enchantment : Enchantment.getRegisteredEnchantments()) {
-            if (enchantment.isFishable() && (Objects.equals(item.getId(), Item.ENCHANTED_BOOK) || enchantment.canEnchant(item))) {
+            if (Objects.equals(item.getId(), Item.ENCHANTED_BOOK) || enchantment.canEnchant(item)) {
                 enchantments.add(enchantment);
             }
         }

--- a/src/main/java/cn/nukkit/item/randomitem/EnchantmentItemSelector.java
+++ b/src/main/java/cn/nukkit/item/randomitem/EnchantmentItemSelector.java
@@ -51,7 +51,7 @@ public class EnchantmentItemSelector extends ConstantItemSelector {
     public List<Enchantment> getSupportEnchantments(Item item) {
         ArrayList<Enchantment> enchantments = new ArrayList<>();
         for (Enchantment enchantment : Enchantment.getRegisteredEnchantments()) {
-            if (Objects.equals(item.getId(), Item.ENCHANTED_BOOK) || enchantment.canEnchant(item)) {
+            if (enchantment.isFishable() && (Objects.equals(item.getId(), Item.ENCHANTED_BOOK) || enchantment.canEnchant(item))) {
                 enchantments.add(enchantment);
             }
         }

--- a/src/main/java/cn/nukkit/item/randomitem/Fishing.java
+++ b/src/main/java/cn/nukkit/item/randomitem/Fishing.java
@@ -4,6 +4,7 @@ import cn.nukkit.block.BlockID;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemID;
 import cn.nukkit.item.enchantment.Enchantment;
+import cn.nukkit.item.randomitem.fishing.FishingEnchantmentItemSelector;
 import cn.nukkit.math.NukkitMath;
 
 import static cn.nukkit.item.randomitem.RandomItem.*;
@@ -22,7 +23,7 @@ public final class Fishing {
     public static final Selector TROPICAL_FISH = putSelector(new ConstantItemSelector(ItemID.TROPICAL_FISH, FISHES), 0.02F);
     public static final Selector PUFFERFISH = putSelector(new ConstantItemSelector(ItemID.PUFFERFISH, FISHES), 0.13F);
     public static final Selector TREASURE_BOW = putSelector(new ConstantItemSelector(ItemID.BOW, TREASURES), 0.1667F);
-    public static final Selector TREASURE_ENCHANTED_BOOK = putSelector(new EnchantmentItemSelector(ItemID.ENCHANTED_BOOK, TREASURES),  0.1667F);
+    public static final Selector TREASURE_ENCHANTED_BOOK = putSelector(new FishingEnchantmentItemSelector(ItemID.ENCHANTED_BOOK, TREASURES),  0.1667F);
     public static final Selector JUNK_BOWL = putSelector(new ConstantItemSelector(ItemID.BOWL, JUNKS), 0.12F);
     public static final Selector JUNK_FISHING_ROD = putSelector(new ConstantItemSelector(ItemID.FISHING_ROD, JUNKS), 0.024F);
     public static final Selector JUNK_LEATHER = putSelector(new ConstantItemSelector(ItemID.LEATHER, JUNKS), 0.12F);

--- a/src/main/java/cn/nukkit/item/randomitem/fishing/FishingEnchantmentItemSelector.java
+++ b/src/main/java/cn/nukkit/item/randomitem/fishing/FishingEnchantmentItemSelector.java
@@ -1,0 +1,36 @@
+package cn.nukkit.item.randomitem.fishing;
+
+import cn.nukkit.item.Item;
+import cn.nukkit.item.enchantment.Enchantment;
+import cn.nukkit.item.randomitem.EnchantmentItemSelector;
+import cn.nukkit.item.randomitem.Selector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class FishingEnchantmentItemSelector extends EnchantmentItemSelector {
+
+    public FishingEnchantmentItemSelector(String id, Selector parent) {
+        this(id, 0, parent);
+    }
+
+    public FishingEnchantmentItemSelector(String id, Integer meta, Selector parent) {
+        super(id, meta, 1,  parent);
+    }
+
+    public FishingEnchantmentItemSelector(String id, Integer meta, int count, Selector parent) {
+        super(Item.get(id, meta, count), parent);
+    }
+
+    @Override
+    public List<Enchantment> getSupportEnchantments(Item item) {
+        ArrayList<Enchantment> enchantments = new ArrayList<>();
+        for (Enchantment enchantment : Enchantment.getRegisteredEnchantments()) {
+            if (enchantment.isFishable() && (Objects.equals(item.getId(), Item.ENCHANTED_BOOK) || enchantment.canEnchant(item))) {
+                enchantments.add(enchantment);
+            }
+        }
+        return enchantments;
+    }
+}


### PR DESCRIPTION
This pull request adds new API methods to allow plugins to regulate which enchantments should be fishable or obtainable from the enchanting table.

Also fixes some treasure enchantments being available while they should not according to [this article](https://minecraft.fandom.com/wiki/Enchanting_mechanics).