### PR TITLE
enhancement: Code Cleanup & Entity Query Enhancements

### DIFF
--- a/src/main/java/cn/nukkit/block/Block.java
+++ b/src/main/java/cn/nukkit/block/Block.java
@@ -694,11 +694,11 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
      */
     @Deprecated
     public boolean is(final String blockTag) {
-        return BlockTags.getTagSet(this.getId()).contains(blockTag);
+        return hasTag(blockTag);
     }
 
     /**
-     * @return if block has a string tag
+     * @return true if block has a string tag
      */
     public boolean hasTag(final String blockTag) {
         CustomBlockDefinition def = getCustomDefinition();
@@ -706,7 +706,7 @@ public abstract class Block extends Position implements Metadatable, AxisAligned
             CompoundTag nbt = def.nbt();
             if (nbt.contains("blockTags")) {
                 ListTag<StringTag> tagList = nbt.getList("blockTags", StringTag.class);
-                return tagList.getAll().contains(new StringTag(blockTag));
+                return tagList.getAll().stream().anyMatch(t -> blockTag.equals(t.data));
             }
         }
 

--- a/src/main/java/cn/nukkit/block/BlockDeadbush.java
+++ b/src/main/java/cn/nukkit/block/BlockDeadbush.java
@@ -59,7 +59,7 @@ public class BlockDeadbush extends BlockFlowable implements BlockFlowerPot.Flowe
     private boolean isSupportValid() {
         Block down = down();
         if(down instanceof BlockHardenedClay)  return true;
-        return down.is(BlockTags.DIRT) || down.is(BlockTags.SAND);
+        return down.hasTag(BlockTags.DIRT) || down.hasTag(BlockTags.SAND);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockDoublePlant.java
+++ b/src/main/java/cn/nukkit/block/BlockDoublePlant.java
@@ -88,7 +88,7 @@ public abstract class BlockDoublePlant extends BlockFlowable {
         if(support instanceof BlockDoublePlant plant) {
             return !plant.isTopHalf();
         }
-        return support.is(BlockTags.DIRT);
+        return support.hasTag(BlockTags.DIRT);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/block/BlockFlower.java
+++ b/src/main/java/cn/nukkit/block/BlockFlower.java
@@ -20,7 +20,7 @@ public abstract class BlockFlower extends BlockFlowable implements BlockFlowerPo
     }
 
     public static boolean isSupportValid(Block block) {
-        return block.is(BlockTags.DIRT);
+        return block.hasTag(BlockTags.DIRT);
     }
 
     public boolean canPlantOn(Block block) {

--- a/src/main/java/cn/nukkit/block/BlockHanging.java
+++ b/src/main/java/cn/nukkit/block/BlockHanging.java
@@ -28,7 +28,7 @@ public abstract class BlockHanging extends BlockFlowable {
     }
 
     protected boolean isSupportValid() {
-        return down().is(BlockTags.DIRT) || switch (down().getId()) {
+        return down().hasTag(BlockTags.DIRT) || switch (down().getId()) {
             case WARPED_NYLIUM, CRIMSON_NYLIUM, SOUL_SOIL -> true;
             default -> false;
         };

--- a/src/main/java/cn/nukkit/block/BlockReeds.java
+++ b/src/main/java/cn/nukkit/block/BlockReeds.java
@@ -174,7 +174,7 @@ public class BlockReeds extends BlockFlowable {
         if (downId.equals(REEDS)) {
             return true;
         }
-        if (!down.is(BlockTags.DIRT) && !down.is(BlockTags.SAND)) {
+        if (!down.hasTag(BlockTags.DIRT) && !down.hasTag(BlockTags.SAND)) {
             return false;
         }
         for (BlockFace face : BlockFace.Plane.HORIZONTAL) {

--- a/src/main/java/cn/nukkit/block/BlockSweetBerryBush.java
+++ b/src/main/java/cn/nukkit/block/BlockSweetBerryBush.java
@@ -155,7 +155,7 @@ public class BlockSweetBerryBush extends BlockFlowable {
     }
 
     public static boolean isSupportValid(Block block) {
-        return block.is(BlockTags.DIRT);
+        return block.hasTag(BlockTags.DIRT);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityConduit.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityConduit.java
@@ -218,9 +218,9 @@ public class BlockEntityConduit extends BlockEntitySpawnable {
             for (int iz = -1; iz <= 1; iz++) {
                 for (int iy = -1; iy <= 1; iy++) {
                     Block block = this.getLevel().getBlock(x + ix, y + iy, z + iz, 0);
-                    if (!block.is(BlockTags.WATER)) {
+                    if (!block.hasTag(BlockTags.WATER)) {
                         block = this.getLevel().getBlock(x + ix, y + iy, z + iz, 1);
-                        if (!block.is(BlockTags.WATER)) {
+                        if (!block.hasTag(BlockTags.WATER)) {
                             return false;
                         }
                     }

--- a/src/main/java/cn/nukkit/command/defaults/TagCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/TagCommand.java
@@ -49,7 +49,7 @@ public class TagCommand extends VanillaCommand {
                 String tag = list.getResult(2);
                 int success_count = 0;
                 for (Entity entity : entities) {
-                    if (entity.containTag(tag))
+                    if (entity.hasTag(tag))
                         continue;
                     entity.addTag(tag);
                     success_count++;
@@ -70,7 +70,7 @@ public class TagCommand extends VanillaCommand {
                 String tag = list.getResult(2);
                 int success_count = 0;
                 for (Entity entity : entities) {
-                    if (!entity.containTag(tag))
+                    if (!entity.hasTag(tag))
                         continue;
                     entity.removeTag(tag);
                     success_count++;

--- a/src/main/java/cn/nukkit/command/selector/args/impl/Tag.java
+++ b/src/main/java/cn/nukkit/command/selector/args/impl/Tag.java
@@ -23,7 +23,7 @@ public class Tag extends CachedSimpleSelectorArgument {
                 dontHave.add(tag);
             } else have.add(tag);
         }
-        return entity -> have.stream().allMatch(entity::containTag) && dontHave.stream().noneMatch(entity::containTag);
+        return entity -> have.stream().allMatch(entity::hasTag) && dontHave.stream().noneMatch(entity::hasTag);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -3022,16 +3022,13 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
         return server;
     }
 
-
     public boolean isUndead() {
         return false;
     }
 
-
     public boolean isInEndPortal() {
         return inEndPortal;
     }
-
 
     public boolean isPreventingSleep(Player player) {
         return false;
@@ -3056,26 +3053,21 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
         return hash;
     }
 
-
     public boolean isSpinAttacking() {
         return this.getDataFlag(EntityFlag.DAMAGE_NEARBY_MOBS);
     }
-
 
     public void setSpinAttacking(boolean value) {
         this.setDataFlag(EntityFlag.DAMAGE_NEARBY_MOBS, value);
     }
 
-
     public void setSpinAttacking() {
         this.setSpinAttacking(true);
     }
 
-
     public boolean isNoClip() {
         return noClip;
     }
-
 
     public void setNoClip(boolean noClip) {
         this.noClip = noClip;
@@ -3086,32 +3078,47 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
         return this instanceof EntityBoss;
     }
 
+    /**
+     * Add a tag to the entity
+     */
     public void addTag(String tag) {
         this.namedTag.putList("Tags", this.namedTag.getList("Tags", StringTag.class).add(new StringTag(tag)));
     }
 
-
+    /**
+     * Remove tag from entity if exist
+     */
     public void removeTag(String tag) {
         ListTag<StringTag> tags = this.namedTag.getList("Tags", StringTag.class);
         tags.remove(new StringTag(tag));
         this.namedTag.putList("Tags", tags);
     }
 
-
+    /**
+     * @deprecated Use {@link #hasTag(String)} instead.
+     */
+    @Deprecated
     public boolean containTag(String tag) {
+        return hasTag(tag);
+    }
+
+    /**
+     * @return true if entity has a string tag
+     */
+    public boolean hasTag(String tag) {
         return this.namedTag.getList("Tags", StringTag.class).getAll().stream().anyMatch(t -> t.data.equals(tag));
     }
 
-
+    /**
+     * @return List of tags for the entity
+     */
     public List<StringTag> getAllTags() {
         return this.namedTag.getList("Tags", StringTag.class).getAll();
     }
 
-
     public float getFreezingEffectStrength() {
         return this.getDataProperty(FREEZING_EFFECT_STRENGTH);
     }
-
 
     public void setFreezingEffectStrength(float strength) {
         if (strength < 0 || strength > 1)
@@ -3119,17 +3126,14 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
         this.setDataProperty(FREEZING_EFFECT_STRENGTH, strength);
     }
 
-
     public int getFreezingTicks() {
         return this.freezingTicks;
     }
-
 
     public void setFreezingTicks(int ticks) {
         this.freezingTicks = Math.max(0, Math.min(ticks, 140));
         setFreezingEffectStrength(ticks / 140f);
     }
-
 
     public void addFreezingTicks(int increments) {
         if (freezingTicks + increments < 0) this.freezingTicks = 0;
@@ -3138,26 +3142,21 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
         setFreezingEffectStrength(this.freezingTicks / 140f);
     }
 
-
     public void setAmbientSoundInterval(float interval) {
         this.setDataProperty(AMBIENT_SOUND_INTERVAL, interval);
     }
-
 
     public void setAmbientSoundIntervalRange(float range) {
         this.setDataProperty(AMBIENT_SOUND_INTERVAL, range);
     }
 
-
     public void setAmbientSoundEvent(Sound sound) {
         this.setAmbientSoundEventName(sound.getSound());
     }
 
-
     public void setAmbientSoundEventName(String eventName) {
         this.setDataProperty(AMBIENT_SOUND_EVENT_NAME, eventName);
     }
-
 
     public void playAnimation(AnimateEntityPacket.Animation animation) {
         var viewers = new HashSet<>(this.getViewers().values());
@@ -3179,7 +3178,6 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
         pk.entityRuntimeIds.add(this.getId());
         Server.broadcastPacket(players, pk);
     }
-
 
     public void playActionAnimation(AnimatePacket.Action action, float rowingTime) {
         var viewers = new HashSet<>(this.getViewers().values());

--- a/src/main/java/cn/nukkit/entity/EntityQueryOptions.java
+++ b/src/main/java/cn/nukkit/entity/EntityQueryOptions.java
@@ -1,0 +1,299 @@
+package cn.nukkit.entity;
+
+import cn.nukkit.math.Vector3;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
+
+/**
+ * Options for filtering and sorting results from {@code Level#getEntities(...)}.
+ *
+ * <p>Combine position, distance, type, tags, and custom predicates to refine search results.
+ * All filters are ANDed. If no spatial constraint is set, only loaded entities are scanned.</p>
+ *
+ * <p><b>Spatial filters:</b></p>
+ * <ul>
+ *     <li><b>location</b> – Center point for distance/volume filters.</li>
+ *     <li><b>maxDistance</b> – Max spherical distance from location (requires location).</li>
+ *     <li><b>minDistance</b> – Min spherical distance from location (requires location).</li>
+ *     <li><b>volume</b> – Cuboid width/height/depth centered at location, useful for axis-aligned scans.</li>
+ *     <li><b>margin</b> – Extra blocks to avoid missing large mobs crossing chunk borders (e.g., ghasts, bosses).</li>
+ *     <li><b>exactLocationMatch</b> – Only match entities exactly at block coords of location (ignores hitbox size).</li>
+ * </ul>
+ *
+ * <p><b>Result limits & ordering:</b></p>
+ * <ul>
+ *     <li><b>limit</b> – Max results after filtering/sorting. Handy for performance-sensitive scans.</li>
+ *     <li><b>closest</b> – Keep N closest entities (requires location).</li>
+ *     <li><b>farthest</b> – Keep N farthest entities (requires location).</li>
+ * </ul>
+ *
+ * <p><b>Entity filters:</b></p>
+ * <ul>
+ *     <li><b>tags</b> – Required tags; entity must have all. Matches {@code Entity.hasTag(...)}.</li>
+ *     <li><b>excludeTags</b> – Tags that must not be present.</li>
+ *     <li><b>typeClass</b> – Match only a given entity class/subclass (e.g., {@code EntityZombie.class}).</li>
+ *     <li><b>nameTagEquals</b> – Exact case-sensitive match for {@code Entity.getNameTag()}.</li>
+ *     <li><b>predicate</b> – Java predicate filter for any complex logic.</li>
+ * </ul>
+ *
+ * <p><b>Chunk loading:</b></p>
+ * <ul>
+ *     <li><b>loadChunks</b> – If true, loads chunks in the search area. Default: false. 
+ *     Use with care to avoid lag spikes.</li>
+ * </ul>
+ *
+ * <p><b>Factory methods:</b></p>
+ * <ul>
+ *     <li>{@link #of(Vector3, double)} – Quick center + radius query.</li>
+ *     <li>{@link #of(Vector3, double, boolean)} – Same, but can load chunks.</li>
+ * </ul>
+ *
+ * <p><b>Example:</b> find the 10 closest zombies within 50 blocks:</p>
+ * <pre>
+ *     List<Entity> zombies = level.getEntities(
+ *         new EntityQueryOptions()
+ *             .location(player.getPosition())
+ *             .maxDistance(50)
+ *             .typeClass(EntityZombie.class)
+ *             .closest(10)
+ *     );
+ * </pre>
+ */
+public final class EntityQueryOptions {
+    public Vector3 location;
+    public Double maxDistance;
+    public Double minDistance;
+    public Vector3 volume;
+
+    public Integer limit;
+    public Integer closest;
+    public Integer farthest;
+
+    public Set<String> tags;
+    public Set<String> excludeTags;
+    public Class<? extends Entity> typeClass;
+    public String nameTagEquals;
+
+    public Predicate<Entity> predicate;
+
+    public boolean loadChunks = false;
+    public double margin = 3.5;
+    public boolean exactLocationMatch = false;
+
+    /**
+     * Sets the center location of the entity search.
+     * <p>
+     * Used as the reference for distance, cuboid volume,
+     * closest/farthest sorting, and exact-location match.
+     *
+     * @param location The {@link Vector3} to center the query on.
+     * @return This {@link EntityQueryOptions} for chaining.
+     */
+    public EntityQueryOptions location(Vector3 location) {
+        this.location = location;
+        return this;
+    }
+
+    /**
+     * Sets the maximum spherical distance (radius) from {@link #location}.
+     * <p>
+     * Requires {@link #location(Vector3)}.
+     *
+     * @param maxDistance Distance in blocks.
+     * @return This {@link EntityQueryOptions} for chaining.
+     */
+    public EntityQueryOptions maxDistance(double maxDistance) {
+        this.maxDistance = maxDistance;
+        return this;
+    }
+
+    /**
+     * Sets the minimum spherical distance (radius) from {@link #location}.
+     * <p>
+     * Requires {@link #location(Vector3)}.
+     *
+     * @param minDistance Distance in blocks.
+     * @return This {@link EntityQueryOptions} for chaining.
+     */
+    public EntityQueryOptions minDistance(double minDistance) {
+        this.minDistance = minDistance;
+        return this;
+    }
+
+    /**
+     * Sets a cuboid volume (width, height, depth) centered at {@link #location}.
+     * <p>
+     * Example: {@code new Vector3(10, 5, 10)} scans a 10×5×10 box.
+     * Requires {@link #location(Vector3)}.
+     *
+     * @param volume The dimensions in blocks.
+     * @return This {@link EntityQueryOptions} for chaining.
+     */
+    public EntityQueryOptions volume(Vector3 volume) {
+        this.volume = volume;
+        return this;
+    }
+
+    /**
+     * Limits the number of entities returned (after filtering/sorting).
+     *
+     * @param limit Max result count.
+     * @return This {@link EntityQueryOptions} for chaining.
+     */
+    public EntityQueryOptions limit(int limit) {
+        this.limit = limit;
+        return this;
+    }
+
+    /**
+     * Keeps only the N closest entities to {@link #location}.
+     * <p>
+     * Requires {@link #location(Vector3)}.
+     *
+     * @param closest Number to keep.
+     * @return This {@link EntityQueryOptions} for chaining.
+     */
+    public EntityQueryOptions closest(int closest) {
+        this.closest = closest;
+        return this;
+    }
+
+    /**
+     * Keeps only the N farthest entities from {@link #location}.
+     * <p>
+     * Requires {@link #location(Vector3)}.
+     *
+     * @param farthest Number to keep.
+     * @return This {@link EntityQueryOptions} for chaining.
+     */
+    public EntityQueryOptions farthest(int farthest) {
+        this.farthest = farthest;
+        return this;
+    }
+
+    /**
+     * Requires that entities contain all given tags.
+     *
+     * @param tags One or more tag strings.
+     * @return This {@link EntityQueryOptions} for chaining.
+     */
+    public EntityQueryOptions tags(String... tags) {
+        this.tags = new HashSet<>(Arrays.asList(tags));
+        return this;
+    }
+
+    /**
+     * Requires that entities contain none of the given tags.
+     *
+     * @param excludeTags One or more tag strings to exclude.
+     * @return This {@link EntityQueryOptions} for chaining.
+     */
+    public EntityQueryOptions excludeTags(String... excludeTags) {
+        this.excludeTags = new HashSet<>(Arrays.asList(excludeTags));
+        return this;
+    }
+
+    /**
+     * Matches entities by Java class (subclasses allowed).
+     * <p>
+     * Example: {@code typeClass(EntityZombie.class)}.
+     *
+     * @param typeClass The class to match.
+     * @return This {@link EntityQueryOptions} for chaining.
+     */
+    public EntityQueryOptions typeClass(Class<? extends Entity> typeClass) {
+        this.typeClass = typeClass;
+        return this;
+    }
+
+    /**
+     * Exact, case-sensitive match for {@code Entity.getNameTag()}.
+     *
+     * @param nameTagEquals The name tag to match.
+     * @return This {@link EntityQueryOptions} for chaining.
+     */
+    public EntityQueryOptions nameTagEquals(String nameTagEquals) {
+        this.nameTagEquals = nameTagEquals;
+        return this;
+    }
+
+    /**
+     * Applies a custom predicate after spatial filters.
+     *
+     * @param predicate Returns true to include the entity.
+     * @return This {@link EntityQueryOptions} for chaining.
+     */
+    public EntityQueryOptions predicate(Predicate<Entity> predicate) {
+        this.predicate = predicate;
+        return this;
+    }
+
+    /**
+     * Whether to load chunks that are not loaded.
+     * <p>
+     * Default: false (unloaded chunks are skipped).
+     *
+     * @param loadChunks True to load on demand.
+     * @return This {@link EntityQueryOptions} for chaining.
+     */
+    public EntityQueryOptions loadChunks(boolean loadChunks) {
+        this.loadChunks = loadChunks;
+        return this;
+    }
+
+    /**
+     * Expands the scan window slightly to account for large hitboxes crossing chunk borders.
+     *
+     * @param margin Extra distance in blocks.
+     * @return This {@link EntityQueryOptions} for chaining.
+     */
+    public EntityQueryOptions margin(double margin) {
+        this.margin = margin;
+        return this;
+    }
+
+    /**
+     * Only match entities whose block coordinates exactly equal {@link #location}.
+     * Ignores hitbox size and neighbors.
+     *
+     * @param exactLocationMatch True to enable exact block match.
+     * @return This {@link EntityQueryOptions} for chaining.
+     */
+    public EntityQueryOptions exactLocationMatch(boolean exactLocationMatch) {
+        this.exactLocationMatch = exactLocationMatch;
+        return this;
+    }
+
+
+    /**
+     * Convenience: center + radius.
+     *
+     * @param center Center location.
+     * @param radius Spherical radius in blocks.
+     * @return New {@link EntityQueryOptions}.
+     */
+    public static EntityQueryOptions of(Vector3 center, double radius) {
+        return new EntityQueryOptions()
+                .location(center)
+                .maxDistance(radius);
+    }
+
+    /**
+     * Convenience: center + radius + optional chunk loading.
+     *
+     * @param center Center location.
+     * @param radius Spherical radius in blocks.
+     * @param loadChunks Whether to load chunks.
+     * @return New {@link EntityQueryOptions}.
+     */
+    public static EntityQueryOptions of(Vector3 center, double radius, boolean loadChunks) {
+        return new EntityQueryOptions()
+                .location(center)
+                .maxDistance(radius)
+                .loadChunks(loadChunks);
+    }
+}

--- a/src/main/java/cn/nukkit/inventory/ShulkerBoxInventory.java
+++ b/src/main/java/cn/nukkit/inventory/ShulkerBoxInventory.java
@@ -74,7 +74,7 @@ public class ShulkerBoxInventory extends ContainerInventory {
 
     @Override
     public boolean canAddItem(Item item) {
-        if (item.isBlock() && item.getBlockUnsafe().is(BlockTags.PNX_SHULKERBOX)) {
+        if (item.isBlock() && item.getBlockUnsafe().hasTag(BlockTags.PNX_SHULKERBOX)) {
             // Do not allow nested shulker boxes.
             return false;
         }

--- a/src/main/java/cn/nukkit/level/vibration/SimpleVibrationManager.java
+++ b/src/main/java/cn/nukkit/level/vibration/SimpleVibrationManager.java
@@ -92,6 +92,6 @@ public class SimpleVibrationManager implements VibrationManager {
     protected boolean canVibrationArrive(Level level, Vector3 from, Vector3 to) {
         return VectorMath.getPassByVector3(from, to)
                 .stream()
-                .noneMatch(vec -> level.getTickCachedBlock(vec).is(BlockTags.PNX_WOOL));
+                .noneMatch(vec -> level.getTickCachedBlock(vec).hasTag(BlockTags.PNX_WOOL));
     }
 }


### PR DESCRIPTION
- Removed all internal usages of deprecated methods of block.is(), as replacement is now `block.hasTag()`.
- Deprecated entity containTag to follow the same standard as blocks with `entity.hasTag()`.
- Added EntityQueryOptions for flexible filtering in `getEntities()` calls, this improvement was done because the fastNearbyEntities() & getNearbyEntities() was not intended to be used as getEntities should do, mirroring BDS behavior (more explanation below).
- Began refactoring getEntities() to integrate EntityQueryOptions (work in progress).

**Refactors getEntities to avoid false negatives caused by strict bounding box intersection in getNearbyEntities/fastNearbyEntities, ensuring large entities are detected even when the search box is smaller than their hitbox.**

**WIP:** Refactor `getEntities()`.