### PR TITLE
Enhancement: Add enableCommandBlocks setting

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockCommandBlock.java
+++ b/src/main/java/cn/nukkit/block/BlockCommandBlock.java
@@ -1,6 +1,7 @@
 package cn.nukkit.block;
 
 import cn.nukkit.Player;
+import cn.nukkit.Server;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.blockentity.BlockEntityCommandBlock;
 import cn.nukkit.item.Item;
@@ -95,7 +96,7 @@ public class BlockCommandBlock extends BlockSolid implements Faceable, BlockEnti
     public boolean onActivate(@NotNull Item item, Player player, BlockFace blockFace, float fx, float fy, float fz) {
         if (player != null) {
             Item itemInHand = player.getInventory().getItemInHand();
-            if (player.isSneaking() && !(itemInHand.isTool() || itemInHand.isNull())) {
+            if (player.isSneaking() && !(itemInHand.isTool() || itemInHand.isNull()) || !Server.getInstance().getSettings().baseSettings().enableCommandBlocks()) {
                 return false;
             }
             BlockEntityCommandBlock tile = this.getOrCreateBlockEntity();

--- a/src/main/java/cn/nukkit/block/BlockCommandBlock.java
+++ b/src/main/java/cn/nukkit/block/BlockCommandBlock.java
@@ -96,7 +96,7 @@ public class BlockCommandBlock extends BlockSolid implements Faceable, BlockEnti
     public boolean onActivate(@NotNull Item item, Player player, BlockFace blockFace, float fx, float fy, float fz) {
         if (player != null) {
             Item itemInHand = player.getInventory().getItemInHand();
-            if (player.isSneaking() && !(itemInHand.isTool() || itemInHand.isNull()) || !Server.getInstance().getSettings().baseSettings().enableCommandBlocks()) {
+            if (player.isSneaking() && !(itemInHand.isTool() || itemInHand.isNull()) || !Server.getInstance().getSettings().gameplaySettings().enableCommandBlocks()) {
                 return false;
             }
             BlockEntityCommandBlock tile = this.getOrCreateBlockEntity();

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityCommandBlock.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityCommandBlock.java
@@ -280,7 +280,7 @@ public class BlockEntityCommandBlock extends BlockEntitySpawnable implements ICo
 
     @Override
     public boolean execute(int chain) {
-        if (!this.getServer().getSettings().baseSettings().enableCommandBlocks() || !this.level.gameRules.getBoolean(GameRule.COMMAND_BLOCKS_ENABLED)) {
+        if (!(this.getServer().getSettings().baseSettings().enableCommandBlocks() && this.level.gameRules.getBoolean(GameRule.COMMAND_BLOCKS_ENABLED))) {
             return false;
         }
         if (this.getLevelBlock().getSide(((Faceable) this.getLevelBlock()).getBlockFace().getOpposite()) instanceof BlockCommandBlock lastCB) {

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityCommandBlock.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityCommandBlock.java
@@ -280,7 +280,7 @@ public class BlockEntityCommandBlock extends BlockEntitySpawnable implements ICo
 
     @Override
     public boolean execute(int chain) {
-        if (!this.level.gameRules.getBoolean(GameRule.COMMAND_BLOCKS_ENABLED)) {
+        if (!this.getServer().getSettings().baseSettings().enableCommandBlocks() || !this.level.gameRules.getBoolean(GameRule.COMMAND_BLOCKS_ENABLED)) {
             return false;
         }
         if (this.getLevelBlock().getSide(((Faceable) this.getLevelBlock()).getBlockFace().getOpposite()) instanceof BlockCommandBlock lastCB) {

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityCommandBlock.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityCommandBlock.java
@@ -280,7 +280,7 @@ public class BlockEntityCommandBlock extends BlockEntitySpawnable implements ICo
 
     @Override
     public boolean execute(int chain) {
-        if (!(this.getServer().getSettings().baseSettings().enableCommandBlocks() && this.level.gameRules.getBoolean(GameRule.COMMAND_BLOCKS_ENABLED))) {
+        if (!(this.getServer().getSettings().gameplaySettings().enableCommandBlocks() && this.level.gameRules.getBoolean(GameRule.COMMAND_BLOCKS_ENABLED))) {
             return false;
         }
         if (this.getLevelBlock().getSide(((Faceable) this.getLevelBlock()).getBlockFace().getOpposite()) instanceof BlockCommandBlock lastCB) {

--- a/src/main/java/cn/nukkit/config/ServerSettings.java
+++ b/src/main/java/cn/nukkit/config/ServerSettings.java
@@ -35,6 +35,9 @@ public final class ServerSettings extends OkaeriConfig {
     @Comment("nukkit.server.settings.playersettings")
     @CustomKey("player-settings")
     private PlayerSettings playerSettings = new PlayerSettings();
+    @Comment("nukkit.server.settings.gameplaysettings")
+    @CustomKey("gameplay-settings")
+    private GameplaySettings gameplaySettings = new GameplaySettings();
 
     @EqualsAndHashCode(callSuper = true)
     @Data
@@ -62,8 +65,6 @@ public final class ServerSettings extends OkaeriConfig {
         int autosave = 6000;
         @Comment("nukkit.server.settings.baseSettings.saveUnknownBlock")
         boolean saveUnknownBlock = true;
-        @Comment("nukkit.server.settings.baseSettings.enableCommandBlocks")
-        boolean enableCommandBlocks = true;
     }
 
     @EqualsAndHashCode(callSuper = true)
@@ -170,5 +171,13 @@ public final class ServerSettings extends OkaeriConfig {
         boolean checkMovement = true;
         @Comment("nukkit.server.settings.playersettings.spawnRadius")
         int spawnRadius = 16;
+    }
+
+    @EqualsAndHashCode(callSuper = true)
+    @Data
+    @Accessors(fluent = true)
+    public static class GameplaySettings extends OkaeriConfig {
+        @Comment("nukkit.server.settings.gameplaysettings.enableCommandBlocks")
+        boolean enableCommandBlocks = true;
     }
 }

--- a/src/main/java/cn/nukkit/config/ServerSettings.java
+++ b/src/main/java/cn/nukkit/config/ServerSettings.java
@@ -62,6 +62,8 @@ public final class ServerSettings extends OkaeriConfig {
         int autosave = 6000;
         @Comment("nukkit.server.settings.baseSettings.saveUnknownBlock")
         boolean saveUnknownBlock = true;
+        @Comment("nukkit.server.settings.baseSettings.enableCommandBlocks")
+        boolean enableCommandBlocks = true;
     }
 
     @EqualsAndHashCode(callSuper = true)

--- a/src/main/resources/language/bra/lang.json
+++ b/src/main/resources/language/bra/lang.json
@@ -43,6 +43,8 @@
   "nukkit.server.settings.playersettings.skinChangeCooldown": "Cooldown time for players changing skins",
   "nukkit.server.settings.playersettings.forceSkinTrusted": "Whether to force trust player skins, allowing players to use third-party skins freely",
   "nukkit.server.settings.playersettings.checkMovement": "Whether to check player movement",
+  "nukkit.server.settings.gameplaysettings": "Server's gameplay configuration",
+  "nukkit.server.settings.gameplaysettings.enableCommandBlocks": "Whether to allow players to use command blocks\nNote: If enabled, per-world gamerules still apply.",
   "chat.type.achievement": "{%0} adquiriu a conquista {%1}",
   "chat.type.admin": "[{%0}: {%1}]",
   "chat.type.announcement": "[{%0}] {%1}",

--- a/src/main/resources/language/chs/lang.json
+++ b/src/main/resources/language/chs/lang.json
@@ -43,6 +43,8 @@
   "nukkit.server.settings.playersettings.skinChangeCooldown": "玩家改变皮肤的冷却时间",
   "nukkit.server.settings.playersettings.forceSkinTrusted": "是否强制信任玩家皮肤，允许玩家随意使用第三方皮肤",
   "nukkit.server.settings.playersettings.checkMovement": "是否检查玩家移动",
+  "nukkit.server.settings.gameplaysettings": "Server's gameplay configuration",
+  "nukkit.server.settings.gameplaysettings.enableCommandBlocks": "Whether to allow players to use command blocks\nNote: If enabled, per-world gamerules still apply.",
   "chat.type.achievement": "{%0} 刚刚获得了 {%1} 成就！",
   "chat.type.admin": "[{%0}: {%1}]",
   "chat.type.announcement": "[{%0}] {%1}",

--- a/src/main/resources/language/cht/lang.json
+++ b/src/main/resources/language/cht/lang.json
@@ -43,6 +43,8 @@
   "nukkit.server.settings.playersettings.skinChangeCooldown": "Cooldown time for players changing skins",
   "nukkit.server.settings.playersettings.forceSkinTrusted": "Whether to force trust player skins, allowing players to use third-party skins freely",
   "nukkit.server.settings.playersettings.checkMovement": "Whether to check player movement",
+  "nukkit.server.settings.gameplaysettings": "Server's gameplay configuration",
+  "nukkit.server.settings.gameplaysettings.enableCommandBlocks": "Whether to allow players to use command blocks\nNote: If enabled, per-world gamerules still apply.",
   "chat.type.achievement": "{%0} 剛剛獲得了成就 {%1}",
   "chat.type.admin": "[{%0}: {%1}]",
   "chat.type.announcement": "[{%0}] {%1}",

--- a/src/main/resources/language/cze/lang.json
+++ b/src/main/resources/language/cze/lang.json
@@ -43,6 +43,8 @@
   "nukkit.server.settings.playersettings.skinChangeCooldown": "Cooldown time for players changing skins",
   "nukkit.server.settings.playersettings.forceSkinTrusted": "Whether to force trust player skins, allowing players to use third-party skins freely",
   "nukkit.server.settings.playersettings.checkMovement": "Whether to check player movement",
+  "nukkit.server.settings.gameplaysettings": "Server's gameplay configuration",
+  "nukkit.server.settings.gameplaysettings.enableCommandBlocks": "Whether to allow players to use command blocks\nNote: If enabled, per-world gamerules still apply.",
   "chat.type.achievement": "{%0} právě získal ocenění {%1}",
   "chat.type.admin": "[{%0}: {%1}]",
   "chat.type.announcement": "[{%0}] {%1}",

--- a/src/main/resources/language/deu/lang.json
+++ b/src/main/resources/language/deu/lang.json
@@ -43,6 +43,8 @@
   "nukkit.server.settings.playersettings.skinChangeCooldown": "Cooldown time for players changing skins",
   "nukkit.server.settings.playersettings.forceSkinTrusted": "Whether to force trust player skins, allowing players to use third-party skins freely",
   "nukkit.server.settings.playersettings.checkMovement": "Whether to check player movement",
+  "nukkit.server.settings.gameplaysettings": "Server's gameplay configuration",
+  "nukkit.server.settings.gameplaysettings.enableCommandBlocks": "Whether to allow players to use command blocks\nNote: If enabled, per-world gamerules still apply.",
   "chat.type.achievement": "{%0} hat die Errungenschaft {%1} erzielt",
   "chat.type.admin": "[{%0}: {%1}]",
   "chat.type.announcement": "[{%0}] {%1}",

--- a/src/main/resources/language/eng/lang.json
+++ b/src/main/resources/language/eng/lang.json
@@ -43,6 +43,8 @@
   "nukkit.server.settings.playersettings.skinChangeCooldown": "Cooldown time for players changing skins",
   "nukkit.server.settings.playersettings.forceSkinTrusted": "Whether to force trust player skins, allowing players to use third-party skins freely",
   "nukkit.server.settings.playersettings.checkMovement": "Whether to check player movement",
+  "nukkit.server.settings.gameplaysettings": "Server's gameplay configuration",
+  "nukkit.server.settings.gameplaysettings.enableCommandBlocks": "Whether to allow players to use command blocks\nNote: If enabled, per-world gamerules still apply.",
   "chat.type.achievement": "{%0} has just earned the achievement {%1}",
   "chat.type.admin": "[{%0}: {%1}]",
   "chat.type.announcement": "[{%0}] {%1}",

--- a/src/main/resources/language/fin/lang.json
+++ b/src/main/resources/language/fin/lang.json
@@ -43,6 +43,8 @@
   "nukkit.server.settings.playersettings.skinChangeCooldown": "Cooldown time for players changing skins",
   "nukkit.server.settings.playersettings.forceSkinTrusted": "Whether to force trust player skins, allowing players to use third-party skins freely",
   "nukkit.server.settings.playersettings.checkMovement": "Whether to check player movement",
+  "nukkit.server.settings.gameplaysettings": "Server's gameplay configuration",
+  "nukkit.server.settings.gameplaysettings.enableCommandBlocks": "Whether to allow players to use command blocks\nNote: If enabled, per-world gamerules still apply.",
   "chat.type.achievement": "{%0} ansaitsi saavutuksen {%1}",
   "chat.type.admin": "[{%0}: {%1}]",
   "chat.type.announcement": "[{%0}] {%1}",

--- a/src/main/resources/language/fra/lang.json
+++ b/src/main/resources/language/fra/lang.json
@@ -43,6 +43,8 @@
   "nukkit.server.settings.playersettings.skinChangeCooldown": "Cooldown time for players changing skins",
   "nukkit.server.settings.playersettings.forceSkinTrusted": "Whether to force trust player skins, allowing players to use third-party skins freely",
   "nukkit.server.settings.playersettings.checkMovement": "Whether to check player movement",
+  "nukkit.server.settings.gameplaysettings": "Server's gameplay configuration",
+  "nukkit.server.settings.gameplaysettings.enableCommandBlocks": "Whether to allow players to use command blocks\nNote: If enabled, per-world gamerules still apply.",
   "chat.type.achievement": "{%0} vient d\u0027obtenir le succès {%1}",
   "chat.type.admin": "[{%0}: {%1}]",
   "chat.type.announcement": "[{%0}] {%1}",

--- a/src/main/resources/language/idn/lang.json
+++ b/src/main/resources/language/idn/lang.json
@@ -43,6 +43,8 @@
   "nukkit.server.settings.playersettings.skinChangeCooldown": "Cooldown time for players changing skins",
   "nukkit.server.settings.playersettings.forceSkinTrusted": "Whether to force trust player skins, allowing players to use third-party skins freely",
   "nukkit.server.settings.playersettings.checkMovement": "Whether to check player movement",
+  "nukkit.server.settings.gameplaysettings": "Server's gameplay configuration",
+  "nukkit.server.settings.gameplaysettings.enableCommandBlocks": "Whether to allow players to use command blocks\nNote: If enabled, per-world gamerules still apply.",
   "chat.type.achievement": "{%0} baru saja memperoleh prestasi {%1}",
   "chat.type.admin": "[{%0}: {%1}]",
   "chat.type.announcement": "[{%0}] {%1}",

--- a/src/main/resources/language/jpn/lang.json
+++ b/src/main/resources/language/jpn/lang.json
@@ -43,6 +43,8 @@
   "nukkit.server.settings.playersettings.skinChangeCooldown": "Cooldown time for players changing skins",
   "nukkit.server.settings.playersettings.forceSkinTrusted": "Whether to force trust player skins, allowing players to use third-party skins freely",
   "nukkit.server.settings.playersettings.checkMovement": "Whether to check player movement",
+  "nukkit.server.settings.gameplaysettings": "Server's gameplay configuration",
+  "nukkit.server.settings.gameplaysettings.enableCommandBlocks": "Whether to allow players to use command blocks\nNote: If enabled, per-world gamerules still apply.",
   "chat.type.achievement": "{%0}は{%1}の実績を手に入れた",
   "chat.type.admin": "[{%0}: {%1}]",
   "chat.type.announcement": "[{%0}] {%1}",

--- a/src/main/resources/language/kor/lang.json
+++ b/src/main/resources/language/kor/lang.json
@@ -43,6 +43,8 @@
   "nukkit.server.settings.playersettings.skinChangeCooldown": "Cooldown time for players changing skins",
   "nukkit.server.settings.playersettings.forceSkinTrusted": "Whether to force trust player skins, allowing players to use third-party skins freely",
   "nukkit.server.settings.playersettings.checkMovement": "Whether to check player movement",
+  "nukkit.server.settings.gameplaysettings": "Server's gameplay configuration",
+  "nukkit.server.settings.gameplaysettings.enableCommandBlocks": "Whether to allow players to use command blocks\nNote: If enabled, per-world gamerules still apply.",
   "chat.type.achievement": "{%0} 님이 {%1} 도전 과제를 획득했습니다",
   "chat.type.admin": "[{%0}: {%1}]",
   "chat.type.announcement": "[{%0}] {%1}",

--- a/src/main/resources/language/ltu/lang.json
+++ b/src/main/resources/language/ltu/lang.json
@@ -43,6 +43,8 @@
   "nukkit.server.settings.playersettings.skinChangeCooldown": "Cooldown time for players changing skins",
   "nukkit.server.settings.playersettings.forceSkinTrusted": "Whether to force trust player skins, allowing players to use third-party skins freely",
   "nukkit.server.settings.playersettings.checkMovement": "Whether to check player movement",
+  "nukkit.server.settings.gameplaysettings": "Server's gameplay configuration",
+  "nukkit.server.settings.gameplaysettings.enableCommandBlocks": "Whether to allow players to use command blocks\nNote: If enabled, per-world gamerules still apply.",
   "chat.type.achievement": "{%0} gavo pasiekimą {%1}",
   "chat.type.admin": "[{%0}: {%1}]",
   "chat.type.announcement": "[{%0}] {%1}",

--- a/src/main/resources/language/pol/lang.json
+++ b/src/main/resources/language/pol/lang.json
@@ -43,6 +43,8 @@
   "nukkit.server.settings.playersettings.skinChangeCooldown": "Cooldown time for players changing skins",
   "nukkit.server.settings.playersettings.forceSkinTrusted": "Whether to force trust player skins, allowing players to use third-party skins freely",
   "nukkit.server.settings.playersettings.checkMovement": "Whether to check player movement",
+  "nukkit.server.settings.gameplaysettings": "Server's gameplay configuration",
+  "nukkit.server.settings.gameplaysettings.enableCommandBlocks": "Whether to allow players to use command blocks\nNote: If enabled, per-world gamerules still apply.",
   "chat.type.achievement": "{%0} zdobywa osiągnięcie {%1}",
   "chat.type.admin": "[{%0}: {%1}]",
   "chat.type.announcement": "[{%0}] {%1}",

--- a/src/main/resources/language/rus/lang.json
+++ b/src/main/resources/language/rus/lang.json
@@ -43,6 +43,8 @@
   "nukkit.server.settings.playersettings.skinChangeCooldown": "Cooldown time for players changing skins",
   "nukkit.server.settings.playersettings.forceSkinTrusted": "Whether to force trust player skins, allowing players to use third-party skins freely",
   "nukkit.server.settings.playersettings.checkMovement": "Whether to check player movement",
+  "nukkit.server.settings.gameplaysettings": "Server's gameplay configuration",
+  "nukkit.server.settings.gameplaysettings.enableCommandBlocks": "Whether to allow players to use command blocks\nNote: If enabled, per-world gamerules still apply.",
   "chat.type.achievement": "{%0} заработал(а) достижение {%1}",
   "chat.type.admin": "[{%0}: {%1}]",
   "chat.type.announcement": "[{%0}] {%1}",

--- a/src/main/resources/language/spa/lang.json
+++ b/src/main/resources/language/spa/lang.json
@@ -43,6 +43,8 @@
   "nukkit.server.settings.playersettings.skinChangeCooldown": "Cooldown time for players changing skins",
   "nukkit.server.settings.playersettings.forceSkinTrusted": "Whether to force trust player skins, allowing players to use third-party skins freely",
   "nukkit.server.settings.playersettings.checkMovement": "Whether to check player movement",
+  "nukkit.server.settings.gameplaysettings": "Server's gameplay configuration",
+  "nukkit.server.settings.gameplaysettings.enableCommandBlocks": "Whether to allow players to use command blocks\nNote: If enabled, per-world gamerules still apply.",
   "chat.type.achievement": "{%0} acaba de ganar un logro {%1}",
   "chat.type.admin": "[{%0}: {%1}]",
   "chat.type.announcement": "[{%0}] {%1}",

--- a/src/main/resources/language/tur/lang.json
+++ b/src/main/resources/language/tur/lang.json
@@ -43,6 +43,8 @@
   "nukkit.server.settings.playersettings.skinChangeCooldown": "Cooldown time for players changing skins",
   "nukkit.server.settings.playersettings.forceSkinTrusted": "Whether to force trust player skins, allowing players to use third-party skins freely",
   "nukkit.server.settings.playersettings.checkMovement": "Whether to check player movement",
+  "nukkit.server.settings.gameplaysettings": "Server's gameplay configuration",
+  "nukkit.server.settings.gameplaysettings.enableCommandBlocks": "Whether to allow players to use command blocks\nNote: If enabled, per-world gamerules still apply.",
   "chat.type.achievement": "{%0}, {%1} başarımını kazandı",
   "chat.type.admin": "[{%0}: {%1}]",
   "chat.type.announcement": "[{%0}] {%1}",

--- a/src/main/resources/language/ukr/lang.json
+++ b/src/main/resources/language/ukr/lang.json
@@ -43,6 +43,8 @@
   "nukkit.server.settings.playersettings.skinChangeCooldown": "Cooldown time for players changing skins",
   "nukkit.server.settings.playersettings.forceSkinTrusted": "Whether to force trust player skins, allowing players to use third-party skins freely",
   "nukkit.server.settings.playersettings.checkMovement": "Whether to check player movement",
+  "nukkit.server.settings.gameplaysettings": "Server's gameplay configuration",
+  "nukkit.server.settings.gameplaysettings.enableCommandBlocks": "Whether to allow players to use command blocks\nNote: If enabled, per-world gamerules still apply.",
   "chat.type.achievement": "{%0} отримав досягнення {%1}",
   "chat.type.admin": "[{%0}: {%1}]",
   "chat.type.announcement": "[{%0}] {%1}",

--- a/src/main/resources/language/vie/lang.json
+++ b/src/main/resources/language/vie/lang.json
@@ -43,6 +43,8 @@
   "nukkit.server.settings.playersettings.skinChangeCooldown": "Cooldown time for players changing skins",
   "nukkit.server.settings.playersettings.forceSkinTrusted": "Whether to force trust player skins, allowing players to use third-party skins freely",
   "nukkit.server.settings.playersettings.checkMovement": "Whether to check player movement",
+  "nukkit.server.settings.gameplaysettings": "Server's gameplay configuration",
+  "nukkit.server.settings.gameplaysettings.enableCommandBlocks": "Whether to allow players to use command blocks\nNote: If enabled, per-world gamerules still apply.",
   "chat.type.achievement": "{%0} vừa đạt được thành tựu {%1}",
   "chat.type.admin": "[{%0}: {%1}]",
   "chat.type.announcement": "[{%0}] {%1}",


### PR DESCRIPTION
This PR adds a new setting to the nukkit.yml to enable or disable the usage of command blocks server wide.

If set to true, gamerules are still able to regulate command blocks.
If set to false, gamerules do not matter.