### PR TITLE
Added Support to Tint Method for custom blocks

### DIFF
--- a/src/main/java/cn/nukkit/block/customblock/data/Materials.java
+++ b/src/main/java/cn/nukkit/block/customblock/data/Materials.java
@@ -2,6 +2,7 @@ package cn.nukkit.block.customblock.data;
 
 import cn.nukkit.nbt.tag.CompoundTag;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 
@@ -29,12 +30,38 @@ public class Materials implements NBTData {
     }
 
     /**
-     * ambientOcclusion=true, faceDimming=true
+     * ambientOcclusion=true, faceDimming=true, tintType=null
      *
      * @see #up(RenderMethod, boolean, boolean, String)
      */
     public Materials up(RenderMethod renderMethod, String texture) {
-        this.process("up", true, true, renderMethod, texture);
+        this.process("up", true, true, renderMethod, texture, null);
+        return this;
+    }
+
+    /**
+     * ambientOcclusion=true, faceDimming=true
+     * @param tintType         Set tintint method for the block
+     * @see #up(RenderMethod, boolean, boolean, String, String)
+     */
+    public Materials up(RenderMethod renderMethod, String texture, String tintType) {
+        this.process("up", true, true, renderMethod, texture, tintType);
+        return this;
+    }
+
+    /**
+     * 指定up面对应的渲染方法、渲染参数和材质。
+     * <p>
+     * Specify the corresponding rendering method, rendering parameters and texture's name for the up face. tintType=null
+     *
+     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
+     * @param texture          指定up方向的材质名称<br>Specify the texture's name of the up face
+     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
+     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @return the materials
+     */
+    public Materials up(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
+        this.process("up", ambientOcclusion, faceDimming, renderMethod, texture, null);
         return this;
     }
 
