### PR TITLE
feat/Adds support for onEntityStepOn and onEntityStepOff for custom blocks

### DIFF
--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -548,10 +548,13 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
     }
 
     /**
-     * Must return true to use onEntityStepOn() and onEntityStepOff.
+     * Returns true if this block has step-on/off sensor.
+     * <p>
+     * For custom blocks, set this using the builder (isStepSensor).
      */
     public boolean hasEntityStepSensor() {
-        return false;
+        CustomBlockDefinition def = getCustomDefinition();
+        return def != null && def.isStepSensor();
     }
 
     public boolean canPassThrough() {
@@ -1169,14 +1172,14 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
 
     /**
      * Called when an entity steps onto this block.<p>
-     * Only triggered if hasEntityStepSensor() returns true.
+     * Only triggered if isStepSensor() returns true on the builder.
      */
     public void onEntityStepOn(Entity entity) {
     }
 
     /**
      * Called when an entity steps off this block.<p>
-     * Only triggered if hasEntityStepSensor() returns true.
+     * Only triggered if isStepSensor() returns true on the builder.
      */
     public void onEntityStepOff(Entity entity) {
     }

--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -550,7 +550,7 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
     /**
      * Returns true if this block has step-on/off sensor.
      * <p>
-     * For custom blocks, set this using the builder (isStepSensor).
+     * For custom blocks, can be set this by using the builder (isStepSensor).
      */
     public boolean hasEntityStepSensor() {
         CustomBlockDefinition def = getCustomDefinition();

--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -529,6 +529,10 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
         return false;
     }
 
+    public boolean hasEntityStepSensor() {
+        return false;
+    }
+
     public boolean canPassThrough() {
         return false;
     }
@@ -1140,6 +1144,20 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
     }
 
     public void onEntityCollide(Entity entity) {
+    }
+
+    /**
+     * Called when an entity steps onto this block.<p>
+     * Only triggered if hasEntityStepSensor() returns true.
+     */
+    public void onEntityStepOn(Entity entity) {
+    }
+
+    /**
+     * Called when an entity steps off this block.<p>
+     * Only triggered if hasEntityStepSensor() returns true.
+     */
+    public void onEntityStepOff(Entity entity) {
     }
 
     public void onEntityFallOn(Entity entity, float fallDistance) {

--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -529,6 +529,9 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
         return false;
     }
 
+    /**
+     * Must return true to use onEntityStepOn() and onEntityStepOff.
+     */
     public boolean hasEntityStepSensor() {
         return false;
     }

--- a/src/main/java/cn/nukkit/block/customblock/CustomBlockDefinition.java
+++ b/src/main/java/cn/nukkit/block/customblock/CustomBlockDefinition.java
@@ -45,7 +45,7 @@ import java.util.function.Consumer;
  * For further customization of runtime behavior, you can still override methods in {@link Block Block}.
  */
 @Slf4j
-public record CustomBlockDefinition(String identifier, CompoundTag nbt, @Nullable BlockTickSettings tickSettings) {
+public record CustomBlockDefinition(String identifier, CompoundTag nbt, @Nullable BlockTickSettings tickSettings, boolean isStepSensor) {
     private static final Object2IntOpenHashMap<String> INTERNAL_ALLOCATION_ID_MAP = new Object2IntOpenHashMap<>();
     private static final AtomicInteger CUSTOM_BLOCK_RUNTIMEID = new AtomicInteger(10000);
 
@@ -71,6 +71,7 @@ public record CustomBlockDefinition(String identifier, CompoundTag nbt, @Nullabl
         protected final String identifier;
         protected final CustomBlock customBlock;
         private BlockTickSettings tickSettings = null;
+        private boolean isStepSensor = false;
 
         protected CompoundTag nbt = new CompoundTag()
                 .putCompound("components", new CompoundTag());
@@ -476,6 +477,16 @@ public record CustomBlockDefinition(String identifier, CompoundTag nbt, @Nullabl
         }
 
         /**
+         * Enables step sensor logic (entity step-on/off).
+         * <p>
+         * When enabled, override {@link #onEntityStepOn(Entity)} and {@link #onEntityStepOff(Entity)} for custom handling.
+         */
+        public Builder isStepSensor(boolean value) {
+            this.isStepSensor = value;
+            return this;
+        }
+
+        /**
          * @return Block Properties in NBT Tag format
          */
         @Nullable
@@ -522,7 +533,7 @@ public record CustomBlockDefinition(String identifier, CompoundTag nbt, @Nullabl
         }
 
         public CustomBlockDefinition build() {
-            return new CustomBlockDefinition(this.identifier, this.nbt, this.tickSettings);
+            return new CustomBlockDefinition(this.identifier, this.nbt, this.tickSettings, this.isStepSensor);
         }
     }
 


### PR DESCRIPTION
**Implements onEntityStepOn and onEntityStepOff hooks for custom blocks with hasEntityStepSensor enabled, directly in the core.**

This feature aligns with vanilla BDS custom block components (e.g., onStepOn/onStepOff), but is more robust and performant since it is handled internally by the core rather than through external event listeners.

To enable step sensor detection on a custom block, use `.isStepSensor(true)` on the block definition builder (isStepSensor defaults to false).