### PR TITLE
Changed is() method from items to hasTag() as standard used by blocks and entities.

### DIFF
--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -818,7 +818,18 @@ public abstract class Item implements Cloneable, ItemID {
         return Objects.equals(this.id, Block.AIR) || this.count <= 0;
     }
 
+    /**
+     * @deprecated Use {@link #hasTag(String)} instead.
+     */
+    @Deprecated
     public boolean is(final String itemTag) {
+        return hasTag(itemTag);
+    }
+
+    /**
+     * @return true if item has a string tag
+     */
+    public boolean hasTag(final String itemTag) {
         boolean contains = ItemTags.getTagSet(this.getId()).contains(itemTag);
         if (contains) return true;
         return ItemTags.getTagSet(this.getBlockId()).contains(itemTag);


### PR DESCRIPTION
Changed is() from items to follow the standard used by BDS and other changes made on blocks and entities that used to have the same method.
As mentioned before, a method is() is to vague... is() what?