### PR TITLE
Fix: isSupportValid for plant type blocks

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockDoublePlant.java
+++ b/src/main/java/cn/nukkit/block/BlockDoublePlant.java
@@ -90,7 +90,7 @@ public abstract class BlockDoublePlant extends BlockFlowable {
             return !plant.isTopHalf();
         }
         return switch (support.getId()) {
-            case GRASS_BLOCK, DIRT, COARSE_DIRT, PODZOL, MYCELIUM, DIRT_WITH_ROOTS, MOSS_BLOCK -> true;
+            case GRASS_BLOCK, DIRT, COARSE_DIRT, PODZOL, FARMLAND, MYCELIUM, DIRT_WITH_ROOTS, MOSS_BLOCK, PALE_MOSS_BLOCK -> true;
             default -> false;
         };
     }

--- a/src/main/java/cn/nukkit/block/BlockDoublePlant.java
+++ b/src/main/java/cn/nukkit/block/BlockDoublePlant.java
@@ -90,7 +90,7 @@ public abstract class BlockDoublePlant extends BlockFlowable {
             return !plant.isTopHalf();
         }
         return switch (support.getId()) {
-            case GRASS_BLOCK, DIRT, PODZOL, MYCELIUM, DIRT_WITH_ROOTS, MOSS_BLOCK -> true;
+            case GRASS_BLOCK, DIRT, COARSE_DIRT, PODZOL, MYCELIUM, DIRT_WITH_ROOTS, MOSS_BLOCK -> true;
             default -> false;
         };
     }

--- a/src/main/java/cn/nukkit/block/BlockFlower.java
+++ b/src/main/java/cn/nukkit/block/BlockFlower.java
@@ -20,7 +20,7 @@ public abstract class BlockFlower extends BlockFlowable implements BlockFlowerPo
 
     public static boolean isSupportValid(Block block) {
         return switch (block.getId()) {
-            case GRASS_BLOCK, DIRT, FARMLAND, PODZOL, DIRT_WITH_ROOTS, MOSS_BLOCK -> true;
+            case GRASS_BLOCK, DIRT, COARSE_DIRT, FARMLAND, PODZOL, DIRT_WITH_ROOTS, MOSS_BLOCK -> true;
             default -> false;
         };
     }

--- a/src/main/java/cn/nukkit/block/BlockFlower.java
+++ b/src/main/java/cn/nukkit/block/BlockFlower.java
@@ -20,7 +20,7 @@ public abstract class BlockFlower extends BlockFlowable implements BlockFlowerPo
 
     public static boolean isSupportValid(Block block) {
         return switch (block.getId()) {
-            case GRASS_BLOCK, DIRT, COARSE_DIRT, FARMLAND, PODZOL, DIRT_WITH_ROOTS, MOSS_BLOCK -> true;
+            case GRASS_BLOCK, DIRT, COARSE_DIRT, PODZOL, FARMLAND, MYCELIUM, DIRT_WITH_ROOTS, MOSS_BLOCK, PALE_MOSS_BLOCK -> true;
             default -> false;
         };
     }

--- a/src/main/java/cn/nukkit/block/BlockMossBlock.java
+++ b/src/main/java/cn/nukkit/block/BlockMossBlock.java
@@ -141,7 +141,7 @@ public class BlockMossBlock extends BlockSolid implements Natural {
 
     public boolean canGrowPlant(Position pos) {
         return switch (pos.add(0, -1, 0).getLevelBlock().getId()) {
-            case GRASS_BLOCK, DIRT, PODZOL, FARMLAND, MYCELIUM, DIRT_WITH_ROOTS, MOSS_BLOCK, PALE_MOSS_BLOCK -> true;
+            case GRASS_BLOCK, DIRT, COARSE_DIRT, PODZOL, FARMLAND, MYCELIUM, DIRT_WITH_ROOTS, MOSS_BLOCK, PALE_MOSS_BLOCK -> true;
             default -> false;
         };
     }

--- a/src/main/java/cn/nukkit/block/BlockPinkPetals.java
+++ b/src/main/java/cn/nukkit/block/BlockPinkPetals.java
@@ -56,7 +56,7 @@ public class BlockPinkPetals extends BlockFlowable {
 
     private static boolean isSupportValid(Block block) {
         return switch (block.getId()) {
-            case GRASS_BLOCK, DIRT, FARMLAND, PODZOL, DIRT_WITH_ROOTS, MOSS_BLOCK -> true;
+            case GRASS_BLOCK, DIRT, COARSE_DIRT, PODZOL, FARMLAND, MYCELIUM, DIRT_WITH_ROOTS, MOSS_BLOCK, PALE_MOSS_BLOCK -> true;
             default -> false;
         };
     }

--- a/src/main/java/cn/nukkit/block/BlockSweetBerryBush.java
+++ b/src/main/java/cn/nukkit/block/BlockSweetBerryBush.java
@@ -155,7 +155,7 @@ public class BlockSweetBerryBush extends BlockFlowable {
 
     public static boolean isSupportValid(Block block) {
         return switch (block.getId()) {
-            case GRASS_BLOCK, DIRT, COARSE_DIRT, PODZOL, DIRT_WITH_ROOTS, MOSS_BLOCK -> true;
+            case GRASS_BLOCK, DIRT, COARSE_DIRT, PODZOL, FARMLAND, MYCELIUM, DIRT_WITH_ROOTS, MOSS_BLOCK, PALE_MOSS_BLOCK -> true;
             default -> false;
         };
     }

--- a/src/main/java/cn/nukkit/block/BlockSweetBerryBush.java
+++ b/src/main/java/cn/nukkit/block/BlockSweetBerryBush.java
@@ -155,7 +155,7 @@ public class BlockSweetBerryBush extends BlockFlowable {
 
     public static boolean isSupportValid(Block block) {
         return switch (block.getId()) {
-            case GRASS_BLOCK, DIRT, PODZOL, DIRT_WITH_ROOTS, MOSS_BLOCK -> true;
+            case GRASS_BLOCK, DIRT, COARSE_DIRT, PODZOL, DIRT_WITH_ROOTS, MOSS_BLOCK -> true;
             default -> false;
         };
     }

--- a/src/main/java/cn/nukkit/tags/BlockTags.java
+++ b/src/main/java/cn/nukkit/tags/BlockTags.java
@@ -24,6 +24,7 @@ public final class BlockTags {
     public static final String DARK_OAK = "dark_oak";
     public static final String DIAMOND_PICK_DIGGABLE = "diamond_pick_diggable";
     public static final String DIRT = "dirt";
+    public static final String COARSE_DIRT = "coarse_dirt";
     public static final String FERTILIZE_AREA = "fertilize_area";
     public static final String GOLD_PICK_DIGGABLE = "gold_pick_diggable";
     public static final String GRASS = "grass";


### PR DESCRIPTION
some of them were missing valid blocks. This should definitely be refactored later to use a generic Growable block tag or something.