### PR TITLE
Fix: BeaconInventory slot -> ContainerSlotType 27 does not exist

### DIFF
--- a/src/main/java/cn/nukkit/inventory/BeaconInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BeaconInventory.java
@@ -23,6 +23,7 @@ public class BeaconInventory extends BaseInventory implements BlockEntityInvento
     public void init() {
         Map<Integer, ContainerSlotType> map = super.slotTypeMap();
         map.put(0, ContainerSlotType.BEACON_PAYMENT);
+        map.put(27, ContainerSlotType.BEACON_PAYMENT);
 
         BiMap<Integer, Integer> networkSlotMap = super.networkSlotMap();
         networkSlotMap.put(0, 27);


### PR DESCRIPTION
This PR fixes an issue where placing an ore item in the Beacon inventory slot would cause a ContainerSlotType 27 does not exist error. The problem occurred due to an incorrect slot mapping, which has now been corrected.