### PR TITLE
Added back Render offsets

### DIFF
--- a/src/main/java/cn/nukkit/item/customitem/CustomItemDefinition.java
+++ b/src/main/java/cn/nukkit/item/customitem/CustomItemDefinition.java
@@ -228,6 +228,8 @@ public record CustomItemDefinition(String identifier, CompoundTag nbt) implement
          * Control rendering offsets of custom items at different viewpoints
          */
         public SimpleBuilder renderOffsets(@NotNull RenderOffsets renderOffsets) {
+            this.nbt.getCompound("components")
+                .putCompound("minecraft:render_offsets", renderOffsets.nbt);
             return this;
         }
 


### PR DESCRIPTION
Added back Render offsets as it seems to don't conflict with block_placer as long they are not added together on the builder
This will allow users that still rely on render offsets to keep using it.

For users that still use that, I would suggest avoid using it as it is deprecated by Mojang since 1.20.10 and can be removed soon or later from the client.
To resize items you can use attachables.