### PR TITLE
Enhancement/show coordinates of command block generating error

### DIFF
--- a/src/main/java/cn/nukkit/blockentity/BlockEntityCommandBlock.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityCommandBlock.java
@@ -584,7 +584,7 @@ public class BlockEntityCommandBlock extends BlockEntitySpawnable implements ICo
 
         Level level = this.getLevel();
         if (level == null) {
-            Server.getInstance().getLogger().error("❌ CommandBlock message failed: level is null. Location approx at x=" + this.x + " y=" + this.y + " z=" + this.z);
+            Server.getInstance().getLogger().error("CommandBlock message failed: level is null. Location approx at x=" + this.x + " y=" + this.y + " z=" + this.z);
             return;
         }
 
@@ -598,33 +598,8 @@ public class BlockEntityCommandBlock extends BlockEntitySpawnable implements ICo
                     ((CommandSender) user).sendMessage(message);
                 }
             }
-
-            // Log where this command block executed
-            Server.getInstance().getLogger().info("📍 CommandBlock executed at: " + this.getLocation() + " - Message: " + message.getText());
         }
     }
-    //public void sendMessage(TextContainer message) {
-    //    if (this.isTrackingOutput()) {
-    //        this.lastOutput = message.getText();
-    //        if (message instanceof TranslationContainer translationContainer) {
-    //            ListTag<StringTag> newParams = new ListTag<>();
-    //            for (String param : translationContainer.getParameters()) {
-    //                newParams.add(new StringTag(param));
-    //            }
-    //            this.lastOutputParams = newParams;
-    //        }
-    //    }
-    //    if (this.getLevel().getGameRules().getBoolean(GameRule.COMMAND_BLOCK_OUTPUT)) {
-    //        message.setText(TextFormat.GRAY + "" + TextFormat.ITALIC + "[" + this.getName() + ": " + TextFormat.RESET +
-    //                (!message.getText().equals(this.getServer().getLanguage().get(message.getText())) ? "%" : "") + message.getText() + "]");
-    //        Set<Permissible> users = this.getServer().getPluginManager().getPermissionSubscriptions(Server.BROADCAST_CHANNEL_ADMINISTRATIVE);
-    //        for (var user : users) {
-    //            if (user instanceof Player || user instanceof ConsoleCommandSender) {
-    //                ((CommandSender) user).sendMessage(message);
-    //            }
-    //        }
-    //    }
-    //}
 
     public void sendCommandOutput(CommandOutputContainer container) {
         for (var message : container.getMessages()) {

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityCommandBlock.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityCommandBlock.java
@@ -581,17 +581,50 @@ public class BlockEntityCommandBlock extends BlockEntitySpawnable implements ICo
                 this.lastOutputParams = newParams;
             }
         }
-        if (this.getLevel().getGameRules().getBoolean(GameRule.COMMAND_BLOCK_OUTPUT)) {
+
+        Level level = this.getLevel();
+        if (level == null) {
+            Server.getInstance().getLogger().error("❌ CommandBlock message failed: level is null. Location approx at x=" + this.x + " y=" + this.y + " z=" + this.z);
+            return;
+        }
+
+        if (level.getGameRules().getBoolean(GameRule.COMMAND_BLOCK_OUTPUT)) {
             message.setText(TextFormat.GRAY + "" + TextFormat.ITALIC + "[" + this.getName() + ": " + TextFormat.RESET +
                     (!message.getText().equals(this.getServer().getLanguage().get(message.getText())) ? "%" : "") + message.getText() + "]");
+
             Set<Permissible> users = this.getServer().getPluginManager().getPermissionSubscriptions(Server.BROADCAST_CHANNEL_ADMINISTRATIVE);
             for (var user : users) {
                 if (user instanceof Player || user instanceof ConsoleCommandSender) {
                     ((CommandSender) user).sendMessage(message);
                 }
             }
+
+            // Log where this command block executed
+            Server.getInstance().getLogger().info("📍 CommandBlock executed at: " + this.getLocation() + " - Message: " + message.getText());
         }
     }
+    //public void sendMessage(TextContainer message) {
+    //    if (this.isTrackingOutput()) {
+    //        this.lastOutput = message.getText();
+    //        if (message instanceof TranslationContainer translationContainer) {
+    //            ListTag<StringTag> newParams = new ListTag<>();
+    //            for (String param : translationContainer.getParameters()) {
+    //                newParams.add(new StringTag(param));
+    //            }
+    //            this.lastOutputParams = newParams;
+    //        }
+    //    }
+    //    if (this.getLevel().getGameRules().getBoolean(GameRule.COMMAND_BLOCK_OUTPUT)) {
+    //        message.setText(TextFormat.GRAY + "" + TextFormat.ITALIC + "[" + this.getName() + ": " + TextFormat.RESET +
+    //                (!message.getText().equals(this.getServer().getLanguage().get(message.getText())) ? "%" : "") + message.getText() + "]");
+    //        Set<Permissible> users = this.getServer().getPluginManager().getPermissionSubscriptions(Server.BROADCAST_CHANNEL_ADMINISTRATIVE);
+    //        for (var user : users) {
+    //            if (user instanceof Player || user instanceof ConsoleCommandSender) {
+    //                ((CommandSender) user).sendMessage(message);
+    //            }
+    //        }
+    //    }
+    //}
 
     public void sendCommandOutput(CommandOutputContainer container) {
         for (var message : container.getMessages()) {


### PR DESCRIPTION
Just getting familiar with the code, it has been a long time I contributed to any repo and during my test bringing up the server I found some lost command blocks producing errors on my logs, so I thought it was worth to log the location of the block generating this error to the server owner at least troubleshoot it.
Nothing special.

The change do:
It checks if the command block is trying to access some level that doesn't exist or not loaded resulting in null, if so it print the message with the location of the source command block and return avoiding possible crashes.