### PR TITLE
fix: block manager subchunk update is now saving chunks

### DIFF
--- a/src/main/java/cn/nukkit/level/generator/object/BlockManager.java
+++ b/src/main/java/cn/nukkit/level/generator/object/BlockManager.java
@@ -122,6 +122,10 @@ public class BlockManager {
     }
 
     public void applySubChunkUpdate(List<Block> blockList, Predicate<Block> predicate) {
+        this.applySubChunkUpdate(blockList, predicate, false);
+    }
+
+    public void applySubChunkUpdate(List<Block> blockList, Predicate<Block> predicate, boolean queueSave) {
         if (predicate != null) {
             blockList = blockList.stream().filter(predicate).toList();
         }
@@ -146,6 +150,9 @@ public class BlockManager {
                 });
                 unsafeChunk.recalculateHeightMap();
             });
+            if (queueSave) {
+                key.setChanged();
+            }
             key.reObfuscateChunk();
         });
         for (var p : batchs.values()) {


### PR DESCRIPTION
changed chunks were not saved when use BlockManager to update ranges