### PR TITLE
fix&enhancement/Added method to get block tags and test for tags

### DIFF
--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -593,8 +593,46 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
         return blockstate;
     }
 
+    /**
+     * @deprecated Use {@link #hasTag(String)} instead.
+     */
+    @Deprecated
     public boolean is(final String blockTag) {
         return BlockTags.getTagSet(this.getId()).contains(blockTag);
+    }
+
+    /**
+     * @return if block has a string tag
+     */
+    public boolean hasTag(final String blockTag) {
+        CustomBlockDefinition def = getCustomDefinition();
+        if (def != null) {
+            CompoundTag nbt = def.nbt();
+            if (nbt.contains("blockTags")) {
+                ListTag<StringTag> tagList = nbt.getList("blockTags", StringTag.class);
+                return tagList.getAll().contains(new StringTag(blockTag));
+            }
+        }
+
+        return BlockTags.getTagSet(this.getId()).contains(blockTag);
+    }
+
+    /**
+     * @return list of tags for the block
+     */
+    public String[] getTags() {
+        CustomBlockDefinition def = getCustomDefinition();
+        if (def != null) {
+            CompoundTag nbt = def.nbt();
+            if (nbt.contains("blockTags")) {
+                ListTag<StringTag> tagList = nbt.getList("blockTags", StringTag.class);
+                return tagList.getAll().stream()
+                    .map(tag -> tag.data)
+                    .toArray(String[]::new);
+            }
+        }
+
+        return BlockTags.getTagSet(this.getId()).toArray(new String[0]);
     }
 
     public <DATATYPE, PROPERTY extends BlockPropertyType<DATATYPE>> DATATYPE getPropertyValue(PROPERTY p) {


### PR DESCRIPTION
The previous method block.is() was not self-explanatory — e.g., block.is()... is what?
It was meant to check for block tags, but the naming made that unclear.

I added an overflow that can be used as:
`block.hasTag("anytag")` — Replaces the ambiguous block.is() call.
It behaves the same for vanilla blocks but now also supports custom block tags, which were previously ignored.

`block.getTags() `— Returns all tags associated with the block.
This enables better introspection and aligns with behavior in BDS.

These new methods improve readability, expand functionality, and maintain parity with Bedrock Dedicated Server behavior.
