### PR TITLE
Fix: getSafeSpawn() on Level fuzzing when radius was set to 0 on config

### DIFF
--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -4150,10 +4150,10 @@ public class Level implements Metadatable {
 
     public Position getSafeSpawn(Vector3 spawn, int horizontalMaxOffset, boolean allowWaterUnder) {
         if (spawn == null)
-            spawn = this.getFuzzySpawnLocation();
+            spawn = (horizontalMaxOffset == 0) ? this.getSpawnLocation().add(0.5, 0, 0.5) : this.getFuzzySpawnLocation();
         if (spawn == null)
             return null;
-        if (standable(spawn, true))
+        if (standable(spawn, allowWaterUnder))
             return Position.fromObject(spawn, this);
 
         int maxY = getDimensionData().getMaxHeight();


### PR DESCRIPTION
getSafeSpawn() on Level should not fuzzy if spawn radius is set to 0, in this scenario the spawn location must be exactly the one defined in the level dat.