### PR TITLE
fix&enhancements/Custom Blocks Server Sync & Custom Blocks Builder Enhancement

### DIFF
--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -407,9 +407,6 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
         return false;
     }
 
-    //public boolean isSolid() {
-    //    return true;
-    //}
     public boolean isSolid() {
         CustomBlockDefinition def = getCustomDefinition();
         if (def != null) {

--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -1,6 +1,8 @@
 package cn.nukkit.block;
 
 import cn.nukkit.Player;
+import cn.nukkit.block.customblock.CustomBlock;
+import cn.nukkit.block.customblock.CustomBlockDefinition;
 import cn.nukkit.block.property.type.BlockPropertyType;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.entity.Entity;
@@ -25,6 +27,7 @@ import cn.nukkit.nbt.tag.ListTag;
 import cn.nukkit.nbt.tag.StringTag;
 import cn.nukkit.nbt.tag.Tag;
 import cn.nukkit.plugin.Plugin;
+import cn.nukkit.registry.BlockRegistry;
 import cn.nukkit.registry.Registries;
 import cn.nukkit.tags.BlockTags;
 import cn.nukkit.utils.BlockColor;
@@ -272,6 +275,12 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
      * Defines the block explosion resistance
      */
     public double getResistance() {
+        CustomBlockDefinition def = getCustomDefinition();
+        if (def != null) {
+            return def.getComponents()
+                      .getCompound("minecraft:destructible_by_explosion")
+                      .getInt("explosion_resistance");
+        }
         return 1;
     }
 
@@ -297,26 +306,32 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
     }
 
     /**
-     * 控制挖掘方块的工具类型
+     * Controls the type of tool used to mine blocks
      *
-     * @return 挖掘方块的工具类型
+     * @return Types of tools used to mine blocks
      */
     public int getToolType() {
         return ItemTool.TYPE_NONE;
     }
 
     /**
-     * 服务端侧的摩擦系数，用于控制玩家丢弃物品、实体、船其在上方移动的速度。值越大，移动越快。
-     * <p>
-     * The friction on the server side, which is used to control the speed that player drops item,entity walk and boat movement on the block.The larger the value, the faster the movement.
+     * The friction, which is used to control the speed that player / entity movement on the block.The larger the value, the faster the movement.
      */
     public double getFrictionFactor() {
+        CustomBlockDefinition def = getCustomDefinition();
+        if (def != null) {
+            CompoundTag comp = def.getComponents().getCompound("minecraft:friction");
+            if (comp != null && comp.contains("value")) {
+                return comp.getFloat("value");
+            }
+        }
+
         return DEFAULT_FRICTION_FACTOR;
     }
 
     /**
-     * 控制方块的通过阻力因素（0-1）。此值越小阻力越大<p/>
-     * 对于不可穿过的方块，若未覆写，此值始终为1（无效）<p/>
+     * Controls the block's resistance factor (0-1). The smaller the value, the greater the resistance.<p/>
+     * For impassable blocks, this value is always 1 (invalid) unless overridden.<p/>
      */
     public double getPassableBlockFrictionFactor() {
         if (!this.canPassThrough()) return 1;
@@ -333,11 +348,19 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
     }
 
     /**
-     * 控制方块的发光等级
+     * Controls the light level of the block
      *
-     * @return 发光等级(0 - 15)
+     * @return Luminance Level (0 - 15)
      */
     public int getLightLevel() {
+        CustomBlockDefinition def = getCustomDefinition();
+        if (def != null) {
+            CompoundTag light = def.getComponents().getCompound("minecraft:light_emission");
+            if (light != null && light.contains("emission")) {
+                return light.getByte("emission");
+            }
+        }
+
         return 0;
     }
 
@@ -349,24 +372,97 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
         return false;
     }
 
+
     /**
-     * 控制方块是否透明(默认为false)
+     * Check if above space is greatner than 0.5 for chests
      *
-     * @return 方块是否透明
+     * @return Can chest be opened with the above space?
+     */
+public boolean hasFreeSpaceAbove() {
+    Block above = this.up();
+
+    System.out.println("[Chest] Checking space above block at " + this.getLocation());
+    System.out.println("[Chest] Block above: " + above.getName() + " (ID: " + above.getId() + ")");
+
+    if (above.isAir()) {
+        System.out.println("[Chest] Block above is air — allowed to open.");
+        return true;
+    }
+
+    AxisAlignedBB box = above.getCollisionBoundingBox();
+    if (box != null) {
+        double minY = box.getMinY();
+        double relativeMinY = minY - above.getY();
+        double maxY = box.getMaxY();
+        double relativeMaxY = maxY - above.getY();
+
+        System.out.println("[Chest] Collision box (absolute): minY = " + minY + ", maxY = " + maxY);
+        System.out.println("[Chest] Collision box (relative): minY = " + relativeMinY + ", maxY = " + relativeMaxY);
+        boolean allowed = relativeMinY >= 0.5;
+        System.out.println("[Chest] relativeMinY >= 0.5? " + allowed);
+        return allowed;
+    } else {
+        System.out.println("[Chest] No collision box — treating as blocking.");
+    }
+
+    return false;
+}
+
+
+    /**
+     * Controls whether the block is transparent (default is false)
+     *
+     * @return Is the block transparent?
      */
     public boolean isTransparent() {
         return false;
     }
 
+    //public boolean isSolid() {
+    //    return true;
+    //}
     public boolean isSolid() {
-        return true;
+        CustomBlockDefinition def = getCustomDefinition();
+        if (def != null) {
+            AxisAlignedBB box = def.getBoundingBox(this);
+            if (box != null) {
+                double height = box.getMaxY() - box.getMinY();
+                return height >= 0.999;
+            }
+        }
+
+        return true; // default for vanilla or unknown blocks
     }
 
     /**
      * Check if blocks can be attached in the given side.
      */
+    //public boolean isSolid(BlockFace side) {
+    //    return isSideFull(side);
+    //}
     public boolean isSolid(BlockFace side) {
-        return isSideFull(side);
+        CustomBlockDefinition def = getCustomDefinition();
+        if (def != null) {
+            AxisAlignedBB box = def.getBoundingBox(this);
+            if (box != null) {
+                switch (side) {
+                    case UP -> {
+                        double height = box.getMaxY() - box.getMinY();
+                        return height >= 0.999;
+                    }
+                    case DOWN -> {
+                        double base = box.getMinY();
+                        return base <= 0.001;
+                    }
+                    // You can extend to X and Z sides too if needed.
+                    default -> {
+                        return true;
+                    }
+                }
+            }
+        }
+
+    return isSideFull(side); // fallback to default solid-side check
     }
 
     // https://minecraft.wiki/w/Opacity#Lighting
