### PR TITLE
Fix Rdstone propagation & schedules of redstone diodes

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockRedstoneDiode.java
+++ b/src/main/java/cn/nukkit/block/BlockRedstoneDiode.java
@@ -18,9 +18,7 @@ import static cn.nukkit.block.property.CommonBlockProperties.MINECRAFT_CARDINAL_
 /**
  * @author CreeperFace
  */
-
 public abstract class BlockRedstoneDiode extends BlockFlowable implements RedstoneComponent, Faceable {
-
     protected boolean isPowered = false;
 
     public BlockRedstoneDiode(BlockState blockstate) {
@@ -83,21 +81,21 @@ public abstract class BlockRedstoneDiode extends BlockFlowable implements Redsto
 
                 if (this.isPowered && !shouldBePowered) {
                     this.level.setBlock(pos, this.getUnpowered(), true, true);
+                    this.isPowered = false;
 
                     Block side = this.getSide(getFacing().getOpposite());
                     side.onUpdate(Level.BLOCK_UPDATE_REDSTONE);
                     RedstoneComponent.updateAroundRedstone(side);
                 } else if (!this.isPowered) {
                     this.level.setBlock(pos, this.getPowered(), true, true);
+                    this.isPowered = true;
+
                     Block side = this.getSide(getFacing().getOpposite());
                     side.onUpdate(Level.BLOCK_UPDATE_REDSTONE);
                     RedstoneComponent.updateAroundRedstone(side);
-
-                    if (!shouldBePowered) {
-                        level.scheduleUpdate(getPowered(), this, this.getDelay());
-                    }
                 }
             }
+            return type;
         } else if (type == Level.BLOCK_UPDATE_NORMAL || type == Level.BLOCK_UPDATE_REDSTONE) {
             if (type == Level.BLOCK_UPDATE_NORMAL && !isSupportValid(down())) {
                 this.level.useBreakOn(this);
@@ -119,18 +117,11 @@ public abstract class BlockRedstoneDiode extends BlockFlowable implements Redsto
 
     public void updateState() {
         if (!this.isLocked()) {
-            boolean shouldPowered = this.shouldBePowered();
+            boolean shouldBePowered = this.shouldBePowered();
+            int delay = this.getDelay();
 
-            if ((this.isPowered && !shouldPowered || !this.isPowered && shouldPowered) && !this.level.isBlockTickPending(this, this)) {
-                /*int priority = -1;
-
-                if (this.isFacingTowardsRepeater()) {
-                    priority = -3;
-                } else if (this.isPowered) {
-                    priority = -2;
-                }*/
-
-                this.level.scheduleUpdate(this, this, this.getDelay());
+            if (this.isPowered && !shouldBePowered || !this.isPowered && shouldBePowered) {
+                this.level.scheduleUpdate(this, this, delay);
             }
         }
     }

--- a/src/main/java/cn/nukkit/block/BlockRedstoneDiode.java
+++ b/src/main/java/cn/nukkit/block/BlockRedstoneDiode.java
@@ -94,8 +94,8 @@ public abstract class BlockRedstoneDiode extends BlockFlowable implements Redsto
                     side.onUpdate(Level.BLOCK_UPDATE_REDSTONE);
                     RedstoneComponent.updateAroundRedstone(side);
                 }
+                return type;
             }
-            return type;
         } else if (type == Level.BLOCK_UPDATE_NORMAL || type == Level.BLOCK_UPDATE_REDSTONE) {
             if (type == Level.BLOCK_UPDATE_NORMAL && !isSupportValid(down())) {
                 this.level.useBreakOn(this);

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -1671,10 +1671,18 @@ public class Level implements Metadatable {
             return;
         }
 
-        BlockUpdateEntry entry = new BlockUpdateEntry(pos.floor(), block, delay + getCurrentTick(), priority, checkBlockWhenUpdate);
+        long tick = delay + getCurrentTick();
+        BlockUpdateEntry entry = new BlockUpdateEntry(pos.floor(), block, tick, priority, checkBlockWhenUpdate);
 
-        if (!this.updateQueue.contains(entry)) {
-            this.updateQueue.add(entry);
+        boolean isRedstoneDiode = block instanceof BlockRedstoneDiode;
+        if (isRedstoneDiode) {
+            if (!this.isConcurrentSchedule(pos.floor(), block, tick, delay) && !this.isBlockTickPending(pos.floor(), block)) {
+                this.updateQueue.add(entry);
+            }
+        } else {
+            if (!this.updateQueue.contains(entry)) {
+                this.updateQueue.add(entry);
+            }
         }
     }
 
@@ -1684,6 +1692,10 @@ public class Level implements Metadatable {
 
     public boolean isUpdateScheduled(Vector3 pos, Block block) {
         return this.updateQueue.contains(new BlockUpdateEntry(pos, block));
+    }
+
+    public boolean isConcurrentSchedule(Vector3 pos, Block block, long targetTick, int delay) {
+        return this.updateQueue.isConcurrentSchedule(pos, block, targetTick, delay);
     }
 
     public boolean isBlockTickPending(Vector3 pos, Block block) {

--- a/src/main/java/cn/nukkit/scheduler/BlockUpdateScheduler.java
+++ b/src/main/java/cn/nukkit/scheduler/BlockUpdateScheduler.java
@@ -100,10 +100,8 @@ public class BlockUpdateScheduler {
     public boolean isConcurrentSchedule(Vector3 pos, Block block, long targetTick, int delay) {
         for (Map.Entry<Long, Set<BlockUpdateEntry>> entry : queuedUpdates.entrySet()) {
             long scheduledTick = entry.getKey();
-            if (entry.getValue().contains(new BlockUpdateEntry(pos, block))) {
-                if (targetTick <= scheduledTick + delay) {
-                    return true;
-                }
+            if (entry.getValue().contains(new BlockUpdateEntry(pos, block)) && targetTick <= scheduledTick + delay) {
+                return true;
             }
         }
         return false;

--- a/src/main/java/cn/nukkit/scheduler/BlockUpdateScheduler.java
+++ b/src/main/java/cn/nukkit/scheduler/BlockUpdateScheduler.java
@@ -97,6 +97,18 @@ public class BlockUpdateScheduler {
         return tmpUpdates.contains(new BlockUpdateEntry(pos, block));
     }
 
+    public boolean isConcurrentSchedule(Vector3 pos, Block block, long targetTick, int delay) {
+        for (Map.Entry<Long, Set<BlockUpdateEntry>> entry : queuedUpdates.entrySet()) {
+            long scheduledTick = entry.getKey();
+            if (entry.getValue().contains(new BlockUpdateEntry(pos, block))) {
+                if (targetTick <= scheduledTick + delay) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     private long getMinTime(BlockUpdateEntry entry) {
         return Math.max(entry.delay, lastTick + 1);
     }


### PR DESCRIPTION
**Improve Redstone Diode Scheduling & Vanilla-Accurate Slab Propagation**

This PR improves redstone stability and accuracy by:
- Refactoring scheduled update handling for repeaters and comparators (**BlockRedstoneDiode**), now allowing only one scheduled update per delay window to prevent task flooding, while supporting fast pulsing and matching vanilla/BDS timing. Other blocks remain one-update-at-a-time.
- Updating redstone wire propagation logic over top slabs to match Bedrock vanilla.
- Upward propagation (from down to up/side) is allowed even if the next block is a top slab (matching vanilla Bedrock).
- Downward propagation (from up to down/side) is not allowed if the source transmitting power is supported by a top slab (matching vanilla restrictions).

These changes bring redstone behavior much closer to vanilla Bedrock, prevent lag from redundant scheduled tasks that sometimes caused out-of-sync repeaters/comparators, and fix edge cases with slab wiring in advanced redstone circuits.