### PR TITLE
fix/BlockEntities become invisible on BDS imported maps

### DIFF
--- a/src/main/java/cn/nukkit/config/category/ChunkSettings.java
+++ b/src/main/java/cn/nukkit/config/category/ChunkSettings.java
@@ -28,4 +28,6 @@ public class ChunkSettings extends OkaeriConfig {
     int generationQueueSize = 128;
     @Comment("pnx.settings.chunk.checkfortickable")
     boolean checkForTickable = false;
+    @Comment("pnx.settings.chunk.convertBDSChunks")
+    boolean convertBDSChunks = false;
 }

--- a/src/main/java/cn/nukkit/level/format/ChunkConversion.java
+++ b/src/main/java/cn/nukkit/level/format/ChunkConversion.java
@@ -1,0 +1,74 @@
+package cn.nukkit.level.format;
+
+import cn.nukkit.block.BlockState;
+import cn.nukkit.blockentity.BlockEntity;
+import cn.nukkit.nbt.tag.CompoundTag;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.*;
+
+@Slf4j
+public class ChunkConversion {
+
+    public static IChunk convert(IChunk chunk) {
+        log.debug("[ChunkConversion] Converting chunk at ({}, {})...", chunk.getX(), chunk.getZ());
+
+        // Fetch height range
+        int minY = chunk.getProvider().getDimensionData().getMinHeight();
+        int maxY = chunk.getProvider().getDimensionData().getMaxHeight();
+        int height = maxY - minY;
+
+        // Clone data
+        BlockState[][][] blocks = new BlockState[16][height][16];
+        int[][][] biomes = new int[16][height][16];
+        int[][] heightMap = new int[16][16];
+        List<CompoundTag> blockEntities = new ArrayList<>();
+
+        for (int x = 0; x < 16; x++) {
+            for (int z = 0; z < 16; z++) {
+                for (int y = minY; y < maxY; y++) {
+                    int ny = y - minY;
+                    blocks[x][ny][z] = chunk.getBlockState(x, y, z);
+                    biomes[x][ny][z] = chunk.getBiomeId(x, y, z);
+                }
+                heightMap[x][z] = chunk.getHeightMap(x, z);
+            }
+        }
+
+        for (BlockEntity be : chunk.getBlockEntities().values()) {
+            blockEntities.add(be.namedTag.copy());
+        }
+
+        // Rebuild chunk with copied data
+        for (int x = 0; x < 16; x++) {
+            for (int z = 0; z < 16; z++) {
+                for (int y = minY; y < maxY; y++) {
+                    int ny = y - minY;
+                    chunk.setBlockState(x, y, z, blocks[x][ny][z]);
+                    chunk.setBiomeId(x, y, z, biomes[x][ny][z]);
+                }
+                chunk.setHeightMap(x, z, heightMap[x][z]);
+            }
+        }
+
+        // Restore block entities
+        chunk.getBlockEntities().clear();
+        for (CompoundTag tag : blockEntities) {
+            String type = tag.getString("id");
+            BlockEntity be = BlockEntity.createBlockEntity(type, chunk, tag);
+            if (be != null) {
+                chunk.addBlockEntity(be);
+            }
+        }
+
+        // Finalize chunk
+        chunk.recalculateHeightMap();
+        chunk.populateSkyLight();
+        chunk.setLightPopulated();
+        chunk.hasChanged();
+        chunk.setChunkState(ChunkState.FINISHED);
+
+        log.debug("[ChunkConversion] Chunk at ({}, {}) converted successfully.", chunk.getX(), chunk.getZ());
+        return chunk;
+    }
+}

--- a/src/main/java/cn/nukkit/level/format/leveldb/LevelDBProvider.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/LevelDBProvider.java
@@ -1,5 +1,6 @@
 package cn.nukkit.level.format.leveldb;
 
+import cn.nukkit.Server;
 import cn.nukkit.api.UsedByReflection;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.blockentity.BlockEntitySpawnable;
@@ -8,6 +9,7 @@ import cn.nukkit.level.GameRule;
 import cn.nukkit.level.GameRules;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.format.Chunk;
+import cn.nukkit.level.format.ChunkConversion;
 import cn.nukkit.level.format.ChunkSection;
 import cn.nukkit.level.format.IChunk;
 import cn.nukkit.level.format.LevelConfig;
@@ -149,6 +151,12 @@ public class LevelDBProvider implements LevelProvider {
                 putChunk(index, chunk);
             }
         } else {
+            if (Server.getInstance().getSettings().chunkSettings().convertBDSChunks() && chunk.isPopulated()) {
+                CompoundTag extra = chunk.getExtraData();
+                if (extra == null || extra.isEmpty()) {
+                    chunk = ChunkConversion.convert(chunk);
+                }
+            }
             putChunk(index, chunk);
         }
         return chunk;

--- a/src/main/resources/language/eng/lang.json
+++ b/src/main/resources/language/eng/lang.json
@@ -68,6 +68,7 @@
   "pnx.settings.chunk.generationqueuesize": "Maximum number of terrain generation tasks executed simultaneously",
   "pnx.settings.chunk.spawnlimit": "Limits how many entities can spawn naturally in a chunk. ",
   "pnx.settings.chunk.checkfortickable": "Check for redstone and liquids to be ticked once at chunk load.",
+  "pnx.settings.chunk.convertBDSChunks": "Enable this if your BDS imported map have invisble chests, signs, beds, etc.",
   "pnx.settings.network.queryplugins": "Whether the query protocol displays plugin information",
   "pnx.settings.network.compressionlevel": "Compression level of the compression algorithm used by the server",
   "pnx.settings.network.zlibprovider": "Zlib compression algorithm provider used by the server. 0 for Java's original algorithm\n 1 for single-threaded low memory usage algorithm\n 2 for multi-threaded caching algorithm\n 3 for hardware-accelerated algorithm",


### PR DESCRIPTION
This PR addresses an issue where Block Entities on maps imported from BDS (Bedrock Dedicated Server) become invisible and non-functional in PowerNukkitX.
These entities fail to render correctly and cannot be interacted with. Additionally, placing new Block Entities on affected chunks also fails — they disappear after the chunk is reloaded.

To solve this, a new `ChunkConversion `system has been introduced.
It can be enabled via the **convertBDSChunks** option in pnx.yml, and is disabled by default.

When enabled, during the loadChunk stage, the system checks:
1. if the chunk is already populated (i.e., not newly generated), and
2. if it does not contain PNX-specific metadata (PNX_EXTRA_DATA).

If these criteria are met, it assumes the chunk was imported from a BDS world and automatically rewrites it with PNX compatible format before caching and sending it to players. This ensures full compatibility and restores missing Block Entity functionality.

**_This PR doesn't offer any risk of breaking chunks, it just rewrites old format chunks to the new format chunks keeping all the blocks, block states, block entities. PS: block palette will be rewritten with the PNX format too._**