### PR TITLE
fix: tickingarea concurrentmodification

### DIFF
--- a/src/main/java/cn/nukkit/level/tickingarea/manager/SimpleTickingAreaManager.java
+++ b/src/main/java/cn/nukkit/level/tickingarea/manager/SimpleTickingAreaManager.java
@@ -5,6 +5,8 @@ import cn.nukkit.level.tickingarea.TickingArea;
 import cn.nukkit.level.tickingarea.storage.TickingAreaStorage;
 
 import javax.annotation.Nullable;
+
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -71,7 +73,7 @@ public class SimpleTickingAreaManager extends TickingAreaManager {
 
     @Override
     public void loadAllTickingArea() {
-        for (TickingArea area : areaMap.values())
+        for (TickingArea area : new ArrayList<>(areaMap.values()))
             if (!area.loadAllChunk()) removeTickingArea(area.getName());
     }
 }


### PR DESCRIPTION
this fixes
```
java.util.ConcurrentModificationException: null
        at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1605) ~[?:?]
        at java.base/java.util.HashMap$ValueIterator.next(HashMap.java:1633) ~[?:?]
        at cn.nukkit.level.tickingarea.manager.SimpleTickingAreaManager.loadAllTickingArea(SimpleTickingAreaManager.java:74) ~[main/:?]
        at cn.nukkit.Server.<init>(Server.java:501) ~[main/:?]
        at cn.nukkit.Nukkit.main(Nukkit.java:158) [main/:?]
```