### PR TITLE
Add block ticking support to custom blocks and refactor of block tick on load

### DIFF
--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -259,10 +259,9 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
         int min = tick.minTicks();
         int max = tick.maxTicks();
 
-        if (tick.looping() && !this.getLevel().isChunkLoaded(this.getFloorX() >> 4, this.getFloorZ() >> 4)) {
+        if (tick.looping() && this.getLevel().isChunkLoaded(this.getFloorX() >> 4, this.getFloorZ() >> 4)) {
             int delay = (min == max) ? max : ThreadLocalRandom.current().nextInt(min, max + 1);
             this.getLevel().scheduleUpdate(this, delay);
-            log.debug("Next scheduled block tick for '{}' in {} ticks", this.getId(), delay);
             return Level.BLOCK_UPDATE_SCHEDULED;
         } else {
             this.getLevel().cancelScheduledUpdate(this, this);

--- a/src/main/java/cn/nukkit/block/BlockBigDripleaf.java
+++ b/src/main/java/cn/nukkit/block/BlockBigDripleaf.java
@@ -224,7 +224,7 @@ public class BlockBigDripleaf extends BlockFlowable implements Faceable {
             setTilt(BigDripleafTilt.NONE);
             level.setBlock(this, this, true, false);
 
-            level.cancelSheduledUpdate(this, this);
+            level.cancelScheduledUpdate(this, this);
             return Level.BLOCK_UPDATE_SCHEDULED;
         }
 

--- a/src/main/java/cn/nukkit/block/BlockLectern.java
+++ b/src/main/java/cn/nukkit/block/BlockLectern.java
@@ -155,7 +155,7 @@ public class BlockLectern extends BlockTransparent implements RedstoneComponent,
 
     public void executeRedstonePulse() {
         if (isActivated()) {
-            level.cancelSheduledUpdate(this, this);
+            level.cancelScheduledUpdate(this, this);
         } else {
             this.level.getServer().getPluginManager().callEvent(new BlockRedstoneEvent(this, 0, 15));
         }

--- a/src/main/java/cn/nukkit/block/BlockStateImpl.java
+++ b/src/main/java/cn/nukkit/block/BlockStateImpl.java
@@ -9,6 +9,8 @@ import cn.nukkit.network.protocol.ProtocolInfo;
 import cn.nukkit.utils.HashUtils;
 import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import lombok.extern.slf4j.Slf4j;
+
 import org.jetbrains.annotations.UnmodifiableView;
 
 import java.util.Arrays;
@@ -19,6 +21,7 @@ import java.util.List;
  *
  * @author Cool_Loong
  */
+@Slf4j
 public record BlockStateImpl(String identifier,
                       int blockhash,
                       short specialValue,
@@ -98,7 +101,9 @@ public record BlockStateImpl(String identifier,
                 return (DATATYPE) property.getValue();
             }
         }
-        throw new IllegalArgumentException("Property " + p + " is not supported by this block " + this.identifier);
+
+        log.debug("Property " + p + " is not supported by this block " + this.identifier);
+        return null;
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockStateImpl.java
+++ b/src/main/java/cn/nukkit/block/BlockStateImpl.java
@@ -9,8 +9,6 @@ import cn.nukkit.network.protocol.ProtocolInfo;
 import cn.nukkit.utils.HashUtils;
 import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import lombok.extern.slf4j.Slf4j;
-
 import org.jetbrains.annotations.UnmodifiableView;
 
 import java.util.Arrays;
@@ -21,7 +19,6 @@ import java.util.List;
  *
  * @author Cool_Loong
  */
-@Slf4j
 public record BlockStateImpl(String identifier,
                       int blockhash,
                       short specialValue,
@@ -101,9 +98,7 @@ public record BlockStateImpl(String identifier,
                 return (DATATYPE) property.getValue();
             }
         }
-
-        log.debug("Property " + p + " is not supported by this block " + this.identifier);
-        return null;
+        throw new IllegalArgumentException("Property " + p + " is not supported by this block " + this.identifier);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockTarget.java
+++ b/src/main/java/cn/nukkit/block/BlockTarget.java
@@ -83,7 +83,7 @@ public class BlockTarget extends BlockTransparent implements RedstoneComponent, 
 
         BlockEntityTarget target = getOrCreateBlockEntity();
         int previous = target.getActivePower();
-        level.cancelSheduledUpdate(this, this);
+        level.cancelScheduledUpdate(this, this);
         level.scheduleUpdate(this, ticks);
         target.setActivePower(power);
         if (previous != power) {

--- a/src/main/java/cn/nukkit/config/category/ChunkSettings.java
+++ b/src/main/java/cn/nukkit/config/category/ChunkSettings.java
@@ -26,8 +26,6 @@ public class ChunkSettings extends OkaeriConfig {
     boolean clearTickList = false;
     @Comment("pnx.settings.chunk.generationqueuesize")
     int generationQueueSize = 128;
-    @Comment("pnx.settings.chunk.checkfortickable")
-    boolean checkForTickable = false;
     @Comment("pnx.settings.chunk.convertBDSChunks")
     boolean convertBDSChunks = false;
 }

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -7,6 +7,7 @@ import cn.nukkit.api.NonComputationAtomic;
 import cn.nukkit.block.*;
 import cn.nukkit.block.customblock.CustomBlock;
 import cn.nukkit.block.customblock.CustomBlockDefinition;
+import cn.nukkit.block.customblock.CustomBlockDefinition.BlockTickSettings;
 import cn.nukkit.block.property.CommonBlockProperties;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.entity.Entity;
@@ -1064,6 +1065,12 @@ public class Level implements Metadatable {
 
             while (!this.normalUpdateQueue.isEmpty()) {
                 QueuedUpdate queuedUpdate = this.normalUpdateQueue.poll();
+                int x = queuedUpdate.block.getFloorX();
+                int z = queuedUpdate.block.getFloorZ();
+                if (!this.isChunkLoaded(x >> 4, z >> 4)) {
+                    continue;
+                }
+
                 Block block = getBlock(queuedUpdate.block, queuedUpdate.block.layer);
                 BlockUpdateEvent event = new BlockUpdateEvent(block);
                 this.server.getPluginManager().callEvent(event);
@@ -1670,7 +1677,7 @@ public class Level implements Metadatable {
         }
     }
 
-    public boolean cancelSheduledUpdate(Vector3 pos, Block block) {
+    public boolean cancelScheduledUpdate(Vector3 pos, Block block) {
         return this.updateQueue.remove(new BlockUpdateEntry(pos, block));
     }
 
@@ -1680,6 +1687,10 @@ public class Level implements Metadatable {
 
     public boolean isBlockTickPending(Vector3 pos, Block block) {
         return this.updateQueue.isBlockTickPending(pos, block);
+    }
+
+    public BlockUpdateScheduler getBlockUpdateScheduler() {
+        return this.updateQueue;
     }
 
     public Set<BlockUpdateEntry> getPendingBlockUpdates(IChunk chunk) {
@@ -2404,6 +2415,22 @@ public class Level implements Metadatable {
         }
 
         blockPrevious.afterRemoval(block, update);
+
+        if (block instanceof CustomBlock customBlock) {
+            CustomBlockDefinition def = customBlock.getDefinition();
+            if (def != null && def.tickSettings() != null) {
+                BlockTickSettings tick = def.tickSettings();
+                int min = tick.minTicks();
+                int max = tick.maxTicks();
+
+                if (min <= max) {
+                    int delay = (min == max) ? max : ThreadLocalRandom.current().nextInt(min, max + 1);
+                    block.getLevel().scheduleUpdate(block, delay);
+                } else {
+                    log.error("Invalid tick range for block '{}': min {} > max {}", block.getId(), min, max);
+                }
+            }
+        }
         return true;
     }
 

--- a/src/main/java/cn/nukkit/level/format/leveldb/LevelDBChunkSerializer.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/LevelDBChunkSerializer.java
@@ -104,7 +104,7 @@ public class LevelDBChunkSerializer {
         deserializeTileAndEntity(db, builder, pnxExtraData);
         deserializeLight(db, builder, pnxExtraData);
         if (pnxExtraData != null) {
-            deserializeBlockTicks(pnxExtraData, builder); // No provider needed!
+            deserializeBlockTicks(pnxExtraData, builder);
         }
     }
 

--- a/src/main/java/cn/nukkit/level/format/leveldb/LevelDBChunkSerializer.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/LevelDBChunkSerializer.java
@@ -1,17 +1,14 @@
 package cn.nukkit.level.format.leveldb;
 
 import cn.nukkit.Player;
-import cn.nukkit.Server;
-import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockAir;
 import cn.nukkit.block.BlockID;
 import cn.nukkit.block.BlockState;
 import cn.nukkit.block.BlockUnknown;
+import cn.nukkit.block.customblock.CustomBlockDefinition;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.level.DimensionData;
-import cn.nukkit.level.Level;
-import cn.nukkit.level.Position;
 import cn.nukkit.level.format.ChunkSection;
 import cn.nukkit.level.format.ChunkState;
 import cn.nukkit.level.format.IChunk;
@@ -21,9 +18,10 @@ import cn.nukkit.level.format.bitarray.BitArrayVersion;
 import cn.nukkit.level.format.palette.BlockPalette;
 import cn.nukkit.level.format.palette.Palette;
 import cn.nukkit.level.util.LevelDBKeyUtil;
-import cn.nukkit.math.BlockVector3;
 import cn.nukkit.nbt.NBTIO;
 import cn.nukkit.nbt.tag.CompoundTag;
+import cn.nukkit.nbt.tag.ListTag;
+import cn.nukkit.registry.BlockRegistry;
 import cn.nukkit.registry.Registries;
 import cn.nukkit.utils.Utils;
 import com.google.common.base.Predicates;
@@ -31,7 +29,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.buffer.Unpooled;
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ReferenceArrayList;
 import org.iq80.leveldb.DB;
 import org.iq80.leveldb.WriteBatch;
@@ -72,6 +69,7 @@ public class LevelDBChunkSerializer {
                 serializeBlock(writeBatch, unsafeChunk);
                 serializeHeightAndBiome(writeBatch, unsafeChunk);
                 serializeLight(writeBatch, unsafeChunk);
+                serializeBlockTicks(unsafeChunk);
                 writeBatch.put(LevelDBKeyUtil.PNX_EXTRA_DATA.getKey(unsafeChunk.getX(), unsafeChunk.getZ(), unsafeChunk.getDimensionData()), NBTIO.write(unsafeChunk.getExtraData()));
             } catch (IOException e) {
                 throw new RuntimeException(e);
@@ -105,34 +103,8 @@ public class LevelDBChunkSerializer {
         deserializeHeightAndBiome(db, builder, pnxExtraData);
         deserializeTileAndEntity(db, builder, pnxExtraData);
         deserializeLight(db, builder, pnxExtraData);
-        if(Server.getInstance().getSettings().chunkSettings().checkForTickable()) {
-            ObjectOpenHashSet<BlockVector3> updates = new ObjectOpenHashSet<>();
-            for(int i = 0; i < builder.getSections().length; i++) {
-                ChunkSection section = builder.getSections()[i];
-                if(section == null) continue;
-                for (int x = 15; x >= 0; x--) {
-                    for (int z = 15; z >= 0; z--) {
-                        for (int y = 15; y >= 0; y--) {
-                            BlockState blockState = section.blockLayer()[0].get(index(x, y, z));
-                            switch (blockState.getIdentifier()) {
-                                case BlockID.FLOWING_WATER, BlockID.WATER,
-                                     BlockID.FLOWING_LAVA, BlockID.LAVA,
-                                     BlockID.REDSTONE_WIRE,
-                                     BlockID.POWERED_REPEATER, BlockID.UNPOWERED_REPEATER,
-                                     BlockID.POWERED_COMPARATOR, BlockID.UNPOWERED_COMPARATOR -> {
-                                    updates.add(new BlockVector3(x + 16*builder.getChunkX(), y + (section.y() << 4), z + 16*builder.getChunkZ()));
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            Level level = builder.getLevelProvider().getLevel();
-            level.getScheduler().scheduleDelayedTask(() -> {
-                for(BlockVector3 vector3 : updates) {
-                    level.getBlock(vector3.x, vector3.y, vector3.z).onUpdate(Level.BLOCK_UPDATE_NORMAL);
-                }
-            }, 20);
+        if (pnxExtraData != null) {
+            deserializeBlockTicks(pnxExtraData, builder); // No provider needed!
         }
     }
 
@@ -406,4 +378,118 @@ public class LevelDBChunkSerializer {
             entityBuffer.release();
         }
     }
+
+    private void serializeBlockTicks(UnsafeChunk chunk) {
+        int cx = chunk.getX();
+        int cz = chunk.getZ();
+
+        ListTag<CompoundTag> scheduledTicks = new ListTag<>();
+        ListTag<CompoundTag> normalTickBlocks = new ListTag<>();
+
+        for (ChunkSection section : chunk.getSections()) {
+            if (section == null) continue;
+            int sectionY = section.y();
+            for (int x = 0; x < 16; x++) {
+                for (int z = 0; z < 16; z++) {
+                    for (int y = 0; y < 16; y++) {
+                        BlockState state = section.blockLayer()[0].get(index(x, y, z));
+                        String id = state.getIdentifier();
+
+                        // 1. Custom block with tickSettings
+                        CustomBlockDefinition def = BlockRegistry.getCustomBlockDefinition(id);
+                        if (def != null && def.tickSettings() != null) {
+                            int bx = x + (cx << 4);
+                            int by = (sectionY << 4) + y;
+                            int bz = z + (cz << 4);
+
+                            CompoundTag tag = new CompoundTag()
+                                .putInt("x", bx)
+                                .putInt("y", by)
+                                .putInt("z", bz)
+                                .putString("id", id)
+                                .putInt("layer", 0)
+                                .putInt("delay", def.tickSettings().minTicks())
+                                .putInt("priority", 0)
+                                .putBoolean("checkBlockWhenUpdate", true);
+
+                            scheduledTicks.add(tag);
+                        }
+
+                        // 2. Vanilla tickable block
+                        switch (id) {
+                            case BlockID.DAYLIGHT_DETECTOR, BlockID.DAYLIGHT_DETECTOR_INVERTED,
+                                 BlockID.REDSTONE_WIRE,
+                                 BlockID.POWERED_REPEATER, BlockID.UNPOWERED_REPEATER,
+                                 BlockID.POWERED_COMPARATOR, BlockID.UNPOWERED_COMPARATOR -> {
+                                CompoundTag tag = new CompoundTag()
+                                    .putInt("x", x + (cx << 4))
+                                    .putInt("y", (sectionY << 4) + y)
+                                    .putInt("z", z + (cz << 4))
+                                    .putString("id", id);
+                                normalTickBlocks.add(tag);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Save both lists to extraData
+        CompoundTag extraData = chunk.getExtraData();
+        extraData.putList("pendingScheduledTicks", scheduledTicks);
+        extraData.putList("pendingNormalTickBlocks", normalTickBlocks);
+    }
+
+    public static class ScheduledTickInfo {
+        public int x, y, z, layer, delay, priority;
+        public String id;
+        public boolean checkBlockWhenUpdate;
+    }
+    public static class NormalTickInfo {
+        public int x, y, z;
+        public String id;
+    }
+
+    public static void deserializeBlockTicks(CompoundTag extraData, IChunkBuilder builder) {
+        long chunkKey = ((long) builder.getChunkX() & 0xffffffffL) << 32 | ((long) builder.getChunkZ() & 0xffffffffL);
+
+        // --- Scheduled Ticks ---
+        if (extraData.contains("pendingScheduledTicks")) {
+            ListTag<CompoundTag> scheduledTicks = extraData.getList("pendingScheduledTicks", CompoundTag.class);
+            List<ScheduledTickInfo> scheduledList = new ArrayList<>();
+            for (CompoundTag tag : scheduledTicks.getAll()) {
+                ScheduledTickInfo info = new ScheduledTickInfo();
+                info.x = tag.getInt("x");
+                info.y = tag.getInt("y");
+                info.z = tag.getInt("z");
+                info.id = tag.getString("id");
+                info.layer = tag.getInt("layer");
+                info.delay = tag.getInt("delay");
+                info.priority = tag.getInt("priority");
+                info.checkBlockWhenUpdate = tag.getBoolean("checkBlockWhenUpdate");
+                scheduledList.add(info);
+            }
+            if (!scheduledList.isEmpty()) {
+                LevelDBProvider.getScheduledTicksMap().put(chunkKey, scheduledList);
+            }
+        }
+
+        // --- Normal Tick Blocks ---
+        if (extraData.contains("pendingNormalTickBlocks")) {
+            ListTag<CompoundTag> normalTicks = extraData.getList("pendingNormalTickBlocks", CompoundTag.class);
+            List<NormalTickInfo> normalList = new ArrayList<>();
+            for (CompoundTag tag : normalTicks.getAll()) {
+                NormalTickInfo info = new NormalTickInfo();
+                info.x = tag.getInt("x");
+                info.y = tag.getInt("y");
+                info.z = tag.getInt("z");
+                info.id = tag.getString("id");
+                normalList.add(info);
+            }
+            if (!normalList.isEmpty()) {
+                LevelDBProvider.getNormalTicksMap().put(chunkKey, normalList);
+            }
+        }
+    }
 }
+

--- a/src/main/java/cn/nukkit/level/format/leveldb/LevelDBChunkSerializer.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/LevelDBChunkSerializer.java
@@ -418,7 +418,7 @@ public class LevelDBChunkSerializer {
                         // 2. Vanilla tickable block
                         switch (id) {
                             case BlockID.DAYLIGHT_DETECTOR, BlockID.DAYLIGHT_DETECTOR_INVERTED,
-                                 BlockID.REDSTONE_WIRE,
+                                 BlockID.REDSTONE_WIRE, BlockID.REDSTONE_TORCH,
                                  BlockID.POWERED_REPEATER, BlockID.UNPOWERED_REPEATER,
                                  BlockID.POWERED_COMPARATOR, BlockID.UNPOWERED_COMPARATOR -> {
                                 CompoundTag tag = new CompoundTag()

--- a/src/main/java/cn/nukkit/level/format/leveldb/LevelDBChunkSerializer.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/LevelDBChunkSerializer.java
@@ -103,9 +103,7 @@ public class LevelDBChunkSerializer {
         deserializeHeightAndBiome(db, builder, pnxExtraData);
         deserializeTileAndEntity(db, builder, pnxExtraData);
         deserializeLight(db, builder, pnxExtraData);
-        if (pnxExtraData != null) {
-            deserializeBlockTicks(pnxExtraData, builder);
-        }
+        deserializeBlockTicks(pnxExtraData, builder);
     }
 
     //serialize chunk section light
@@ -455,6 +453,7 @@ public class LevelDBChunkSerializer {
     }
 
     public static void deserializeBlockTicks(CompoundTag extraData, IChunkBuilder builder) {
+        if (extraData == null) return;
         long chunkKey = ((long) builder.getChunkX() & 0xffffffffL) << 32 | ((long) builder.getChunkZ() & 0xffffffffL);
 
         // --- Scheduled Ticks ---

--- a/src/main/java/cn/nukkit/level/format/leveldb/LevelDBProvider.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/LevelDBProvider.java
@@ -200,7 +200,6 @@ public class LevelDBProvider implements LevelProvider {
         if (normalList != null && !normalList.isEmpty()) {
             int batchSize = 32;
             int total = normalList.size();
-            log.info("[TickRestore] Restoring " + total + " normal tick blocks for chunk (" + chunk.getX() + "," + chunk.getZ() + ")");
             for (int i = 0; i < total; i += batchSize) {
                 int from = i;
                 int to = Math.min(i + batchSize, total);

--- a/src/main/java/cn/nukkit/level/format/leveldb/LevelDBProvider.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/LevelDBProvider.java
@@ -204,7 +204,7 @@ public class LevelDBProvider implements LevelProvider {
     private static void restoreNormalTicks(Level level, IChunk chunk, List<NormalTickInfo> normalList) {
         if (normalList == null || normalList.isEmpty()) return;
 
-        int batchSize = 64;
+        int batchSize = 32;
         int total = normalList.size();
         for (int i = 0; i < total; i += batchSize) {
             int from = i;

--- a/src/main/java/cn/nukkit/level/format/leveldb/LevelDBProvider.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/LevelDBProvider.java
@@ -2,6 +2,7 @@ package cn.nukkit.level.format.leveldb;
 
 import cn.nukkit.Server;
 import cn.nukkit.api.UsedByReflection;
+import cn.nukkit.block.Block;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.blockentity.BlockEntitySpawnable;
 import cn.nukkit.level.DimensionData;
@@ -14,6 +15,8 @@ import cn.nukkit.level.format.ChunkSection;
 import cn.nukkit.level.format.IChunk;
 import cn.nukkit.level.format.LevelConfig;
 import cn.nukkit.level.format.LevelProvider;
+import cn.nukkit.level.format.leveldb.LevelDBChunkSerializer.NormalTickInfo;
+import cn.nukkit.level.format.leveldb.LevelDBChunkSerializer.ScheduledTickInfo;
 import cn.nukkit.math.BlockVector3;
 import cn.nukkit.math.Vector3;
 import cn.nukkit.nbt.NBTIO;
@@ -63,6 +66,8 @@ public class LevelDBProvider implements LevelProvider {
     private static final byte[] levelDatMagic = new byte[]{10, 0, 0, 0, 68, 11, 0, 0};
     private final ThreadLocal<WeakReference<IChunk>> lastChunk = new ThreadLocal<>();
     protected final Long2ObjectNonBlockingMap<IChunk> chunks = new Long2ObjectNonBlockingMap<>();
+    private static final Map<Long, List<ScheduledTickInfo>> scheduledTicksMap = new HashMap<>();
+    private static final Map<Long, List<NormalTickInfo>> normalTicksMap = new HashMap<>();
     protected final LevelDat levelDat;
     protected final LevelDBStorage storage;
     protected final Level level;
@@ -158,8 +163,59 @@ public class LevelDBProvider implements LevelProvider {
                 }
             }
             putChunk(index, chunk);
+
+            Level level = this.getLevel();
+            restoreBlockTicks(level, chunk);
         }
         return chunk;
+    }
+
+    public static Map<Long, List<ScheduledTickInfo>> getScheduledTicksMap() {
+        return scheduledTicksMap;
+    }
+    public static Map<Long, List<NormalTickInfo>> getNormalTicksMap() {
+        return normalTicksMap;
+    }
+
+    public static void restoreBlockTicks(Level level, IChunk chunk) {
+        long chunkKey = ((long) chunk.getX() & 0xffffffffL) << 32 | ((long) chunk.getZ() & 0xffffffffL);
+
+        List<ScheduledTickInfo> scheduledList = LevelDBProvider.getScheduledTicksMap().remove(chunkKey);
+        List<NormalTickInfo> normalList = LevelDBProvider.getNormalTicksMap().remove(chunkKey);
+
+        // --- Scheduled Ticks ---
+        if (scheduledList != null && !scheduledList.isEmpty()) {
+            for (ScheduledTickInfo info : scheduledList) {
+                level.getScheduler().scheduleDelayedTask(() -> {
+                    Block block = level.getBlock(info.x, info.y, info.z, info.layer);
+                    if (block.getId().equals(info.id)) {
+                        level.scheduleUpdate(block, new Vector3(info.x, info.y, info.z),
+                                Math.max(info.delay, 1), info.priority, false, info.checkBlockWhenUpdate);
+                    }
+                }, 1);
+            }
+        }
+
+        // --- Normal Ticks (batched) ---
+        if (normalList != null && !normalList.isEmpty()) {
+            int batchSize = 32;
+            int total = normalList.size();
+            log.info("[TickRestore] Restoring " + total + " normal tick blocks for chunk (" + chunk.getX() + "," + chunk.getZ() + ")");
+            for (int i = 0; i < total; i += batchSize) {
+                int from = i;
+                int to = Math.min(i + batchSize, total);
+                List<NormalTickInfo> sub = normalList.subList(from, to);
+
+                level.getScheduler().scheduleDelayedTask(() -> {
+                    for (NormalTickInfo info : sub) {
+                        Block block = level.getBlock(info.x, info.y, info.z);
+                        if (block.getId().equals(info.id)) {
+                            block.onUpdate(Level.BLOCK_UPDATE_NORMAL);
+                        }
+                    }
+                }, 1 + (from / batchSize));
+            }
+        }
     }
 
     public int size() {

--- a/src/main/java/cn/nukkit/registry/BlockRegistry.java
+++ b/src/main/java/cn/nukkit/registry/BlockRegistry.java
@@ -1411,9 +1411,6 @@ public final class BlockRegistry implements BlockID, IRegistry<String, Block, Cl
                     CustomBlockDefinition def = customBlock.getDefinition();
                     customBlockDefinitions.add(def);
                     CUSTOM_BLOCK_DEFINITION_BY_ID.put(customBlock.getId(), customBlock.getDefinition());
-                    if (def.tickSettings() != null) {
-                        Level.setCanRandomTick(customBlock.getId(), true);
-                    }
                     int rid = 255 - CustomBlockDefinition.getRuntimeId(customBlock.getId());
                     Registries.ITEM_RUNTIMEID.registerCustomRuntimeItem(new ItemRuntimeIdRegistry.RuntimeEntry(customBlock.getId(), rid, false));
                     CompoundTag nbt = def.nbt();
@@ -1583,5 +1580,9 @@ public final class BlockRegistry implements BlockID, IRegistry<String, Block, Cl
 
     public boolean shouldSkip(String bid) {
         return skipBlockSet.contains(bid);
+    }
+
+    public static CustomBlockDefinition getCustomBlockDefinition(String identifier) {
+        return CUSTOM_BLOCK_DEFINITION_BY_ID.get(identifier);
     }
 }

--- a/src/main/java/cn/nukkit/registry/BlockRegistry.java
+++ b/src/main/java/cn/nukkit/registry/BlockRegistry.java
@@ -1410,7 +1410,7 @@ public final class BlockRegistry implements BlockID, IRegistry<String, Block, Cl
                     List<CustomBlockDefinition> customBlockDefinitions = CUSTOM_BLOCK_DEFINITIONS.computeIfAbsent(plugin, (p) -> new ArrayList<>());
                     CustomBlockDefinition def = customBlock.getDefinition();
                     customBlockDefinitions.add(def);
-                    CUSTOM_BLOCK_DEFINITION_BY_ID.put(customBlock.getId(), customBlock.getDefinition()); 
+                    CUSTOM_BLOCK_DEFINITION_BY_ID.put(customBlock.getId(), customBlock.getDefinition());
                     int rid = 255 - CustomBlockDefinition.getRuntimeId(customBlock.getId());
                     Registries.ITEM_RUNTIMEID.registerCustomRuntimeItem(new ItemRuntimeIdRegistry.RuntimeEntry(customBlock.getId(), rid, false));
                     CompoundTag nbt = def.nbt();

--- a/src/main/java/cn/nukkit/registry/BlockRegistry.java
+++ b/src/main/java/cn/nukkit/registry/BlockRegistry.java
@@ -1411,6 +1411,9 @@ public final class BlockRegistry implements BlockID, IRegistry<String, Block, Cl
                     CustomBlockDefinition def = customBlock.getDefinition();
                     customBlockDefinitions.add(def);
                     CUSTOM_BLOCK_DEFINITION_BY_ID.put(customBlock.getId(), customBlock.getDefinition());
+                    if (def.tickSettings() != null) {
+                        Level.setCanRandomTick(customBlock.getId(), true);
+                    }
                     int rid = 255 - CustomBlockDefinition.getRuntimeId(customBlock.getId());
                     Registries.ITEM_RUNTIMEID.registerCustomRuntimeItem(new ItemRuntimeIdRegistry.RuntimeEntry(customBlock.getId(), rid, false));
                     CompoundTag nbt = def.nbt();

--- a/src/main/java/cn/nukkit/registry/BlockRegistry.java
+++ b/src/main/java/cn/nukkit/registry/BlockRegistry.java
@@ -1410,7 +1410,7 @@ public final class BlockRegistry implements BlockID, IRegistry<String, Block, Cl
                     List<CustomBlockDefinition> customBlockDefinitions = CUSTOM_BLOCK_DEFINITIONS.computeIfAbsent(plugin, (p) -> new ArrayList<>());
                     CustomBlockDefinition def = customBlock.getDefinition();
                     customBlockDefinitions.add(def);
-                    CUSTOM_BLOCK_DEFINITION_BY_ID.put(customBlock.getId(), customBlock.getDefinition());
+                    CUSTOM_BLOCK_DEFINITION_BY_ID.put(customBlock.getId(), customBlock.getDefinition()); 
                     int rid = 255 - CustomBlockDefinition.getRuntimeId(customBlock.getId());
                     Registries.ITEM_RUNTIMEID.registerCustomRuntimeItem(new ItemRuntimeIdRegistry.RuntimeEntry(customBlock.getId(), rid, false));
                     CompoundTag nbt = def.nbt();


### PR DESCRIPTION
This change introduces full support for block ticking behavior (random and scheduled) on custom blocks by extending core ticking logic into CustomBlockDefinition and integrating tick scheduling with the Level system.

**CustomBlockDefinition.Builder#blockTick(int minTicks, int maxTicks, boolean looping)**
Allows plugin developers to define:
- minTicks and maxTicks: tick interval range in server ticks (20 ticks = 1s).
- looping: whether the block should keep ticking or only tick once.

**Extension of Block#onUpdate(int type) to**:
- Handle custom block ticks.
- Schedule next tick automatically based on tickSettings.
- Automatically remove non-looping blocks from the random tick list after first trigger.

Examples of usage when defining custom blocks:
```
.blockTick(60, 60, true) // Tick every 3 seconds (60 ticks), indefinitely
.blockTick(20, 40, true) // Tick every 1-2 seconds (randomized)
.blockTick(10, 10, false) // Tick once after 0.5s, then stop
```

**Refactor of normal block tick restoration on chunk load:**

- Saves both normal block ticks and scheduled ticks of custom blocks as PNX extra data during chunk serialization, enabling efficient deserialization on chunk load (the most performance-critical path).
- Prevents brute-force restoration and infinite chunk load cycles by only processing normal block ticks for loaded chunks.
- Ensures scheduled/custom ticks and normal ticks are serialized and restored efficiently, avoiding chunk reload recursion and lag spikes.
- Removed liquids from ticking on chunk load, it would kill any server when a player spawns or move against a ocean of water or lava, BDS Vanilla updates the liquids ticking based on neighbor changes or terrain editions.
