### PR TITLE
Fix/Allow IntPropertyType ranges with non-zero min values

### DIFF
--- a/src/main/java/cn/nukkit/block/property/type/IntPropertyType.java
+++ b/src/main/java/cn/nukkit/block/property/type/IntPropertyType.java
@@ -25,7 +25,7 @@ public final class IntPropertyType extends BaseBlockPropertyType<Integer> {
         cachedValues = new IntPropertyValue[max - min + 1];
         for (int i = min; i <= max; i++) {
             IntPropertyValue value = new IntPropertyValue(i);
-            cachedValues[i] = value;
+            cachedValues[i - min] = value;
         }
     }
 


### PR DESCRIPTION
Fixes a bug in IntPropertyType where property ranges with a non-zero minimum value would cause an exception. The constructor now correctly handles integer property ranges starting at any minimum value, not just zero.