### PR TITLE
Improve reliability of large resource packs delivery with controlled chunking and scheduling

### DIFF
--- a/src/main/java/cn/nukkit/config/category/NetworkSettings.java
+++ b/src/main/java/cn/nukkit/config/category/NetworkSettings.java
@@ -21,7 +21,7 @@ public class NetworkSettings extends OkaeriConfig {
     @Comment("pnx.settings.network.compressionbuffersize")
     int compressionBufferSize = 1048576;
     @Comment("pnx.settings.network.maxdecompresssize")
-    int maxDecompressSize = 67108864;
+    int maxDecompressSize = 536870912;
     @Comment("pnx.settings.network.packetlimit")
     int packetLimit = 240;
     @Comment("pnx.settings.network.query")

--- a/src/main/java/cn/nukkit/config/legacy/LegacyServerSettings.java
+++ b/src/main/java/cn/nukkit/config/legacy/LegacyServerSettings.java
@@ -80,7 +80,7 @@ public final class LegacyServerSettings extends OkaeriConfig {
         @Comment("nukkit.server.settings.networkSettings.compressionBufferSize")
         int compressionBufferSize = 1048576;
         @Comment("nukkit.server.settings.networkSettings.maxDecompressSize")
-        int maxDecompressSize = 67108864;
+        int maxDecompressSize = 536870912;
         @Comment("nukkit.server.settings.networkSettings.packetLimit")
         int packetLimit = 240;
     }

--- a/src/main/java/cn/nukkit/network/process/handler/ResourcePackHandler.java
+++ b/src/main/java/cn/nukkit/network/process/handler/ResourcePackHandler.java
@@ -102,6 +102,9 @@ public class ResourcePackHandler extends BedrockSessionPacketHandler {
         dataPacket.chunkIndex = pk.chunkIndex;
         dataPacket.data = resourcePack.getPackChunk(maxChunkSize * pk.chunkIndex, maxChunkSize);
         dataPacket.progress = maxChunkSize * (long) pk.chunkIndex;
-        session.sendPacket(dataPacket);
+        session.getServer().getScheduler().scheduleDelayedTask(() -> {
+            session.sendPacket(dataPacket);
+            session.flushSendBuffer();
+        }, 4);
     }
 }

--- a/src/main/java/cn/nukkit/network/process/handler/ResourcePackHandler.java
+++ b/src/main/java/cn/nukkit/network/process/handler/ResourcePackHandler.java
@@ -1,5 +1,7 @@
 package cn.nukkit.network.process.handler;
 
+import cn.nukkit.scheduler.ServerScheduler;
+import cn.nukkit.Server;
 import cn.nukkit.network.connection.BedrockSession;
 import cn.nukkit.network.process.SessionState;
 import cn.nukkit.network.protocol.ResourcePackChunkDataPacket;

--- a/src/main/java/cn/nukkit/resourcepacks/ResourcePackManager.java
+++ b/src/main/java/cn/nukkit/resourcepacks/ResourcePackManager.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 @Slf4j
 public class ResourcePackManager {
 
-    private int maxChunkSize = 1024 * 32;// 32kb is default
+    private int maxChunkSize = 1024 * 256;
     
     private final Map<UUID, ResourcePack> resourcePacksById = new HashMap<>();
     private final Set<ResourcePack> resourcePacks = new HashSet<>();


### PR DESCRIPTION
This fix addresses issues with resource packs transmission failures, especially when delivering large or multi-pack resources that exceed the typical client handling thresholds (smaller in clients like PS4/PS5).

Common issues:
>>> Failed to download resource packs due to the rapid fragmented packets delivery
>>> Clients being disconnected with QUEUE_TOO_LONG errors
>>> Floods of NAK packets from overwhelmed clients

These behaviors was common while clients from consoles tries to download the resources packs.