### PR TITLE
fix: Correct chunk register/unregister logic in Level

### DIFF
--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -929,7 +929,7 @@ public class Level implements Metadatable {
             this.loaderCounter.put(hash, this.loaderCounter.get(hash) + 1);
         }
 
-        this.cancelUnloadChunkRequest(hash);
+        this.cancelUnloadChunkRequest(chunkX, chunkZ);
 
         if (autoLoad) {
             this.loadChunk(chunkX, chunkZ);
@@ -939,7 +939,7 @@ public class Level implements Metadatable {
     public boolean unregisterChunkLoader(ChunkLoader loader, int chunkX, int chunkZ, boolean isSafeUnload) {
         int loaderId = loader.getLoaderId();
         long chunkHash = Level.chunkHash(chunkX, chunkZ);
-        if(chunkHash < 0) return false;
+
         Map<Integer, ChunkLoader> chunkLoadersIndex = this.chunkLoaders.get(chunkHash);
         if (chunkLoadersIndex != null) {
             ChunkLoader oldLoader = chunkLoadersIndex.remove(loaderId);


### PR DESCRIPTION
In **registerChunkLoader()**, cancel unload by chunk index instead of loaderId (cancelUnloadChunkRequest(chunkX, chunkZ)), so the right entry is removed from unloadQueue and pinned chunks aren’t repeatedly considered for unload.

In **unregisterChunkLoader()**, remove the invalid check if (chunkHash < 0) return false; — chunkHash negative values are valid.

**With the change chunks being unregistered via unregisterChunkLoader reliably gets unloaded, avoiding stale chunks in memory.**