### PR TITLE
Fix skylight not updating after opening way to sky lights

### DIFF
--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -464,9 +464,6 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
     /**
      * Check if blocks can be attached in the given side.
      */
-    //public boolean isSolid(BlockFace side) {
-    //    return isSideFull(side);
-    //}
     public boolean isSolid(BlockFace side) {
         CustomBlockDefinition def = getCustomDefinition();
         if (def != null) {
@@ -481,7 +478,6 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
                         double base = box.getMinY();
                         return base <= 0.001;
                     }
-                    // You can extend to X and Z sides too if needed.
                     default -> {
                         return true;
                     }
@@ -489,7 +485,7 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
             }
         }
 
-    return isSideFull(side); // fallback to default solid-side check
+    return isSideFull(side);
     }
 
     // https://minecraft.wiki/w/Opacity#Lighting

--- a/src/main/java/cn/nukkit/block/BlockDaylightDetector.java
+++ b/src/main/java/cn/nukkit/block/BlockDaylightDetector.java
@@ -11,6 +11,7 @@ import cn.nukkit.level.Level;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.math.MathHelper;
 import cn.nukkit.utils.RedstoneComponent;
+
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -105,12 +106,15 @@ public class BlockDaylightDetector extends BlockTransparent implements RedstoneC
 
     @Override
     public boolean onActivate(@NotNull Item item, Player player, BlockFace blockFace, float fx, float fy, float fz) {
-        if(isNotActivate(player)) return false;
+        if (isNotActivate(player)) return false;
+
         BlockDaylightDetectorInverted block = new BlockDaylightDetectorInverted();
         getLevel().setBlock(this, block, true, true);
+
         if (this.level.getServer().getSettings().gameplaySettings().enableRedstone()) {
             block.updatePower();
         }
+
         return true;
     }
 
