### PR TITLE
Fix getPropertyValue from throwing error

### DIFF
--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -36,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -584,7 +585,22 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
     }
 
     public List<BlockPropertyType.BlockPropertyValue<?, ?, ?>> getPropertyValues() {
-        return this.blockstate.getBlockPropertyValues();
+        try {
+            return this.blockstate.getBlockPropertyValues();
+        } catch (IllegalArgumentException | NullPointerException e) {
+            log.warn("The block does not have this property.");
+            return Collections.emptyList();
+        }
+    }
+
+    @Nullable
+    public Object getPropertyValue(String name) {
+        for (BlockPropertyType.BlockPropertyValue<?, ?, ?> prop : this.getPropertyValues()) {
+            if (prop.getPropertyType().getName().equals(name)) {
+                return prop.getValue();
+            }
+        }
+        return null;
     }
 
     public boolean isAir() {

--- a/src/main/java/cn/nukkit/block/BlockStateImpl.java
+++ b/src/main/java/cn/nukkit/block/BlockStateImpl.java
@@ -9,6 +9,8 @@ import cn.nukkit.network.protocol.ProtocolInfo;
 import cn.nukkit.utils.HashUtils;
 import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import lombok.extern.slf4j.Slf4j;
+
 import org.jetbrains.annotations.UnmodifiableView;
 
 import java.util.Arrays;
@@ -19,6 +21,7 @@ import java.util.List;
  *
  * @author Cool_Loong
  */
+@Slf4j
 public record BlockStateImpl(String identifier,
                       int blockhash,
                       short specialValue,
@@ -98,7 +101,9 @@ public record BlockStateImpl(String identifier,
                 return (DATATYPE) property.getValue();
             }
         }
-        throw new IllegalArgumentException("Property " + p + " is not supported by this block " + this.identifier);
+
+        log.debug("Property " + p + " is not supported by this block " + this.identifier);
+        return null;
     }
 
     @Override


### PR DESCRIPTION
**Improve getPropertyValue() to return null instead of throwing when property is missing**
Previously, getPropertyValue() would throw an IllegalArgumentException if the requested property was not present in the block. This prevented dynamic or optional property checks and could break block logic when probing states specially for custom blocks where the property may vary.

This change returns `null` instead, allowing the caller to check for existence and safely fallback, which aligns better with Bedrock behavior and dynamic block property handling.