@@ -677,18 +773,18 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
     }
 
     /**
-     * 计算方块挖掘时间
+     * Calculating block mining time
      *
-     * @param item   挖掘该方块的物品
-     * @param player 挖掘该方块的玩家
-     * @return 方块的挖掘时间
+     * @param item   Mining items from this block
+     * @param player The player who mined the block
+     * @return Mining time of blocks
      */
     public double calculateBreakTime(@NotNull Item item, @Nullable Player player) {
         double seconds = this.calculateBreakTimeNotInAir(item, player);
 
         if (player != null) {
-            //玩家距离上次在空中过去5tick之后，才认为玩家是在地上挖掘。
-            //如果单纯用onGround检测，这个方法返回的时间将会不连续。
+            // The player is considered to be digging on the ground only after 5 ticks have passed since the last time the player was in the air.
+            // If you only use onGround detection, the time returned by this method will be discontinuous.
             if (player.getLevel().getTick() - player.getLastInAirTick() < 5) {
                 seconds *= 5;
             }
@@ -697,11 +793,11 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
     }
 
     /**
-     * 忽略玩家在空中时，计算方块的挖掘时间
+     * Ignore when the player is in the air when calculating the mining time of the block
      *
-     * @param item   挖掘该方块的物品
-     * @param player 挖掘该方块的玩家
-     * @return 方块的挖掘时间
+     * @param item   Mining items from this block
+     * @param player The player who mined the block
+     * @return Mining time of blocks
      */
     public double calculateBreakTimeNotInAir(@NotNull Item item, @Nullable Player player) {
         double seconds;
@@ -761,8 +857,32 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
         return seconds;
     }
 
-    public boolean canBeBrokenWith(Item item) {
+    /**
+     * Checks if the block can be destroyed by mining with a specific item.
+     */
+    public boolean canBeMinedWith(Item item) {
+        CustomBlockDefinition def = getCustomDefinition();
+        if (def != null) {
+            CompoundTag mining = def.getComponents().getCompound("minecraft:destructible_by_mining");
+            if (mining != null && mining.contains("value")) {
+                float secondsToDestroy = mining.getFloat("value");
+                return secondsToDestroy != -1f;
+            }
+        }
         return this.getHardness() != -1;
+    }
+
+    /**
+     * Checks if the block can be destroyed by explosions.
+     */
+    public boolean canBeExploded() {
+        CustomBlockDefinition def = getCustomDefinition();
+        if (def != null) {
+            CompoundTag resistance = def.getComponents().getCompound("minecraft:destructible_by_explosion");
+            int resistanceValue = resistance.getInt("explosion_resistance");
+            return resistanceValue != -1;
+        }
+        return this.getResistance() != -1;
     }
 
     public Block getTickCachedSide(BlockFace face) {
@@ -937,15 +1057,26 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
         return true;
     }
 
-    public AxisAlignedBB getBoundingBox() {
-        return this.recalculateBoundingBox();
-    }
-
     public AxisAlignedBB getCollisionBoundingBox() {
         return this.recalculateCollisionBoundingBox();
     }
 
+    protected AxisAlignedBB recalculateCollisionBoundingBox() {
+        return getBoundingBox();
+    }
+
+    public AxisAlignedBB getBoundingBox() {
+        return this.recalculateBoundingBox();
+    }
+
     protected AxisAlignedBB recalculateBoundingBox() {
+        try {
+            CustomBlockDefinition def = getCustomDefinition();
+            if (def != null && def.getComponents().contains("minecraft:collision_box")) {
+                AxisAlignedBB box = def.getBoundingBox(this);
+                if (box != null) return box;
+            }
+        } catch (Exception ignored) {}
         return this;
     }
 
@@ -979,9 +1110,7 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
         return this.z + 1;
     }
 
-    protected AxisAlignedBB recalculateCollisionBoundingBox() {
-        return getBoundingBox();
-    }
+
 
     @Override
     public MovingObjectPosition calculateIntercept(Vector3 pos1, Vector3 pos2) {
@@ -1357,11 +1486,17 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
     }
 
     /**
-     * 控制方块吸收的光亮
-     *
-     * @return 方块吸收的光亮
+     * Controls the amount of light absorbed by the block
+     * @return Light absorbed by the block 0-15
      */
     public int getLightFilter() {
+        CustomBlockDefinition def = getCustomDefinition();
+        if (def != null) {
+            CompoundTag light = def.getComponents().getCompound("minecraft:light_dampening");
+            if (light != null && light.contains("lightLevel")) {
+                return light.getByte("lightLevel");
+            }
+        }
         return isSolid() && !isTransparent() ? 15 : 1;
     }
 
@@ -1421,6 +1556,14 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
         } else {
             return pos.level.setBlock(pos, this.layer, this.clone(), true, update);
         }
+    }
+
+    @Nullable
+    public CustomBlockDefinition getCustomDefinition() {
+        if (this instanceof CustomBlock customBlock) {
+            return BlockRegistry.getCustomBlockDefinitionByIdStatic(customBlock.getId());
+        }
+        return null;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -378,35 +378,24 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
      *
      * @return Can chest be opened with the above space?
      */
-public boolean hasFreeSpaceAbove() {
-    Block above = this.up();
+    public boolean hasFreeSpaceAbove() {
+        Block above = this.up();
 
-    System.out.println("[Chest] Checking space above block at " + this.getLocation());
-    System.out.println("[Chest] Block above: " + above.getName() + " (ID: " + above.getId() + ")");
+        if (above.isAir()) {
+            return true;
+        }
 
-    if (above.isAir()) {
-        System.out.println("[Chest] Block above is air — allowed to open.");
-        return true;
+        AxisAlignedBB box = above.getCollisionBoundingBox();
+        if (box != null) {
+            double minY = box.getMinY();
+            double relativeMinY = minY - above.getY();
+            boolean allowed = relativeMinY >= 0.5;
+
+            return allowed;
+        }
+
+        return false;
     }
-
-    AxisAlignedBB box = above.getCollisionBoundingBox();
-    if (box != null) {
-        double minY = box.getMinY();
-        double relativeMinY = minY - above.getY();
-        double maxY = box.getMaxY();
-        double relativeMaxY = maxY - above.getY();
-
-        System.out.println("[Chest] Collision box (absolute): minY = " + minY + ", maxY = " + maxY);
-        System.out.println("[Chest] Collision box (relative): minY = " + relativeMinY + ", maxY = " + relativeMaxY);
-        boolean allowed = relativeMinY >= 0.5;
-        System.out.println("[Chest] relativeMinY >= 0.5? " + allowed);
-        return allowed;
-    } else {
-        System.out.println("[Chest] No collision box — treating as blocking.");
-    }
-
-    return false;
-}
 
 
     /**
@@ -464,16 +453,6 @@ public boolean hasFreeSpaceAbove() {
 
     return isSideFull(side); // fallback to default solid-side check
     }
-
-
-
-
-
-
-
-
-
-
 
     // https://minecraft.wiki/w/Opacity#Lighting
     public boolean diffusesSkyLight() {

--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -465,6 +465,16 @@ public boolean hasFreeSpaceAbove() {
     return isSideFull(side); // fallback to default solid-side check
     }
 
+
+
+
+
+
+
+
+
+
+
     // https://minecraft.wiki/w/Opacity#Lighting
     public boolean diffusesSkyLight() {
         return false;

--- a/src/main/java/cn/nukkit/block/BlockChest.java
+++ b/src/main/java/cn/nukkit/block/BlockChest.java
@@ -215,8 +215,7 @@ public class BlockChest extends BlockTransparent implements Faceable, BlockEntit
         Item itemInHand = player.getInventory().getItemInHand();
         if (player.isSneaking() && !(itemInHand.isTool() || itemInHand.isNull())) return false;
 
-        Block top = up();
-        if (!top.isTransparent()) {
+        if (!this.hasFreeSpaceAbove()) {
             return false;
         }
 

--- a/src/main/java/cn/nukkit/block/BlockEnderChest.java
+++ b/src/main/java/cn/nukkit/block/BlockEnderChest.java
@@ -133,8 +133,7 @@ public class BlockEnderChest extends BlockTransparent implements Faceable, Block
     public boolean onActivate(@NotNull Item item, Player player, BlockFace blockFace, float fx, float fy, float fz) {
         if(isNotActivate(player)) return false;
 
-        Block top = this.up();
-        if (!top.isTransparent()) {
+        if (!this.hasFreeSpaceAbove()) {
             return false;
         }
 

--- a/src/main/java/cn/nukkit/block/BlockTrapdoor.java
+++ b/src/main/java/cn/nukkit/block/BlockTrapdoor.java
@@ -254,7 +254,11 @@ public class BlockTrapdoor extends BlockTransparent implements RedstoneComponent
     }
 
     public void playOpenCloseSound() {
-        if (isOpen()) playOpenSound(); else playCloseSound();
+        if (isOpen()) {
+            playOpenSound();
+        } else {
+            playCloseSound();
+        }
     }
 
     public void playOpenSound() {

--- a/src/main/java/cn/nukkit/block/BlockTrapdoor.java
+++ b/src/main/java/cn/nukkit/block/BlockTrapdoor.java
@@ -25,12 +25,11 @@ import org.jetbrains.annotations.NotNull;
 import javax.annotation.Nullable;
 import java.util.Set;
 
-/**
- * @author Pub4Game
- * @since 26.12.2015
- */
 public class BlockTrapdoor extends BlockTransparent implements RedstoneComponent, Faceable {
-    public static final BlockProperties PROPERTIES = new BlockProperties(TRAPDOOR, CommonBlockProperties.DIRECTION, CommonBlockProperties.OPEN_BIT, CommonBlockProperties.UPSIDE_DOWN_BIT);
+    public static final BlockProperties PROPERTIES = new BlockProperties(TRAPDOOR,
+            CommonBlockProperties.DIRECTION,
+            CommonBlockProperties.OPEN_BIT,
+            CommonBlockProperties.UPSIDE_DOWN_BIT);
 
     private static final double THICKNESS = 0.1875;
 
@@ -39,58 +38,6 @@ public class BlockTrapdoor extends BlockTransparent implements RedstoneComponent
     // previously the door always closed, when placing an unpowered redstone at the door, this fixes it
     // and gives the vanilla behavior; no idea how to make this better :d
     private static final Set<Location> manualOverrides = Sets.newConcurrentHashSet();
-
-    private static final AxisAlignedBB[] boundingBox2SpecialV = new AxisAlignedBB[0x1 << PROPERTIES.getSpecialValueBits()];
-
-    //<editor-fold desc="pre-computing the bounding boxes" defaultstate="collapsed">
-    static {
-        for (int specialValue = 0; specialValue < boundingBox2SpecialV.length; specialValue++) {
-            AxisAlignedBB bb;
-            if (PROPERTIES.getPropertyValue(specialValue, CommonBlockProperties.OPEN_BIT)) {
-                BlockFace face = CommonPropertyMap.EWSN_DIRECTION.inverse().get(PROPERTIES.getPropertyValue(specialValue, CommonBlockProperties.DIRECTION));
-                face = face.getOpposite();
-                if (face.getAxisDirection() == AxisDirection.NEGATIVE) {
-                    bb = new SimpleAxisAlignedBB(
-                            0,
-                            0,
-                            0,
-                            1 + face.getXOffset() - (THICKNESS * face.getXOffset()),
-                            1,
-                            1 + face.getZOffset() - (THICKNESS * face.getZOffset())
-                    );
-                } else {
-                    bb = new SimpleAxisAlignedBB(
-                            face.getXOffset() - (THICKNESS * face.getXOffset()),
-                            0,
-                            face.getZOffset() - (THICKNESS * face.getZOffset()),
-                            1,
-                            1,
-                            1
-                    );
-                }
-            } else if (PROPERTIES.getPropertyValue(specialValue, CommonBlockProperties.UPSIDE_DOWN_BIT)) {
-                bb = new SimpleAxisAlignedBB(
-                        0,
-                        1 - THICKNESS,
-                        0,
-                        1,
-                        1,
-                        1
-                );
-            } else {
-                bb = new SimpleAxisAlignedBB(
-                        0,
-                        0,
-                        0,
-                        1,
-                        0 + THICKNESS,
-                        1
-                );
-            }
-            boundingBox2SpecialV[specialValue] = bb;
-        }
-    }
-    //</editor-fold>
 
     public BlockTrapdoor() {
         this(PROPERTIES.getDefaultState());
@@ -136,10 +83,6 @@ public class BlockTrapdoor extends BlockTransparent implements RedstoneComponent
         return 1;
     }
 
-    private AxisAlignedBB getRelativeBoundingBox() {
-        return boundingBox2SpecialV[this.blockstate.specialValue()];
-    }
-
     @Override
     public double getMinX() {
         return this.x + getRelativeBoundingBox().getMinX();
@@ -170,21 +113,59 @@ public class BlockTrapdoor extends BlockTransparent implements RedstoneComponent
         return this.z + getRelativeBoundingBox().getMaxZ();
     }
 
+    private AxisAlignedBB getRelativeBoundingBox() {
+        int value = this.blockstate.specialValue();
+        BlockProperties props = getProperties();
+
+        boolean open = props.getPropertyValue(value, CommonBlockProperties.OPEN_BIT);
+        boolean top = props.getPropertyValue(value, CommonBlockProperties.UPSIDE_DOWN_BIT);
+
+        AxisAlignedBB aabb;
+
+        if (open) {
+            BlockFace face = CommonPropertyMap.EWSN_DIRECTION.inverse().get(
+                    props.getPropertyValue(value, CommonBlockProperties.DIRECTION)).getOpposite();
+
+            if (face.getAxisDirection() == AxisDirection.NEGATIVE) {
+                aabb = new SimpleAxisAlignedBB(
+                        0,
+                        0,
+                        0,
+                        1 + face.getXOffset() - (THICKNESS * face.getXOffset()),
+                        1,
+                        1 + face.getZOffset() - (THICKNESS * face.getZOffset())
+                );
+            } else {
+                aabb = new SimpleAxisAlignedBB(
+                        face.getXOffset() - (THICKNESS * face.getXOffset()),
+                        0,
+                        face.getZOffset() - (THICKNESS * face.getZOffset()),
+                        1,
+                        1,
+                        1
+                );
+            }
+        } else if (top) {
+            aabb = new SimpleAxisAlignedBB(0, 1 - THICKNESS, 0, 1, 1, 1);
+        } else {
+            aabb = new SimpleAxisAlignedBB(0, 0, 0, 1, THICKNESS, 1);
+        }
+
+        return aabb;
+    }
+
     @Override
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_REDSTONE && this.level.getServer().getSettings().gameplaySettings().enableRedstone()) {
             if ((this.isOpen() != this.isGettingPower()) && !this.getManualOverride()) {
-                if (this.isOpen() != this.isGettingPower()) {
-                    level.getServer().getPluginManager().callEvent(new BlockRedstoneEvent(this, this.isOpen() ? 15 : 0, this.isOpen() ? 0 : 15));
-
-                    this.setOpen(null, this.isGettingPower());
-                }
+                level.getServer().getPluginManager().callEvent(new BlockRedstoneEvent(this,
+                        this.isOpen() ? 15 : 0, this.isOpen() ? 0 : 15));
+                this.setOpen(null, this.isGettingPower());
             } else if (this.getManualOverride() && (this.isGettingPower() == this.isOpen())) {
                 this.setManualOverride(false);
             }
             return type;
         }
-
         return 0;
     }
 
@@ -207,7 +188,8 @@ public class BlockTrapdoor extends BlockTransparent implements RedstoneComponent
     }
 
     @Override