@@ -47,20 +74,48 @@ public class Materials implements NBTData {
      * @param texture          指定up方向的材质名称<br>Specify the texture's name of the up face
      * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
      * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param tintType         Set tintint method for the block
      * @return the materials
      */
-    public Materials up(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
-        this.process("up", ambientOcclusion, faceDimming, renderMethod, texture);
+    public Materials up(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture, String tintType) {
+        this.process("up", ambientOcclusion, faceDimming, renderMethod, texture, tintType);
+        return this;
+    }
+
+    /**
+     * ambientOcclusion=true, faceDimming=true, tintType=null
+     *
+     * @see #down(RenderMethod, boolean, boolean, String)
+     */
+    public Materials down(RenderMethod renderMethod, String texture) {
+        this.process("down", true, true, renderMethod, texture, null);
         return this;
     }
 
     /**
      * ambientOcclusion=true, faceDimming=true
-     *
-     * @see #down(RenderMethod, boolean, boolean, String)
+     * @param tintType         Set tintint method for the block
+     * 
+     * @see #up(RenderMethod, boolean, boolean, String, String)
      */
-    public Materials down(RenderMethod renderMethod, String texture) {
-        this.process("down", true, true, renderMethod, texture);
+    public Materials down(RenderMethod renderMethod, String texture, String tintType) {
+        this.process("down", true, true, renderMethod, texture, tintType);
+        return this;
+    }
+
+    /**
+     * 指定down面对应的渲染方法、渲染参数和材质。
+     * <p>
+     * Specify the corresponding rendering method, rendering parameters and texture's name for the down face. tintType=null
+     *
+     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
+     * @param texture          指定down方向的材质名称<br>Specify the texture's name of the down face
+     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
+     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @return the materials
+     */
+    public Materials down(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
+        this.process("down", ambientOcclusion, faceDimming, renderMethod, texture, null);
         return this;
     }
 
@@ -73,20 +128,47 @@ public class Materials implements NBTData {
      * @param texture          指定down方向的材质名称<br>Specify the texture's name of the down face
      * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
      * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param tintType         Set tintint method for the block
      * @return the materials
      */
-    public Materials down(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
-        this.process("down", ambientOcclusion, faceDimming, renderMethod, texture);
+    public Materials down(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture, String tintType) {
+        this.process("down", ambientOcclusion, faceDimming, renderMethod, texture, tintType);
+        return this;
+    }
+
+    /**
+     * ambientOcclusion=true, faceDimming=true, tintType=null
+     *
+     * @see #north(RenderMethod, boolean, boolean, String)
+     */
+    public Materials north(RenderMethod renderMethod, String texture) {
+        this.process("north", true, true, renderMethod, texture, null);
         return this;
     }
 
     /**
      * ambientOcclusion=true, faceDimming=true
-     *
-     * @see #north(RenderMethod, boolean, boolean, String)
+     * @param tintType         Set tintint method for the block
+     * @see #up(RenderMethod, boolean, boolean, String, String)
      */
-    public Materials north(RenderMethod renderMethod, String texture) {
-        this.process("north", true, true, renderMethod, texture);
+    public Materials north(RenderMethod renderMethod, String texture, String tintType) {
+        this.process("north", true, true, renderMethod, texture, tintType);
+        return this;
+    }
+
+    /**
+     * 指定north面对应的渲染方法、渲染参数和材质。
+     * <p>
+     * Specify the corresponding rendering method, rendering parameters and texture's name for the north face. tintType=null
+     *
+     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
+     * @param texture          指定north方向的材质名称<br>Specify the texture's name of the north face
+     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
+     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @return the materials
+     */
+    public Materials north(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
+        this.process("north", ambientOcclusion, faceDimming, renderMethod, texture, null);
         return this;
     }
 
@@ -99,20 +181,47 @@ public class Materials implements NBTData {
      * @param texture          指定north方向的材质名称<br>Specify the texture's name of the north face
      * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
      * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param tintType         Set tintint method for the block
      * @return the materials
      */
-    public Materials north(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
-        this.process("north", ambientOcclusion, faceDimming, renderMethod, texture);
+    public Materials north(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture, String tintType) {
+        this.process("north", ambientOcclusion, faceDimming, renderMethod, texture, tintType);
+        return this;
+    }
+
+    /**
+     * ambientOcclusion=true, faceDimming=true, tintType=null
+     *
+     * @see #south(RenderMethod, boolean, boolean, String)
+     */
+    public Materials south(RenderMethod renderMethod, String texture) {
+        this.process("south", true, true, renderMethod, texture, null);
         return this;
     }
 
     /**
      * ambientOcclusion=true, faceDimming=true
-     *
-     * @see #south(RenderMethod, boolean, boolean, String)
+     * @param tintType         Set tintint method for the block
+     * @see #up(RenderMethod, boolean, boolean, String, String)
      */
-    public Materials south(RenderMethod renderMethod, String texture) {
-        this.process("south", true, true, renderMethod, texture);
+    public Materials south(RenderMethod renderMethod, String texture, String tintType) {
+        this.process("south", true, true, renderMethod, texture, tintType);
+        return this;
+    }
+
+    /**
+     * 指定south面对应的渲染方法、渲染参数和材质。
+     * <p>
+     * Specify the corresponding rendering method, rendering parameters and texture's name for the south face. tintType=null
+     *
+     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
+     * @param texture          指定south方向的材质名称<br>Specify the texture's name of the south face
+     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
+     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @return the materials
+     */
+    public Materials south(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
+        this.process("south", ambientOcclusion, faceDimming, renderMethod, texture, null);
         return this;
     }
 
@@ -125,20 +234,48 @@ public class Materials implements NBTData {
      * @param texture          指定south方向的材质名称<br>Specify the texture's name of the south face
      * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
      * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param tintType         Set tintint method for the block
      * @return the materials
      */
-    public Materials south(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
-        this.process("south", ambientOcclusion, faceDimming, renderMethod, texture);
+    public Materials south(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture, String tintType) {
+        this.process("south", ambientOcclusion, faceDimming, renderMethod, texture, tintType);
+        return this;
+    }
+
+    /**
+     * ambientOcclusion=true, faceDimming=true, tintType=null
+     *
+     * @see #east(RenderMethod, boolean, boolean, String)
+     */
+    public Materials east(RenderMethod renderMethod, String texture) {
+        this.process("east", true, true, renderMethod, texture, null);
         return this;
     }
 
     /**
      * ambientOcclusion=true, faceDimming=true
-     *
-     * @see #east(RenderMethod, boolean, boolean, String)
+     * @param tintType         Set tintint method for the block
+     * 
+     * @see #up(RenderMethod, boolean, boolean, String, String)
      */
-    public Materials east(RenderMethod renderMethod, String texture) {
-        this.process("east", true, true, renderMethod, texture);
+    public Materials east(RenderMethod renderMethod, String texture, String tintType) {
+        this.process("east", true, true, renderMethod, texture, tintType);
+        return this;
+    }
+
+    /**
+     * 指定east面对应的渲染方法、渲染参数和材质。
+     * <p>
+     * Specify the corresponding rendering method, rendering parameters and texture's name for the east face. tintType=null
+     *
+     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
+     * @param texture          指定east方向的材质名称<br>Specify the texture's name of the east face
+     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
+     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @return the materials
+     */
+    public Materials east(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
+        this.process("east", ambientOcclusion, faceDimming, renderMethod, texture, null);
         return this;
     }
 
@@ -151,20 +288,47 @@ public class Materials implements NBTData {
      * @param texture          指定east方向的材质名称<br>Specify the texture's name of the east face
      * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
      * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param tintType         Set tintint method for the block
      * @return the materials
      */
-    public Materials east(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
-        this.process("east", ambientOcclusion, faceDimming, renderMethod, texture);
+    public Materials east(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture, String tintType) {
+        this.process("east", ambientOcclusion, faceDimming, renderMethod, texture, tintType);
+        return this;
+    }
+
+    /**
+     * ambientOcclusion=true, faceDimming=true, tintType=null
+     *
+     * @see #west(RenderMethod, boolean, boolean, String)
+     */
+    public Materials west(RenderMethod renderMethod, String texture) {
+        this.process("west", true, true, renderMethod, texture, null);
         return this;
     }
 
     /**
      * ambientOcclusion=true, faceDimming=true
-     *
-     * @see #west(RenderMethod, boolean, boolean, String)
+     * @param tintType         Set tintint method for the block
+     * @see #up(RenderMethod, boolean, boolean, String, String)
      */
-    public Materials west(RenderMethod renderMethod, String texture) {
-        this.process("west", true, true, renderMethod, texture);
+    public Materials west(RenderMethod renderMethod, String texture, String tintType) {
+        this.process("west", true, true, renderMethod, texture, tintType);
+        return this;
+    }
+
+    /**
+     * 指定west面对应的渲染方法、渲染参数和材质。
+     * <p>
+     * Specify the corresponding rendering method, rendering parameters and texture's name for the west face. tintType=null
+     *
+     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
+     * @param texture          指定west方向的材质名称<br>Specify the texture's name of the west face
+     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
+     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @return the materials
+     */
+    public Materials west(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
+        this.process("west", ambientOcclusion, faceDimming, renderMethod, texture, null);
         return this;
     }
 
@@ -177,20 +341,48 @@ public class Materials implements NBTData {
      * @param texture          指定west方向的材质名称<br>Specify the texture's name of the west face
      * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
      * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param tintType         Set tintint method for the block
      * @return the materials
      */
-    public Materials west(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
-        this.process("west", ambientOcclusion, faceDimming, renderMethod, texture);
+    public Materials west(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture, String tintType) {
+        this.process("west", ambientOcclusion, faceDimming, renderMethod, texture, tintType);
+        return this;
+    }
+
+    /**
+     * ambientOcclusion=true, faceDimming=true, tintType=null
+     *
+     * @see #any(RenderMethod, boolean, boolean, String)
+     */
+    public Materials any(RenderMethod renderMethod, String texture) {
+        this.process("*", true, true, renderMethod, texture, null);
         return this;
     }
 
     /**
      * ambientOcclusion=true, faceDimming=true
-     *
-     * @see #any(RenderMethod, boolean, boolean, String)
+     * 
+     * 
+     * @see #up(RenderMethod, boolean, boolean, String, String)
      */
-    public Materials any(RenderMethod renderMethod, String texture) {
-        this.process("*", true, true, renderMethod, texture);
+    public Materials any(RenderMethod renderMethod, String texture, String tintType) {
+        this.process("*", true, true, renderMethod, texture, tintType);
+        return this;
+    }
+
+    /**
+     * 指定所有面对应的渲染方法、渲染参数和材质。
+     * <p>
+     * Specify all corresponding rendering method, rendering parameters and texture name. tintType=null
+     *
+     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
+     * @param texture          材质名称<br>Specify the texture's name
+     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
+     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @return the materials
+     */
+    public Materials any(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
+        this.process("*", ambientOcclusion, faceDimming, renderMethod, texture, null);
         return this;
     }
 
@@ -205,8 +397,8 @@ public class Materials implements NBTData {
      * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
      * @return the materials
      */
-    public Materials any(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
-        this.process("*", ambientOcclusion, faceDimming, renderMethod, texture);
+    public Materials any(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture, String tintType) {
+        this.process("*", ambientOcclusion, faceDimming, renderMethod, texture, tintType);
         return this;
     }
 
@@ -218,21 +410,48 @@ public class Materials implements NBTData {
      * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
      * @param renderMethodName 要使用的渲染方法<br>Rendering method to be used
      * @param texture          材质名称<br>Specify the texture's name
+     * @param tintType         材质名称<br>Specify the tinting type
      */
-    public void process(@NotNull String face, boolean ambientOcclusion, boolean faceDimming, @NotNull String renderMethodName, @NotNull String texture) {
-        this.tag.putCompound(face, new CompoundTag()
-                .putBoolean("ambient_occlusion", ambientOcclusion)
-                .putBoolean("face_dimming", faceDimming)
-                .putString("render_method", renderMethodName)
-                .putString("texture", texture));
+    //public void process(@NotNull String face, boolean ambientOcclusion, boolean faceDimming, @NotNull String renderMethodName, @NotNull String texture, @Nullable String tintType) {
+    //    this.tag.putCompound(face, new CompoundTag()
+    //            .putBoolean("ambient_occlusion", ambientOcclusion)
+    //            .putBoolean("face_dimming", faceDimming)
+    //            .putString("render_method", renderMethodName)
+    //            .putString("texture", texture));
+    //            if (tintType != null && !tintType.isBlank()) faceTag.putString("tint_method", tintType)
+    //}
+    public void process(@NotNull String face, boolean ambientOcclusion, boolean faceDimming, @NotNull String renderMethodName, @NotNull String texture, @Nullable String tintType) {
+        CompoundTag faceTag = new CompoundTag()
+            .putBoolean("ambient_occlusion", ambientOcclusion)
+            .putBoolean("face_dimming", faceDimming)
+            .putString("render_method", renderMethodName)
+            .putString("texture", texture);
+
+        if (tintType != null && !tintType.isBlank()) {
+            faceTag.putString("tint_method", tintType);
+        }
+        this.tag.putCompound(face, faceTag);
     }
 
-    private void process(@NotNull String face, boolean ambientOcclusion, boolean faceDimming, @NotNull RenderMethod renderMethod, @NotNull String texture) {
-        this.tag.putCompound(face, new CompoundTag()
-                .putBoolean("ambient_occlusion", ambientOcclusion)
-                .putBoolean("face_dimming", faceDimming)
-                .putString("render_method", renderMethod.name().toLowerCase(Locale.ENGLISH))
-                .putString("texture", texture));
+    //private void process(@NotNull String face, boolean ambientOcclusion, boolean faceDimming, @NotNull RenderMethod renderMethod, @NotNull String texture, @Nullable String tintType) {
+    //    this.tag.putCompound(face, new CompoundTag()
+    //            .putBoolean("ambient_occlusion", ambientOcclusion)
+    //            .putBoolean("face_dimming", faceDimming)
+    //            .putString("render_method", renderMethod.name().toLowerCase(Locale.ENGLISH))
+    //            .putString("texture", texture));
+    //            if (tintType != null && !tintType.isBlank()) faceTag.putString("tint_method", tintType)
+    //}
+    private void process(@NotNull String face, boolean ambientOcclusion, boolean faceDimming, @NotNull RenderMethod renderMethod, @NotNull String texture, @Nullable String tintType) {
+        CompoundTag faceTag = new CompoundTag()
+            .putBoolean("ambient_occlusion", ambientOcclusion)
+            .putBoolean("face_dimming", faceDimming)
+            .putString("render_method", renderMethod.name().toLowerCase(Locale.ENGLISH))
+            .putString("texture", texture);
+
+        if (tintType != null && !tintType.isBlank()) {
+            faceTag.putString("tint_method", tintType);
+        }
+        this.tag.putCompound(face, faceTag);
     }
 
     public CompoundTag toCompoundTag() {


### PR DESCRIPTION
This change add support for tint_method to be used with custom blocks, allowing tinting based on biome placed or forced types.
Tested and attached photos.
![image](https://github.com/user-attachments/assets/9dc5c413-9fe0-4c45-85f2-f74270a28167)


Blocks on left is the original vanilla, on right custom grass block.
![image](https://github.com/user-attachments/assets/d94d56d9-2828-4611-8db7-4328fd2a9240)
![image](https://github.com/user-attachments/assets/a66bda45-183c-446f-8684-5075a9819f80)
![image](https://github.com/user-attachments/assets/49590942-f9fb-45bd-a7e3-9d1e69c93bbc)