@@ -141,31 +145,67 @@ public class BlockDaylightDetector extends BlockTransparent implements RedstoneC
 
     public void updatePower() {
         int i;
-        if (getLevel().getDimension() == Level.DIMENSION_OVERWORLD) {
-            i = getLevel().getBlockSkyLightAt((int) x, (int) y, (int) z) - getLevel().calculateSkylightSubtracted(1.0F);
-            float f = getLevel().getCelestialAngle(1.0F) * 6.2831855F;
+        Level level = this.getLevel();
 
-            if (this.isInverted()) {
-                i = 15 - i;
-            }
+        if (level.getDimension() == Level.DIMENSION_OVERWORLD) {
+            int skylight = getEffectiveSkyLightSignalAround(level, getFloorX(), getFloorY(), getFloorZ());
+            i = skylight - level.calculateSkylightSubtracted(1.0F);
 
-            if (i > 0 && !this.isInverted()) {
+            float f = level.getCelestialAngle(1.0F) * 6.2831855F;
+
+            if (i > 0) {
                 float f1 = f < (float) Math.PI ? 0.0F : ((float) Math.PI * 2F);
                 f = f + (f1 - f) * 0.2F;
                 i = Math.round((float) i * MathHelper.cos(f));
             }
 
             i = MathHelper.clamp(i, 0, 15);
-        } else i = 0;
+        } else {
+            i = 0;
+        }
 
-        if (i != getLevel().getBlockStateAt(getFloorX(), getFloorY(), getFloorZ()).getPropertyValue(CommonBlockProperties.REDSTONE_SIGNAL)) {
-            BlockState blockState;
+        int current = level.getBlockStateAt(getFloorX(), getFloorY(), getFloorZ())
+                          .getPropertyValue(CommonBlockProperties.REDSTONE_SIGNAL);
+
+        if (i != current) {
             this.setPropertyValue(CommonBlockProperties.REDSTONE_SIGNAL, i);
-            blockState = this.getBlockState();
-            getLevel().setBlockStateAt(getFloorX(), getFloorY(), getFloorZ(), blockState);
+            BlockState blockState = this.getBlockState();
+            level.setBlockStateAt(getFloorX(), getFloorY(), getFloorZ(), blockState);
             updateAroundRedstone();
         }
     }
+
+    public int getEffectiveSkyLightSignalAround(Level level, int x, int y, int z) {
+        int skyReduction = level.skyLightSubtracted;
+
+        int bestSignal = level.getBlockSkyLightAt(x, y + 1, z) - skyReduction;
+        if (bestSignal >= 15) {
+            return 15;
+        }
+
+        final int radius = 11;
+
+        for (int dx = -radius; dx <= radius; dx++) {
+            for (int dz = -radius; dz <= radius; dz++) {
+                int dist = Math.abs(dx) + Math.abs(dz);
+                if (dist == 0 || dist > radius) continue;
+
+                int cx = x + dx;
+                int cz = z + dz;
+
+                int skylight = level.getBlockSkyLightAt(cx, y + 1, cz);
+                int signal = skylight - skyReduction - dist;
+
+                if (signal > bestSignal) {
+                    bestSignal = signal;
+                    if (bestSignal >= 15) return 15;
+                }
+            }
+        }
+
+        return Math.max(0, bestSignal);
+    }
+
 
     @Override
     public boolean isSolid() {

--- a/src/main/java/cn/nukkit/block/BlockDaylightDetectorInverted.java
+++ b/src/main/java/cn/nukkit/block/BlockDaylightDetectorInverted.java
@@ -4,14 +4,15 @@ import cn.nukkit.Player;
 import cn.nukkit.block.property.CommonBlockProperties;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBlock;
+import cn.nukkit.level.Level;
 import cn.nukkit.math.BlockFace;
+
 import org.jetbrains.annotations.NotNull;
 
 /**
  * @author CreeperFace
  * @since 2015/11/22
  */
-
 public class BlockDaylightDetectorInverted extends BlockDaylightDetector {
 
     public static final BlockProperties PROPERTIES = new BlockProperties(DAYLIGHT_DETECTOR_INVERTED, CommonBlockProperties.REDSTONE_SIGNAL);
@@ -40,15 +41,70 @@ public class BlockDaylightDetectorInverted extends BlockDaylightDetector {
     }
 
     @Override
+    public void updatePower() {
+        int i;
+
+        Level level = this.getLevel();
+
+        if (level.getDimension() == Level.DIMENSION_OVERWORLD) {
+            boolean isDark = getIsFullyDarkAround(level, getFloorX(), getFloorY(), getFloorZ());
+            i = isDark ? 15 : 0;
+        } else {
+            i = 0;
+        }
+
+        int current = level.getBlockStateAt(getFloorX(), getFloorY(), getFloorZ())
+                          .getPropertyValue(CommonBlockProperties.REDSTONE_SIGNAL);
+
+        if (i != current) {
+            this.setPropertyValue(CommonBlockProperties.REDSTONE_SIGNAL, i);
+            BlockState blockState = this.getBlockState();
+            level.setBlockStateAt(getFloorX(), getFloorY(), getFloorZ(), blockState);
+            updateAroundRedstone();
+        }
+    }
+
+    public static boolean getIsFullyDarkAround(Level level, int x, int y, int z) {
+        int skyReduction = level.skyLightSubtracted;
+
+        int directSky = level.getBlockSkyLightAt(x, y + 1, z);
+        int directSignal = directSky - skyReduction;
+        if (directSignal >= 5) return false;
+
+        final int radius = 10;
+
+        for (int dx = -radius; dx <= radius; dx++) {
+            for (int dz = -radius; dz <= radius; dz++) {
+                int dist = Math.abs(dx) + Math.abs(dz);
+                if (dist == 0 || dist > radius) continue;
+
+                int cx = x + dx;
+                int cz = z + dz;
+
+                int sky = level.getBlockSkyLightAt(cx, y + 1, cz);
+                int signal = sky - skyReduction - dist;
+
+                if (signal >= 5) return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
     public boolean onActivate(@NotNull Item item, Player player, BlockFace blockFace, float fx, float fy, float fz) {
-        if(isNotActivate(player)) return false;
+        if (isNotActivate(player)) return false;
+
         BlockDaylightDetector block = new BlockDaylightDetector();
         getLevel().setBlock(this, block, true, true);
+
         if (this.level.getServer().getSettings().gameplaySettings().enableRedstone()) {
             block.updatePower();
         }
+
         return true;
     }
+
 
     @Override
     public boolean isInverted() {

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -2154,6 +2154,7 @@ public class Level implements Metadatable {
                 level -= block.getLightLevel();
             }
             if (level <= 0) level = 0;
+            //if(_y != height && !block.canPassThrough() && block.up().canPassThrough()) addSkyLightUpdate(x, _y+1, z); ToDo: Light Spread
             setBlockSkyLightAt(x, _y, z, level);
         }
     }

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -2131,14 +2131,20 @@ public class Level implements Metadatable {
         this.addBlockLightUpdate((int) pos.x, (int) pos.y, (int) pos.z);
     }
 
+    /**
+     * Updates skylight for the entire vertical column at (x, z) by scanning from world top down,
+     * setting values according to block transparency and attenuation, stopping at the first solid block.
+     */
     public void updateBlockSkyLight(int x, int y, int z) {
         IChunk chunk = getChunkIfLoaded(x >> 4, z >> 4);
 
         if (chunk == null) return;
 
-        int height = chunk.recalculateHeightMapColumn(x & 0x0f, z & 0x0f);
+        int minY = getDimensionData().getMinHeight();
+        int maxY = getDimensionData().getMaxHeight();
         int level = 15;
-        for(int _y = height ; _y >= getDimensionData().getMinHeight(); _y--) {
+
+        for (int _y = maxY; _y >= minY; _y--) {
             Block block = getBlock(x, _y, z);
             if (!block.isTransparent()) {
                 level = 0;
@@ -2147,8 +2153,7 @@ public class Level implements Metadatable {
             } else {
                 level -= block.getLightLevel();
             }
-            if(level <= 0) level = 0;
-            //if(_y != height && !block.canPassThrough() && block.up().canPassThrough()) addSkyLightUpdate(x, _y+1, z); ToDo: Light Spread
+            if (level <= 0) level = 0;
             setBlockSkyLightAt(x, _y, z, level);
         }
     }


### PR DESCRIPTION
**Fix skylight not updating after opening way to sky lights**
- Changed updateBlockSkyLight to scan from world top (maxY) down to minY for each affected column, instead of starting from the heightmap.
- This ensures all air and transparent blocks above the first solid now correctly receive skylight 15, matching vanilla/BDS behavior.
- Fixes issues where daylight detectors and crops failed to update after removing blocks above them.
- Removed unused commented codes
- Fixed Daylight Detectors to properly get light surrounding it