-    public boolean place(@NotNull Item item, @NotNull Block block, @NotNull Block target, @NotNull BlockFace face, double fx, double fy, double fz, @Nullable Player player) {
+    public boolean place(@NotNull Item item, @NotNull Block block, @NotNull Block target,
+                         @NotNull BlockFace face, double fx, double fy, double fz, @Nullable Player player) {
         setBlockFace(player == null ? face : player.getDirection().getOpposite());
         setTop(face.getAxis().isHorizontal() ? fy > 0.5 : face != BlockFace.UP);
 
@@ -215,7 +197,8 @@ public class BlockTrapdoor extends BlockTransparent implements RedstoneComponent
             return false;
         }
 
-        if (level.getServer().getSettings().gameplaySettings().enableRedstone() && !this.isOpen() && this.isGettingPower()) {
+        if (level.getServer().getSettings().gameplaySettings().enableRedstone() &&
+                !this.isOpen() && this.isGettingPower()) {
             this.setOpen(null, true);
         }
 
@@ -232,9 +215,8 @@ public class BlockTrapdoor extends BlockTransparent implements RedstoneComponent
     }
 
     public boolean toggle(Player player) {
-        if(player != null) {
-            if (!player.getAdventureSettings().get(AdventureSettings.Type.DOORS_AND_SWITCHED))
-                return false;
+        if (player != null && !player.getAdventureSettings().get(AdventureSettings.Type.DOORS_AND_SWITCHED)) {
+            return false;
         }
         return this.setOpen(player, !this.isOpen());
     }
@@ -252,10 +234,9 @@ public class BlockTrapdoor extends BlockTransparent implements RedstoneComponent
         }
 
         player = event.getPlayer();
-
         setPropertyValue(CommonBlockProperties.OPEN_BIT, open);
-        if (!level.setBlock(this, this, true, true))
-            return false;
+
+        if (!level.setBlock(this, this, true, true)) return false;
 
         if (player != null) {
             this.setManualOverride(this.isGettingPower() || isOpen());
@@ -264,17 +245,16 @@ public class BlockTrapdoor extends BlockTransparent implements RedstoneComponent
         playOpenCloseSound();
 
         var source = this.getVector3().add(0.5, 0.5, 0.5);
-        VibrationEvent vibrationEvent = open ? new VibrationEvent(player != null ? player : this, source, VibrationType.BLOCK_OPEN) : new VibrationEvent(player != null ? player : this, source, VibrationType.BLOCK_CLOSE);
+        VibrationEvent vibrationEvent = open
+                ? new VibrationEvent(player != null ? player : this, source, VibrationType.BLOCK_OPEN)
+                : new VibrationEvent(player != null ? player : this, source, VibrationType.BLOCK_CLOSE);
+
         this.level.getVibrationManager().callVibrationEvent(vibrationEvent);
         return true;
     }
 
     public void playOpenCloseSound() {
-        if (isOpen()) {
-            playOpenSound();
-        } else {
-            playCloseSound();
-        }
+        if (isOpen()) playOpenSound(); else playCloseSound();
     }
 
     public void playOpenSound() {

--- a/src/main/java/cn/nukkit/block/customblock/CustomBlockUtils.java
+++ b/src/main/java/cn/nukkit/block/customblock/CustomBlockUtils.java
@@ -1,0 +1,204 @@
+package cn.nukkit.block.customblock;
+
+import cn.nukkit.block.Block;
+import cn.nukkit.block.BlockProperties;
+import cn.nukkit.block.property.CommonBlockProperties;
+import cn.nukkit.block.property.enums.MinecraftCardinalDirection;
+import cn.nukkit.math.AxisAlignedBB;
+import cn.nukkit.math.BlockFace;
+import cn.nukkit.math.SimpleAxisAlignedBB;
+import cn.nukkit.math.Vector3f;
+import cn.nukkit.nbt.tag.CompoundTag;
+import cn.nukkit.nbt.tag.FloatTag;
+import cn.nukkit.nbt.tag.ListTag;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public final class CustomBlockUtils {
+
+    private CustomBlockUtils() {}
+
+    public static @Nullable AxisAlignedBB getBoundingBox(CustomBlockDefinition def, Block block) {
+        CompoundTag components = def.getComponents();
+        if (!components.contains("minecraft:collision_box")) {
+            return null;
+        }
+
+        float[] origin = readVector(components, "origin");
+        float[] size = readVector(components, "size");
+        if (origin == null || size == null) return null;
+
+        // Bedrock origin/size is in pixels converted to block coordinates (0-1)
+        float[] normOrigin = new float[3];
+        float[] normSize = new float[3];
+        for (int i = 0; i < 3; i++) {
+            normOrigin[i] = origin[i] / 16f;
+            normSize[i] = size[i] / 16f;
+        }
+
+        float[] rotation = getRotation(block);
+        float rotX = rotation[0], rotY = rotation[1];
+        Vector3f[] corners = buildAndRotateBoxCorners(normOrigin, normSize, rotX, rotY);
+        float[] bounds = calculateBounds(corners);
+
+        // Clamp bounds to [0, 1]
+        for (int i = 0; i < 3; i++) {
+            if (bounds[i] < 0f) {
+                float delta = -bounds[i];
+                bounds[i] = 0f;
+                bounds[i + 3] += delta;
+            }
+            if (bounds[i + 3] > 1f) {
+                float delta = bounds[i + 3] - 1f;
+                bounds[i + 3] = 1f;
+                bounds[i] -= delta;
+            }
+        }
+
+        double x = block.x, y = block.y, z = block.z;
+        double x1 = x + bounds[0];
+        double y1 = y + bounds[1];
+        double z1 = z + bounds[2];
+        double x2 = x + bounds[3];
+        double y2 = y + bounds[4];
+        double z2 = z + bounds[5];
+
+        return new SimpleAxisAlignedBB(x1, y1, z1, x2, y2, z2);
+    }
+
+    public static boolean isSolidForBlock(CustomBlockDefinition def, @NotNull Block block) {
+        AxisAlignedBB box = getBoundingBox(def, block);
+        if (box == null) return true;
+        double height = box.getMaxY() - box.getMinY();
+        return height >= 0.99;
+    }
+
+    private static float[] readVector(CompoundTag components, String key) {
+        CompoundTag collision = components.getCompound("minecraft:collision_box");
+        ListTag<FloatTag> tagList = collision.getList(key, FloatTag.class);
+        if (tagList.size() < 3) return null;
+        return new float[]{ tagList.get(0).data, tagList.get(1).data, tagList.get(2).data };
+    }
+
+    private static float[] getRotation(Block block) {
+        BlockFace facing = BlockFace.NORTH;
+        MinecraftCardinalDirection cardinal = MinecraftCardinalDirection.NORTH;
+        BlockProperties props = block.getProperties();
+
+        boolean hasFacing = props.getPropertyTypeSet().contains(CommonBlockProperties.MINECRAFT_FACING_DIRECTION);
+        boolean hasCardinal = props.getPropertyTypeSet().contains(CommonBlockProperties.MINECRAFT_CARDINAL_DIRECTION);
+
+        if (hasFacing) {
+            facing = block.getPropertyValue(CommonBlockProperties.MINECRAFT_FACING_DIRECTION);
+        }
+        if (hasCardinal) {
+            cardinal = block.getPropertyValue(CommonBlockProperties.MINECRAFT_CARDINAL_DIRECTION);
+        }
+
+        float rotX = 0f;
+        float rotY = 0f;
+
+        if (hasFacing) {
+            switch (facing) {
+                case NORTH -> rotY = 0f;
+                case SOUTH -> rotY = 180f;
+                case EAST  -> rotY = -90f;
+                case WEST  -> rotY = 90f;
+                case UP -> {
+                    rotX = 270f;
+                    if (hasCardinal) {
+                        switch (cardinal) {
+                            case NORTH -> rotY = 0f;
+                            case SOUTH -> rotY = 180f;
+                            case EAST -> rotY = -90f;
+                            case WEST -> rotY = 90f;
+                        }
+                    }
+                }
+                case DOWN -> {
+                    rotX = -270f;
+                    if (hasCardinal) {
+                        switch (cardinal) {
+                            case NORTH -> rotY = 0f;
+                            case SOUTH -> rotY = 180f;
+                            case EAST -> rotY = -90f;
+                            case WEST -> rotY = 90f;
+                        }
+                    }
+                }
+            }
+        } else if (hasCardinal) {
+            // Fallback: use cardinal for horizontal rotation if no facing is present
+            switch (cardinal) {
+                case NORTH -> rotY = 0f;
+                case SOUTH -> rotY = 180f;
+                case EAST  -> rotY = -90f;
+                case WEST  -> rotY = 90f;
+            }
+        }
+        // else: default rotY = 0 (north)
+
+        return new float[]{ rotX, rotY };
+    }
+
+    private static Vector3f[] buildAndRotateBoxCorners(float[] normOrigin, float[] normSize, float rotX, float rotY) {
+        Vector3f[] corners = new Vector3f[8];
+        int idx = 0;
+        // Build 8 corners relative to block center
+        for (int dx = 0; dx <= 1; dx++) {
+            for (int dy = 0; dy <= 1; dy++) {
+                for (int dz = 0; dz <= 1; dz++) {
+                    float px = normOrigin[0] + dx * normSize[0];
+                    float py = normOrigin[1] + dy * normSize[1];
+                    float pz = normOrigin[2] + dz * normSize[2];
+                    // Shift to block-space: add 0.5 to rotate around center
+                    Vector3f local = new Vector3f(px + 0.5f, py + 0.5f, pz + 0.5f);
+                    // Rotate around center (0.5,0.5,0.5)
+                    Vector3f centered = new Vector3f(local.x - 0.5f, local.y - 0.5f, local.z - 0.5f);
+                    Vector3f rotated = rotateBlock(centered, rotX, rotY, 0f);
+                    corners[idx++] = new Vector3f(rotated.x + 0.5f, rotated.y + 0.5f, rotated.z + 0.5f);
+                }
+            }
+        }
+        return corners;
+    }
+
+    private static float[] calculateBounds(Vector3f[] corners) {
+        float minX = Float.MAX_VALUE, minY = Float.MAX_VALUE, minZ = Float.MAX_VALUE;
+        float maxX = -Float.MAX_VALUE, maxY = -Float.MAX_VALUE, maxZ = -Float.MAX_VALUE;
+        for (Vector3f v : corners) {
+            minX = Math.min(minX, v.x);
+            minY = Math.min(minY, v.y);
+            minZ = Math.min(minZ, v.z);
+            maxX = Math.max(maxX, v.x);
+            maxY = Math.max(maxY, v.y);
+            maxZ = Math.max(maxZ, v.z);
+        }
+        return new float[]{ minX, minY, minZ, maxX, maxY, maxZ };
+    }
+
+    // Rotates a point (relative to block center) by angleX, angleY, angleZ (in degrees)
+    private static Vector3f rotateBlock(Vector3f point, float angleX, float angleY, float angleZ) {
+        float radX = (float) Math.toRadians(angleX);
+        float radY = (float) Math.toRadians(angleY);
+        float radZ = (float) Math.toRadians(angleZ);
+
+        float x = point.x;
+        float y = point.y;
+        float z = point.z;
+
+        // X-axis rotation
+        float y1 = y * (float) Math.cos(radX) - z * (float) Math.sin(radX);
+        float z1 = y * (float) Math.sin(radX) + z * (float) Math.cos(radX);
+
+        // Y-axis rotation
+        float x2 = x * (float) Math.cos(radY) + z1 * (float) Math.sin(radY);
+        float z2 = -x * (float) Math.sin(radY) + z1 * (float) Math.cos(radY);
+
+        // Z-axis rotation
+        float x3 = x2 * (float) Math.cos(radZ) - y1 * (float) Math.sin(radZ);
+        float y3 = x2 * (float) Math.sin(radZ) + y1 * (float) Math.cos(radZ);
+
+        return new Vector3f(x3, y3, z2);
+    }
+}

--- a/src/main/java/cn/nukkit/block/customblock/CustomBlockUtils.java
+++ b/src/main/java/cn/nukkit/block/customblock/CustomBlockUtils.java
@@ -36,9 +36,6 @@ public final class CustomBlockUtils {
             normSize[i] = size[i] / 16f;
         }
 
-        //float[] rotation = getRotation(block);
-        //float rotX = rotation[0], rotY = rotation[1];
-        //Vector3f[] corners = buildAndRotateBoxCorners(normOrigin, normSize, rotX, rotY);
         RotationResult rotation = getRotation(block);
         Vector3f[] corners = buildAndRotateBoxCorners(normOrigin, normSize, rotation.rotX, rotation.rotY, rotation.isVerticalRotated);
         float[] bounds = calculateBounds(corners);

--- a/src/main/java/cn/nukkit/block/customblock/data/Materials.java
+++ b/src/main/java/cn/nukkit/block/customblock/data/Materials.java
@@ -7,9 +7,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Locale;
 
 /**
- * 用于将方块的face(面)映射到实际的材质实例,并且设置渲染方法和参数
- * <p>
- * Used to map the face of a block to a material instance, and set the rendering method and parameters.
+ * Used to map the face of the block to the actual material instance and set the rendering method and parameters
  */
 
 
@@ -50,14 +48,12 @@ public class Materials implements NBTData {
     }
 
     /**
-     * 指定up面对应的渲染方法、渲染参数和材质。
-     * <p>
      * Specify the corresponding rendering method, rendering parameters and texture's name for the up face. tintType=null
      *
-     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
-     * @param texture          指定up方向的材质名称<br>Specify the texture's name of the up face
-     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
-     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param renderMethod     Rendering method to be used
+     * @param texture          Specify the texture's name of the up face
+     * @param ambientOcclusion Should I apply ambient light shielding when lighting?
+     * @param faceDimming      Should it be dimmed according to the direction it is facing?
      * @return the materials
      */
     public Materials up(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
@@ -66,14 +62,12 @@ public class Materials implements NBTData {
     }
 
     /**
-     * 指定up面对应的渲染方法、渲染参数和材质。
-     * <p>
      * Specify the corresponding rendering method, rendering parameters and texture's name for the up face.
      *
-     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
-     * @param texture          指定up方向的材质名称<br>Specify the texture's name of the up face
-     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
-     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param renderMethod     Rendering method to be used
+     * @param texture          Specify the texture's name of the up face
+     * @param ambientOcclusion Should I apply ambient light shielding when lighting?
+     * @param faceDimming      Should it be dimmed according to the direction it is facing?
      * @param tintType         Set tintint method for the block
      * @return the materials
      */
@@ -104,14 +98,12 @@ public class Materials implements NBTData {
     }
 
     /**
-     * 指定down面对应的渲染方法、渲染参数和材质。
-     * <p>
      * Specify the corresponding rendering method, rendering parameters and texture's name for the down face. tintType=null
      *
-     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
-     * @param texture          指定down方向的材质名称<br>Specify the texture's name of the down face
-     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
-     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param renderMethod     Rendering method to be used
+     * @param texture          指定down方向的Specify the texture's name of the down face
+     * @param ambientOcclusion Should I apply ambient light shielding when lighting?
+     * @param faceDimming      Should it be dimmed according to the direction it is facing?
      * @return the materials
      */
     public Materials down(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
@@ -120,14 +112,12 @@ public class Materials implements NBTData {
     }
 
     /**
-     * 指定down面对应的渲染方法、渲染参数和材质。
-     * <p>
      * Specify the corresponding rendering method, rendering parameters and texture's name for the down face.
      *
-     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
-     * @param texture          指定down方向的材质名称<br>Specify the texture's name of the down face
-     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
-     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param renderMethod     Rendering method to be used
+     * @param texture          指定down方向的Specify the texture's name of the down face
+     * @param ambientOcclusion Should I apply ambient light shielding when lighting?
+     * @param faceDimming      Should it be dimmed according to the direction it is facing?
      * @param tintType         Set tintint method for the block
      * @return the materials
      */
@@ -157,14 +147,12 @@ public class Materials implements NBTData {
     }
 
     /**
-     * 指定north面对应的渲染方法、渲染参数和材质。
-     * <p>
      * Specify the corresponding rendering method, rendering parameters and texture's name for the north face. tintType=null
      *
-     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
-     * @param texture          指定north方向的材质名称<br>Specify the texture's name of the north face
-     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
-     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param renderMethod     Rendering method to be used
+     * @param texture          Specify the texture's name of the north face
+     * @param ambientOcclusion Should I apply ambient light shielding when lighting?
+     * @param faceDimming      Should it be dimmed according to the direction it is facing?
      * @return the materials
      */
     public Materials north(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
@@ -173,14 +161,12 @@ public class Materials implements NBTData {
     }
 
     /**
-     * 指定north面对应的渲染方法、渲染参数和材质。
-     * <p>
      * Specify the corresponding rendering method, rendering parameters and texture's name for the north face.
      *
-     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
-     * @param texture          指定north方向的材质名称<br>Specify the texture's name of the north face
-     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
-     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param renderMethod     Rendering method to be used
+     * @param texture          Specify the texture's name of the north face
+     * @param ambientOcclusion Should I apply ambient light shielding when lighting?
+     * @param faceDimming      Should it be dimmed according to the direction it is facing?
      * @param tintType         Set tintint method for the block
      * @return the materials
      */
@@ -210,14 +196,12 @@ public class Materials implements NBTData {
     }
 
     /**
-     * 指定south面对应的渲染方法、渲染参数和材质。
-     * <p>
      * Specify the corresponding rendering method, rendering parameters and texture's name for the south face. tintType=null
      *
-     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
-     * @param texture          指定south方向的材质名称<br>Specify the texture's name of the south face
-     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
-     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param renderMethod     Rendering method to be used
+     * @param texture          Specify the texture's name of the south face
+     * @param ambientOcclusion Should I apply ambient light shielding when lighting?
+     * @param faceDimming      Should it be dimmed according to the direction it is facing?
      * @return the materials
      */
     public Materials south(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
@@ -226,14 +210,12 @@ public class Materials implements NBTData {
     }
 
     /**
-     * 指定south面对应的渲染方法、渲染参数和材质。
-     * <p>
      * Specify the corresponding rendering method, rendering parameters and texture's name for the south face.
      *
-     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
-     * @param texture          指定south方向的材质名称<br>Specify the texture's name of the south face
-     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
-     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param renderMethod     Rendering method to be used
+     * @param texture          Specify the texture's name of the south face
+     * @param ambientOcclusion Should I apply ambient light shielding when lighting?
+     * @param faceDimming      Should it be dimmed according to the direction it is facing?
      * @param tintType         Set tintint method for the block
      * @return the materials
      */
@@ -264,14 +246,12 @@ public class Materials implements NBTData {
     }
 
     /**
-     * 指定east面对应的渲染方法、渲染参数和材质。
-     * <p>
      * Specify the corresponding rendering method, rendering parameters and texture's name for the east face. tintType=null
      *
-     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
-     * @param texture          指定east方向的材质名称<br>Specify the texture's name of the east face
-     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
-     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param renderMethod     Rendering method to be used
+     * @param texture          Specify the texture's name of the east face
+     * @param ambientOcclusion Should I apply ambient light shielding when lighting?
+     * @param faceDimming      Should it be dimmed according to the direction it is facing?
      * @return the materials
      */
     public Materials east(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
@@ -280,14 +260,12 @@ public class Materials implements NBTData {
     }
 
     /**
-     * 指定east面对应的渲染方法、渲染参数和材质。
-     * <p>
      * Specify the corresponding rendering method, rendering parameters and texture's name for the east face.
      *
-     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
-     * @param texture          指定east方向的材质名称<br>Specify the texture's name of the east face
-     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
-     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param renderMethod     Rendering method to be used
+     * @param texture          Specify the texture's name of the east face
+     * @param ambientOcclusion Should I apply ambient light shielding when lighting?
+     * @param faceDimming      Should it be dimmed according to the direction it is facing?
      * @param tintType         Set tintint method for the block
      * @return the materials
      */
@@ -317,14 +295,12 @@ public class Materials implements NBTData {
     }
 
     /**
-     * 指定west面对应的渲染方法、渲染参数和材质。
-     * <p>
      * Specify the corresponding rendering method, rendering parameters and texture's name for the west face. tintType=null
      *
-     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
-     * @param texture          指定west方向的材质名称<br>Specify the texture's name of the west face
-     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
-     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param renderMethod     Rendering method to be used
+     * @param texture          指定west方向的Specify the texture's name of the west face
+     * @param ambientOcclusion Should I apply ambient light shielding when lighting?
+     * @param faceDimming      Should it be dimmed according to the direction it is facing?
      * @return the materials
      */
     public Materials west(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
@@ -333,14 +309,12 @@ public class Materials implements NBTData {
     }
 
     /**
-     * 指定west面对应的渲染方法、渲染参数和材质。
-     * <p>
      * Specify the corresponding rendering method, rendering parameters and texture's name for the west face.
      *
-     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
-     * @param texture          指定west方向的材质名称<br>Specify the texture's name of the west face
-     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
-     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param renderMethod     Rendering method to be used
+     * @param texture          指定west方向的Specify the texture's name of the west face
+     * @param ambientOcclusion Should I apply ambient light shielding when lighting?
+     * @param faceDimming      Should it be dimmed according to the direction it is facing?
      * @param tintType         Set tintint method for the block
      * @return the materials
      */
@@ -371,14 +345,12 @@ public class Materials implements NBTData {
     }
 
     /**
-     * 指定所有面对应的渲染方法、渲染参数和材质。
-     * <p>
      * Specify all corresponding rendering method, rendering parameters and texture name. tintType=null
      *
-     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
-     * @param texture          材质名称<br>Specify the texture's name
-     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
-     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param renderMethod     Rendering method to be used
+     * @param texture          Specify the texture's name
+     * @param ambientOcclusion Should I apply ambient light shielding when lighting?
+     * @param faceDimming      Should it be dimmed according to the direction it is facing?
      * @return the materials
      */
     public Materials any(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture) {
@@ -387,14 +359,12 @@ public class Materials implements NBTData {
     }
 
     /**
-     * 指定所有面对应的渲染方法、渲染参数和材质。
-     * <p>
      * Specify all corresponding rendering method, rendering parameters and texture name.
      *
-     * @param renderMethod     要使用的渲染方法<br>Rendering method to be used
-     * @param texture          材质名称<br>Specify the texture's name
-     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should I apply ambient light shielding when lighting?
-     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
+     * @param renderMethod     Rendering method to be used
+     * @param texture          Specify the texture's name
+     * @param ambientOcclusion Should I apply ambient light shielding when lighting?
+     * @param faceDimming      Should it be dimmed according to the direction it is facing?
      * @return the materials
      */
     public Materials any(RenderMethod renderMethod, boolean ambientOcclusion, boolean faceDimming, String texture, String tintType) {
@@ -403,14 +373,15 @@ public class Materials implements NBTData {
     }
 
     /**
-     * 指定对应对应的渲染方法、渲染参数和材质。此方法是完全自定义的，请在使用之前抓包确认参数合法性
+     * Specify the corresponding rendering method, rendering parameters and materials.<p>
+     * This method is completely customized. Please capture the package to confirm the legality of the parameters before using it.
      *
-     * @param face             指定面的名称，可选值为：up, down, north, south, east, west, *
-     * @param ambientOcclusion 在照明时是否应该应用环境光遮蔽?<br>Should it be applied ambient light shielding when lighting?
-     * @param faceDimming      是否应该根据它所面对的方向变暗?<br>Should it be dimmed according to the direction it is facing?
-     * @param renderMethodName 要使用的渲染方法<br>Rendering method to be used
-     * @param texture          材质名称<br>Specify the texture's name
-     * @param tintType         材质名称<br>Specify the tinting type
+     * @param face             Specifies the name of the face. The optional value is：up, down, north, south, east, west, *
+     * @param ambientOcclusion Should it be applied ambient light shielding when lighting?
+     * @param faceDimming      Should it be dimmed according to the direction it is facing?
+     * @param renderMethodName Rendering method to be used
+     * @param texture          Specify the texture's name
+     * @param tintType         Specify the tinting type
      */
     public void process(
         @NotNull String face,
@@ -457,16 +428,20 @@ public class Materials implements NBTData {
     }
 
     /**
-     * 渲染方法枚举
+     * Render methods and their properties:<p>
      * <p>
-     * The enum Render method.
-     *
-     * @see <a href="https://wiki.bedrock.dev/blocks/blocks-16.html#additional-notes">wiki.bedrock.dev</a>
+     * OPAQUE (default)        >> Transparency No | Translucency No | Backface Culling Yes | Distant Culling No | Ex: Dirt, Stone, Concrete<p>
+     * BLEND                   >> Transparency Yes | Translucency Yes | Backface Culling Yes | Distant Culling No | Ex: Glass, Beacon, Honey Block<p>
+     * DOUBLE_SIDED            >> Transparency No | Translucency No | Backface Culling No | Distant Culling No | Ex: Powder Snow<p>
+     * ALPHA_TEST              >> Transparency Yes | Translucency No | Backface Culling No | Distant Culling Yes | Ex: Ladder, Monster Spawner, Vines<p>
+     * ALPHA_TEST_SINGLE_SIDED >> Transparency Yes | Translucency No | Backface Culling Yes | Distant Culling Yes | Ex: Doors, Saplings, Trapdoors<p>
+     * @see <a href="https://wiki.bedrock.dev/blocks/blocks-16.html#additional-notes">wiki.bedrock.dev</a><p>
      */
     public enum RenderMethod {
         OPAQUE,
-        ALPHA_TEST,
         BLEND,
-        DOUBLE_SIDED
+        DOUBLE_SIDED,
+        ALPHA_TEST,
+        ALPHA_TEST_SINGLE_SIDED
     }
 }

--- a/src/main/java/cn/nukkit/entity/EntityLiving.java
+++ b/src/main/java/cn/nukkit/entity/EntityLiving.java
@@ -57,6 +57,11 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
     }
 
     @Override
+    protected double getStepHeight() {
+        return 0.5;
+    }
+
+    @Override
     protected void initEntity() {
         super.initEntity();
 

--- a/src/main/java/cn/nukkit/entity/EntityPhysical.java
+++ b/src/main/java/cn/nukkit/entity/EntityPhysical.java
@@ -20,23 +20,23 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public abstract class EntityPhysical extends EntityCreature implements EntityAsyncPrepare {
     /**
-     * 移动精度阈值，绝对值小于此阈值的移动被视为没有移动
+     * Movement accuracy threshold. Movements with an absolute value less than this threshold are considered as no movement.
      */
     public static final float PRECISION = 0.00001f;
 
     public static final AtomicInteger globalCycleTickSpread = new AtomicInteger();
     /**
-     * 时间泛播延迟，用于缓解在同一时间大量提交任务挤占cpu的情况
+     * Time flooding delay is used to alleviate the situation where a large number of tasks are submitted at the same time and occupy the CPU.
      */
     public final int tickSpread;
     /**
-     * 提供实时最新碰撞箱位置
+     * Provide real-time latest collision box position
      */
     protected final AxisAlignedBB offsetBoundingBox;
     protected final Vector3 previousCollideMotion;
     protected final Vector3 previousCurrentMotion;
     /**
-     * 实体自由落体运动的时间
+     * The time of free fall of an object
      */
     protected int fallingTick = 0;
     protected boolean needsRecalcMovement = true;
@@ -52,15 +52,15 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
 
     @Override
     public void asyncPrepare(int currentTick) {
-        // 计算是否需要重新计算高开销实体运动
+        // Calculates whether expensive entity motion needs to be recalculated
         this.needsRecalcMovement = this.level.tickRateOptDelay == 1 || ((currentTick + tickSpread) & (this.level.tickRateOptDelay - 1)) == 0;
-        // 重新计算绝对位置碰撞箱
+        // Recalculate absolute position collision box
         this.calculateOffsetBoundingBox();
         if (!this.isImmobile()) {
-            // 处理重力
+            // Dealing with gravity
             handleGravity();
             if (needsRecalcMovement) {
-                // 处理碰撞箱挤压运动
+                // Handling collision box extrusion movement
                 handleCollideMovement(currentTick);
             }
             addTmpMoveMotionXZ(previousCollideMotion);
@@ -72,11 +72,11 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
 
     @Override
     public boolean onUpdate(int currentTick) {
-        // 记录最大高度，用于计算坠落伤害
+        // Record the maximum height for calculating fall damage
         if (!this.onGround && this.y > highestPosition) {
             this.highestPosition = this.y;
         }
-        // 添加挤压伤害
+        // Added crush damage
         if (needsCollisionDamage) {
             this.attack(new EntityDamageEvent(this, EntityDamageEvent.DamageCause.COLLIDE, 3));
         }
@@ -117,7 +117,7 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
 
     @Override
     public void updateMovement() {
-        // 检测自由落体时间
+        // Detection of free fall time
         if (isFalling()) {
             this.fallingTick++;
         }
@@ -141,52 +141,54 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
     }
 
     protected void handleGravity() {
-        //重力一直存在
+        // Gravity is always there
         this.motionY -= this.getGravity();
         if (!this.onGround && this.hasWaterAt(getFootHeight())) {
-            //落地水
+            // Landing water
             resetFallDistance();
         }
     }
 
     /**
-     * 计算地面摩擦力
+     * Calculating ground friction
      */
 
     protected void handleGroundFrictionMovement() {
-        //未在地面就没有地面阻力
+        // No ground resistance
         if (!this.onGround) return;
-        //小于精度
+        // Less than precision
         if (Math.abs(this.motionZ) < PRECISION && Math.abs(this.motionX) < PRECISION) return;
-        // 减少移动向量（计算摩擦系数，在冰上滑得更远）
+        // Reduce movement vector (calculate friction coefficient, slide further on ice)
         final double factor = getGroundFrictionFactor();
         this.motionX *= factor;
         this.motionZ *= factor;
+
         if (Math.abs(this.motionX) < PRECISION) this.motionX = 0;
         if (Math.abs(this.motionZ) < PRECISION) this.motionZ = 0;
     }
 
     /**
-     * 计算流体阻力（空气/液体）
+     * Calculate fluid resistance (air/liquid)
      */
 
     protected void handlePassableBlockFrictionMovement() {
-        //小于精度
+        // Less than precision
         if (Math.abs(this.motionZ) < PRECISION && Math.abs(this.motionX) < PRECISION && Math.abs(this.motionY) < PRECISION)
             return;
         final double factor = getPassableBlockFrictionFactor();
         this.motionX *= factor;
         this.motionY *= factor;
         this.motionZ *= factor;
+
         if (Math.abs(this.motionX) < PRECISION) this.motionX = 0;
         if (Math.abs(this.motionY) < PRECISION) this.motionY = 0;
         if (Math.abs(this.motionZ) < PRECISION) this.motionZ = 0;
     }
 
     /**
-     * 计算当前位置的地面摩擦因子
+     * Calculate the ground friction factor at the current location
      *
-     * @return 当前位置的地面摩擦因子
+     * @return The ground friction factor at the current location
      */
 
     public double getGroundFrictionFactor() {
@@ -195,9 +197,9 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
     }
 
     /**
-     * 计算当前位置的流体阻力因子（空气/水）
+     * Calculate the fluid resistance factor (air/water) at the current location
      *
-     * @return 当前位置的流体阻力因子
+     * @return The fluid resistance factor at the current location
      */
 
     public double getPassableBlockFrictionFactor() {
@@ -207,7 +209,7 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
     }
 
     /**
-     * 默认使用nk内置实现，这只是个后备算法
+     * By default, the built-in implementation of nk is used, which is just a fallback algorithm.
      */
     protected void handleLiquidMovement() {
         final var tmp = new Vector3();
@@ -243,14 +245,14 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
     }
 
     /**
-     * 浮力系数<br>
-     * 示例:
+     * Buoyancy coefficient<br>
+     * Example:
      * <pre>
-     * if (hasWaterAt(this.getFloatingHeight())) {//实体指定高度进入水中后实体上浮
-     *     return 1.3;//因为浮力系数>1,该值越大上浮越快
+     * if (hasWaterAt(this.getFloatingHeight())) { // The entity floats up after entering the water at a specified height
+     *     return 1.3;// Because the buoyancy coefficient > 1, the larger the value, the faster the float
      * }
-     * return 0.7;//实体指定高度没进入水中，实体存在浮力会抵抗部分重力，但是不会上浮。
-     *            //因为浮力系数<1,该值最好和上值相加等于2，例 1.3+0.7=2
+     * return 0.7; // The entity does not enter the water at the specified height. The entity's buoyancy will resist part of the gravity, but it will not float.
+     *             // Because the buoyancy coefficient is less than 1, it is best to add this value to the previous value to equal 2, for example 1.3+0.7=2
      * </pre>
      *
      * @return the floating force factor
@@ -264,8 +266,9 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
     }
 
     /**
-     * 获得浮动到的实体高度 , 0为实体底部 {@link Entity#getCurrentHeight()}为实体顶部<br>
-     * 例：<br>值为0时，实体的脚接触水平面<br>值为getCurrentHeight/2时，实体的中间部分接触水平面<br>值为getCurrentHeight时，实体的头部接触水平面
+     * Get the height of the entity to float to, 0 is the bottom of the entity {@link Entity#getCurrentHeight()} For the top of the entity<br>
+     * Example: <br>When the value is 0, the entity's feet touch the horizontal plane<br>When the value is getCurrentHeight/2, the entity's middle 
+     * part touches the horizontal plane<br>When the value is getCurrentHeight, the entity's head touches the horizontal plane
      *
      * @return the float
      */
@@ -277,6 +280,7 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
         var selfAABB = getOffsetBoundingBox().getOffsetBoundingBox(this.motionX, this.motionY, this.motionZ);
         var collidingEntities = this.level.fastCollidingEntities(selfAABB, this);
         collidingEntities.removeIf(entity -> !(entity.canCollide() && (entity instanceof EntityPhysical || entity instanceof Player)));
+
         var size = collidingEntities.size();
         if (size == 0) {
             this.previousCollideMotion.setX(0);
@@ -287,6 +291,7 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
                 return;
             }
         }
+
         var dxPositives = new DoubleArrayList(size);
         var dxNegatives = new DoubleArrayList(size);
         var dzPositives = new DoubleArrayList(size);
@@ -296,6 +301,7 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
         if (size > 4) {
             stream = stream.parallel();
         }
+
         stream.forEach(each -> {
             AxisAlignedBB targetAABB;
             if (each instanceof EntityPhysical entityPhysical) {
@@ -305,30 +311,44 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
             } else {
                 return;
             }
-            // 计算碰撞箱
+
             double centerXWidth = (targetAABB.getMaxX() + targetAABB.getMinX() - selfAABB.getMaxX() - selfAABB.getMinX()) * 0.5;
             double centerZWidth = (targetAABB.getMaxZ() + targetAABB.getMinZ() - selfAABB.getMaxZ() - selfAABB.getMinZ()) * 0.5;
+
             if (centerXWidth > 0) {
-                dxPositives.add((targetAABB.getMaxX() - targetAABB.getMinX()) + (selfAABB.getMaxX() - selfAABB.getMinX()) * 0.5 - centerXWidth);
+                double value = (targetAABB.getMaxX() - targetAABB.getMinX()) + (selfAABB.getMaxX() - selfAABB.getMinX()) * 0.5 - centerXWidth;
+                dxPositives.add(value);
             } else {
-                dxNegatives.add((targetAABB.getMaxX() - targetAABB.getMinX()) + (selfAABB.getMaxX() - selfAABB.getMinX()) * 0.5 + centerXWidth);
+                double value = (targetAABB.getMaxX() - targetAABB.getMinX()) + (selfAABB.getMaxX() - selfAABB.getMinX()) * 0.5 + centerXWidth;
+                dxNegatives.add(value);
             }
+
             if (centerZWidth > 0) {
-                dzPositives.add((targetAABB.getMaxZ() - targetAABB.getMinZ()) + (selfAABB.getMaxZ() - selfAABB.getMinZ()) * 0.5 - centerZWidth);
+                double value = (targetAABB.getMaxZ() - targetAABB.getMinZ()) + (selfAABB.getMaxZ() - selfAABB.getMinZ()) * 0.5 - centerZWidth;
+                dzPositives.add(value);
             } else {
-                dzNegatives.add((targetAABB.getMaxZ() - targetAABB.getMinZ()) + (selfAABB.getMaxZ() - selfAABB.getMinZ()) * 0.5 + centerZWidth);
+                double value = (targetAABB.getMaxZ() - targetAABB.getMinZ()) + (selfAABB.getMaxZ() - selfAABB.getMinZ()) * 0.5 + centerZWidth;
+                dzNegatives.add(value);
             }
         });
-        double resultX = (size > 4 ? dxPositives.doubleParallelStream() : dxPositives.doubleStream()).max().orElse(0) - (size > 4 ? dxNegatives.doubleParallelStream() : dxNegatives.doubleStream()).max().orElse(0);
-        double resultZ = (size > 4 ? dzPositives.doubleParallelStream() : dzPositives.doubleStream()).max().orElse(0) - (size > 4 ? dzNegatives.doubleParallelStream() : dzNegatives.doubleStream()).max().orElse(0);
+
+        double resultX = (size > 4 ? dxPositives.doubleParallelStream() : dxPositives.doubleStream()).max().orElse(0)
+                       - (size > 4 ? dxNegatives.doubleParallelStream() : dxNegatives.doubleStream()).max().orElse(0);
+        double resultZ = (size > 4 ? dzPositives.doubleParallelStream() : dzPositives.doubleStream()).max().orElse(0)
+                       - (size > 4 ? dzNegatives.doubleParallelStream() : dzNegatives.doubleStream()).max().orElse(0);
         double len = Math.sqrt(resultX * resultX + resultZ * resultZ);
-        this.previousCollideMotion.setX(-(resultX / len * 0.2 * 0.32));
-        this.previousCollideMotion.setZ(-(resultZ / len * 0.2 * 0.32));
+
+        double finalX = -(resultX / len * 0.2 * 0.32);
+        double finalZ = -(resultZ / len * 0.2 * 0.32);
+
+        this.previousCollideMotion.setX(finalX);
+        this.previousCollideMotion.setZ(finalZ);
     }
 
+
     /**
-     * @param collidingEntities 碰撞的实体
-     * @return false以拦截实体碰撞运动计算
+     * @param collidingEntities Colliding Entities
+     * @return false to intercept entity collision motion calculation
      */
     protected boolean onCollide(int currentTick, List<Entity> collidingEntities) {
         if (currentTick % 10 == 0) {
@@ -351,7 +371,7 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
     }
 
     protected void calculateOffsetBoundingBox() {
-        //由于是asyncPrepare,this.offsetBoundingBox有几率为null，需要判空
+        // Because it is asyncPrepare, this.offsetBoundingBox has a chance to be null, so it needs to be judged as null
         if (this.offsetBoundingBox == null) return;
         final double dx = this.getWidth() * 0.5;
         final double dz = this.getHeight() * 0.5;

--- a/src/main/java/cn/nukkit/entity/ai/controller/WalkController.java
+++ b/src/main/java/cn/nukkit/entity/ai/controller/WalkController.java
@@ -12,8 +12,8 @@ import cn.nukkit.math.Vector3;
 import java.util.Arrays;
 
 /**
- * 处理陆地行走实体运动
- * todo: 有待解耦
+ * Handling land walking entity movement
+ * todo: To be decoupled
  */
 
 
@@ -39,7 +39,7 @@ public class WalkController implements IController {
         }
 
         if (entity.hasMoveDirection() && !entity.isShouldUpdateMoveDirection()) {
-            //clone防止异步导致的NPE
+            // Clone prevents NPE caused by asynchronous
             Vector3 direction = entity.getMoveDirectionEnd().clone();
             var speed = entity.getMovementSpeed();
             if (entity.motionX * entity.motionX + entity.motionZ * entity.motionZ > speed * speed * 0.4756) {
@@ -60,13 +60,15 @@ public class WalkController implements IController {
             var dy = 0.0d;
             Block target = entity.getLevel().getBlock(entity.getMoveDirectionStart());
             if (target.down().isSolid() && relativeVector.y > 0 && collidesBlocks(entity, dx, 0, dz) && currentJumpCoolDown > JUMP_COOL_DOWN || (entity.isTouchingWater() && !(target instanceof BlockLiquid || target.getLevel().getBlock(target, 1) instanceof BlockLiquid)  && target.down().isSolid())) {
-                //note: 从对BDS的抓包信息来看，台阶的碰撞箱在服务端和半砖一样，高度都为0.5
+                // note: From the BDS packet capture information, the collision box of the stairs is the same as that of the half brick on the server side, and the height is 0.5
                 Block[] collisionBlocks = entity.level.getTickCachedCollisionBlocks(entity.getOffsetBoundingBox().getOffsetBoundingBox(dx, dy, dz), false, false, this::canJump);
-                //计算出需要向上移动的高度
+                // Calculate the height you need to move upward
                 double maxY = Arrays.stream(collisionBlocks).map(b -> b.getCollisionBoundingBox().getMaxY()).max(Double::compareTo).orElse(0.0d);
                 double diffY = maxY - entity.getY();
-                dy += entity.getJumpingMotion(diffY);
-                currentJumpCoolDown = 0;
+                if (diffY > 0.01 && diffY <= 1.1) { // 1.1 gives some leeway for stairs etc.
+                    dy += entity.getJumpingMotion(diffY);
+                    currentJumpCoolDown = 0;
+                }
             }
             entity.addTmpMoveMotion(new Vector3(dx, dy, dz));
             entity.setDataFlag(EntityFlag.MOVING, true);
@@ -82,7 +84,7 @@ public class WalkController implements IController {
     }
 
     protected void needNewDirection(EntityIntelligent entity) {
-        //通知需要新的移动目标
+        // Notification requires new moving target
         entity.setShouldUpdateMoveDirection(true);
     }
 

--- a/src/main/java/cn/nukkit/level/Explosion.java
+++ b/src/main/java/cn/nukkit/level/Explosion.java
@@ -171,7 +171,7 @@ public class Explosion {
                             }
                             Block block = this.level.getBlock(vBlock);
 
-                            if (!block.isAir()) {
+                            if (!block.isAir() && block.canBeExploded()) {
                                 Block layer1 = block.getLevelBlockAtLayer(1);
                                 double resistance = Math.max(block.getResistance(), layer1.getResistance());
                                 blastForce -= (resistance / 5 + 0.3d) * this.STEP_LEN;

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -6,6 +6,7 @@ import cn.nukkit.Server;
 import cn.nukkit.api.NonComputationAtomic;
 import cn.nukkit.block.*;
 import cn.nukkit.block.customblock.CustomBlock;
+import cn.nukkit.block.customblock.CustomBlockDefinition;
 import cn.nukkit.block.property.CommonBlockProperties;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.entity.Entity;
@@ -2593,11 +2594,14 @@ public class Level implements Metadatable {
                 if (!player.getAdventureSettings().get(PlayerAbility.MINE))
                     return null;
 
-                //使用calculateBreakTimeNotInAir目的是获取玩家在陆地上的挖掘时间，如果挖掘时间小于这个时间才认为玩家作弊。
+                // The purpose of using calculateBreakTimeNotInAir is to obtain the player's digging time on land. If the digging time is less
+                // than this time, the player is considered cheating.
                 double breakTime = target.calculateBreakTimeNotInAir(item, player);
-                //对于自定义方块，由于用户可以自由设置客户端侧的挖掘时间，拿服务端硬度计算出来的挖掘时间来判断是否为fastBreak是不准确的。
-                if (target instanceof CustomBlock customBlock) {
-                    var comp = customBlock.getDefinition().nbt().getCompound("components");
+                // For custom blocks, since users can freely set the mining time on the client side, it is inaccurate to use the mining time
+                // calculated by the server hardness to determine whether it is a fastBreak.
+                CustomBlockDefinition def = target.getCustomDefinition();
+                if (def != null) {
+                    var comp = def.nbt().getCompound("components");
                     if (comp.containsCompound("minecraft:destructible_by_mining")) {
                         var clientBreakTime = comp.getCompound("minecraft:destructible_by_mining").getFloat("value");
                         breakTime = Math.min(breakTime, clientBreakTime);


### PR DESCRIPTION
**This PR brings a batch of much-needed improvements and fixes to the custom block system and entity behavior. Here’s a quick rundown:**

**Block definition caching:**

> Custom block definitions are now cached when registered, so the server isn’t rebuilding them on every event. This cuts down CPU/memory use and keeps things running smoothly, even with lots of custom blocks.

**Better collision & entity movement:**

> Collision boxes for custom and vanilla blocks are now always in sync server-side even with permutations or properties changes, so mobs won’t “float” above blocks with unusual shapes, and pathfinding/jumping is much more natural.
> Entity AI now jumps only when it makes sense (no more mobs endlessly bouncing at walls).

**Water culling fix:**

> Water next to custom blocks with lower height now culls properly, fixing some rendering issues.

**Support for alpha_test_single_sided:**

> Added this material instance for custom blocks.

**Automatic rotation for collision boxes:**

> Custom block collision is now properly rotated if set on the builder, matching visuals and physics.

**Easier builder API:**

> Standard features like mining/explosion resistance, friction, light, and map color—if set on the builder—are now automatically used server-side. No need for extra overrides.

**Chest/ender chest fix:**

> Chests now open correctly even with thin blocks (like custom thin blocks) above them, if there’s space.

________________________________________
Overall, these changes should make custom content more reliable, performant, and easier to use for plugin and pack creators.

Photos of Issues fixed in this PR:
<img width="574" height="492" alt="image" src="https://github.com/user-attachments/assets/ebbcb731-4b4a-4bbf-bbb3-5301e6137bad" />
<img width="326" height="465" alt="image" src="https://github.com/user-attachments/assets/348f000d-9806-49b2-8c7b-896e5ff8e846" />
<img width="329" height="390" alt="image" src="https://github.com/user-attachments/assets/1046b1e0-b4eb-4fbd-af4e-bdc5fa96b20f" />


