### PR TITLE
Fixed that players cannot open their inventory after using another inventory

### DIFF
--- a/src/main/java/cn/nukkit/network/process/processor/ContainerCloseProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/ContainerCloseProcessor.java
@@ -7,14 +7,17 @@ import cn.nukkit.inventory.SpecialWindowId;
 import cn.nukkit.network.process.DataPacketProcessor;
 import cn.nukkit.network.protocol.ContainerClosePacket;
 import cn.nukkit.network.protocol.ProtocolInfo;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
+@Slf4j
 public class ContainerCloseProcessor extends DataPacketProcessor<ContainerClosePacket> {
 
     @Override
     public void handle(@NotNull PlayerHandle playerHandle, @NotNull ContainerClosePacket pk) {
         Player player = playerHandle.player;
         if (!player.spawned || pk.windowId == SpecialWindowId.PLAYER.getId() && !playerHandle.getInventoryOpen()) {
+            log.warn("{} tried to close his own inventory without it being open.", player.getName());
             return;
         }
 
@@ -29,10 +32,11 @@ public class ContainerCloseProcessor extends DataPacketProcessor<ContainerCloseP
                 playerHandle.removeWindow(playerHandle.getWindowIndex().get(pk.windowId));
             }
         }
-        
+
         if (pk.windowId == -1) {
             player.addWindow(player.getCraftingGrid(), SpecialWindowId.NONE.getId());
         }
+
         if (inventory != null) {
             ContainerClosePacket pk2 = new ContainerClosePacket();
             pk2.wasServerInitiated = false;
@@ -40,7 +44,8 @@ public class ContainerCloseProcessor extends DataPacketProcessor<ContainerCloseP
             pk2.type = inventory.getType();
             player.dataPacket(pk2);
             player.resetInventory();
-        }
+        } else log.warn("{} tried to close inventory {} without it being open. (null)", player.getName(), pk.windowId);
+
     }
 
     @Override

--- a/src/main/java/cn/nukkit/network/process/processor/InteractProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/InteractProcessor.java
@@ -78,8 +78,10 @@ public class InteractProcessor extends DataPacketProcessor<InteractPacket> {
                     return;
                 }
                 if (!playerHandle.getInventoryOpen()) {
+                    if(player.getTopWindow().isPresent()) return;
                     playerHandle.setInventoryOpen(player.getInventory().open(player));
-                }
+                } else log.warn("{} tried to open the inventory while still being open!", player.getName());
+
             }
         }
     }


### PR DESCRIPTION
i hope this was the only cause for that bug to happen.
Players who tried to open their inventory after another inventory opened, couldn't open any inventory anymore.