### PR TITLE
Initial commit, added support for dynamicProperties on items

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -126,6 +126,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
 
 /**
  * Represents a server object, global singleton.
@@ -201,6 +202,13 @@ public class Server {
     private final Map<UUID, Player> playerList = new ConcurrentHashMap<>();
     private QueryRegenerateEvent queryRegenerateEvent;
     private PositionTrackingService positionTrackingService;
+
+    // Dynamic Properties defaults
+    private static volatile String DP_DEFAULT_GROUP_UUID = "00000000-0000-0000-0000-000000000000";
+    private static final int DP_MAX_STRING_BYTES = 32767;
+    private static final double DP_NUMBER_ABS_MAX = 9_223_372_036_854_775_807d;
+    private static final Pattern DP_UUID_CANON =
+                Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
 
     private final Map<Integer, Level> levels = new HashMap<>() {
         @Override
@@ -2748,6 +2756,19 @@ public class Server {
     public List<ExperimentEntry> getExperiments() {
         return experiments;
     }
+
+    /** Allow plugins to override the default DP group UUID (e.g., when migrating from BDS). */
+    public static void setDefaultDynamicPropertiesGroupUUID(String uuid) {
+        if (uuid == null || !DP_UUID_CANON.matcher(uuid).matches()) {
+            log.warn("DynamicProperties default group UUID rejected: '{}'", uuid);
+            return;
+        }
+        DP_DEFAULT_GROUP_UUID = uuid.toLowerCase();
+    }
+
+    public static String getDefaultDynamicPropertiesGroupUUID() { return DP_DEFAULT_GROUP_UUID; }
+    public static int    getDynamicPropertiesMaxStringBytes()   { return DP_MAX_STRING_BYTES; }
+    public static double getDynamicPropertiesNumberAbsMax()     { return DP_NUMBER_ABS_MAX; }
 
     //todo NukkitConsole 会阻塞关不掉
     private class ConsoleThread extends Thread implements InterruptibleThread {

--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -1,6 +1,7 @@
 package cn.nukkit.item;
 
 import cn.nukkit.Player;
+import cn.nukkit.Server;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockAir;
 import cn.nukkit.block.BlockID;
@@ -11,9 +12,14 @@ import cn.nukkit.level.Level;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.math.Vector3;
 import cn.nukkit.nbt.NBTIO;
+import cn.nukkit.nbt.tag.ByteTag;
 import cn.nukkit.nbt.tag.CompoundTag;
+import cn.nukkit.nbt.tag.DoubleTag;
+import cn.nukkit.nbt.tag.FloatTag;
 import cn.nukkit.nbt.tag.IntTag;
 import cn.nukkit.nbt.tag.ListTag;
+import cn.nukkit.nbt.tag.LongTag;
+import cn.nukkit.nbt.tag.ShortTag;
 import cn.nukkit.nbt.tag.StringTag;
 import cn.nukkit.nbt.tag.Tag;
 import cn.nukkit.registry.Registries;
@@ -34,9 +40,11 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
 
@@ -60,6 +68,12 @@ public abstract class Item implements Cloneable, ItemID {
     private byte[] tags = EmptyArrays.EMPTY_BYTES;
     private CompoundTag cachedNBT;
     private static int STACK_NETWORK_ID_COUNTER = 1;
+    private static String DP_DEFAULT_GROUP_UUID() {
+        return Server.getDefaultDynamicPropertiesGroupUUID();
+    }
+    private static final int    DP_MAX_STRING_BYTES = Server.getDynamicPropertiesMaxStringBytes();
+    private static final double DP_NUMBER_ABS_MAX   = Server.getDynamicPropertiesNumberAbsMax();
+    private static final String DP_ROOT = "DynamicProperties";
 
     private String idConvertToName() {
         if (this.name != null) {
@@ -689,6 +703,361 @@ public abstract class Item implements Cloneable, ItemID {
         this.setNamedTag(tag);
         return this;
     }
+
+    /**
+     * Remove a DynamicProperty by key Id.
+     *
+     * @param key the key id of the DynamicProperty
+     */
+    public Item removeDynamicProperty(String key) {
+        CompoundTag group = getDynamicPropertiesGroup(DP_DEFAULT_GROUP_UUID());
+        if (group == null) return this;
+        if (group.contains(key)) {
+            group.remove(key);
+            saveDynamicPropertiesGroup(DP_DEFAULT_GROUP_UUID(), group);
+        }
+        return this;
+    }
+
+    /**
+     * Remove all DynamicProperties on the item.
+     */
+    public Item clearDynamicProperties() {
+        CompoundTag group = getDynamicPropertiesGroup(DP_DEFAULT_GROUP_UUID());
+        if (group == null) return this;
+        saveDynamicPropertiesGroup(DP_DEFAULT_GROUP_UUID(), new CompoundTag());
+        return this;
+    }
+
+    /**
+     * Set a double int DynamicProperty.
+     *
+     * @param key the key id of the DynamicProperty
+     * @param value the double int value of the DynamicProperty
+     */
+    public Item setDynamicProperty(String key, Double value) {
+        if (value == null) return removeDynamicProperty(key);
+        if (!isFiniteAndInRange(value)) {
+            log.warn("DynamicProperty '{}' rejected: out of numeric bounds or non-finite (value={})", key, value);
+            return this;
+        }
+        CompoundTag g = ensureDynamicPropertiesGroup(DP_DEFAULT_GROUP_UUID());
+        g.putDouble(key, value);
+        saveDynamicPropertiesGroup(DP_DEFAULT_GROUP_UUID(), g);
+        return this;
+    }
+
+    /**
+     * Set a int DynamicProperty.
+     *
+     * @param key the key id of the DynamicProperty
+     * @param value the int value of the DynamicProperty
+     */
+    public Item setDynamicProperty(String key, Integer value) {
+        return setDynamicProperty(key, value == null ? null : value.doubleValue());
+    }
+
+    /**
+     * Set a int DynamicProperty.
+     *
+     * @param key the key id of the DynamicProperty
+     * @param value the int value of the DynamicProperty
+     */
+    public Item setDynamicProperty(String key, Float value) {
+        return setDynamicProperty(key, value == null ? null : value.doubleValue());
+    }
+
+    /**
+     * Set a boolean DynamicProperty.
+     *
+     * @param key the key id of the DynamicProperty
+     * @param bool the bool value of the DynamicProperty
+     */
+    public Item setDynamicProperty(String key, Boolean bool) {
+        if (bool == null) return removeDynamicProperty(key);
+        CompoundTag g = ensureDynamicPropertiesGroup(DP_DEFAULT_GROUP_UUID());
+        g.putBoolean(key, bool);
+        saveDynamicPropertiesGroup(DP_DEFAULT_GROUP_UUID(), g);
+        return this;
+    }
+
+    /**
+     * Set a string DynamicProperty.
+     *
+     * @param key the key id of the DynamicProperty
+     * @param string the string value of the DynamicProperty
+     */
+    public Item setDynamicProperty(String key, String string) {
+        if (string == null) return removeDynamicProperty(key);
+        if (!fitsUtf8Limit(string)) {
+            log.warn("DynamicProperty '{}' rejected: string exceeds {} UTF-8 bytes", key, DP_MAX_STRING_BYTES);
+            return this;
+        }
+        CompoundTag g = ensureDynamicPropertiesGroup(DP_DEFAULT_GROUP_UUID());
+        g.putString(key, string);
+        saveDynamicPropertiesGroup(DP_DEFAULT_GROUP_UUID(), g);
+        return this;
+    }
+
+    /**
+     * Set a Vec3 DynamicProperty.
+     *
+     * @param key the key id of the DynamicProperty
+     * @param vec3 the vec3 value of the DynamicProperty
+     */
+    public Item setVec3DynamicProperty(String key, Vector3 vec3) {
+        if (vec3 == null) return removeDynamicProperty(key);
+        if (!isFiniteAndInRange(vec3.x) || !isFiniteAndInRange(vec3.y) || !isFiniteAndInRange(vec3.z)) {
+            log.warn("DynamicProperty '{}' rejected: vec3 has component(s) out of bounds or non-finite (x={}, y={}, z={})", key, vec3.x, vec3.y, vec3.z);
+            return this;
+        }
+        ListTag<FloatTag> list = new ListTag<>();
+        list.add(new FloatTag("", (float) vec3.x));
+        list.add(new FloatTag("", (float) vec3.y));
+        list.add(new FloatTag("", (float) vec3.z));
+        CompoundTag g = ensureDynamicPropertiesGroup(DP_DEFAULT_GROUP_UUID());
+        g.putList(key, list);
+        saveDynamicPropertiesGroup(DP_DEFAULT_GROUP_UUID(), g);
+        return this;
+    }
+
+    /**
+     * Set a Vec3 DynamicProperty.
+     *
+     * @param key the key id of the DynamicProperty
+     * @param xyz a map with keys "x","y","z" and numeric values, e.g. {x: 400, y: 60, z: 300}
+     */
+    public Item setVec3DynamicProperty(String key, Map<String, Number> xyz) {
+        if (xyz == null) return removeDynamicProperty(key);
+        Number nx = xyz.get("x"), ny = xyz.get("y"), nz = xyz.get("z");
+        if (nx == null || ny == null || nz == null) {
+            log.warn("DynamicProperty '{}' rejected: vec3 map must contain numeric keys 'x','y','z'", key);
+            return this;
+        }
+        double x = nx.doubleValue(), y = ny.doubleValue(), z = nz.doubleValue();
+        if (!isFiniteAndInRange(x) || !isFiniteAndInRange(y) || !isFiniteAndInRange(z)) {
+            log.warn("DynamicProperty '{}' rejected: vec3 has component(s) out of bounds or non-finite (x={}, y={}, z={})", key, x, y, z);
+            return this;
+        }
+        ListTag<FloatTag> list = new ListTag<>();
+        list.add(new FloatTag("", (float) x));
+        list.add(new FloatTag("", (float) y));
+        list.add(new FloatTag("", (float) z));
+        CompoundTag g = ensureDynamicPropertiesGroup(DP_DEFAULT_GROUP_UUID());
+        g.putList(key, list);
+        saveDynamicPropertiesGroup(DP_DEFAULT_GROUP_UUID(), g);
+        return this;
+    }
+
+    /**
+     * Get a double int DynamicProperty.
+     *
+     * @param key the key id of the DynamicProperty
+     * @return the double int value or null if not available.
+     */
+    public Double getDoubleDynamicProperty(String key) {
+        Tag t = findDynamicPropertyTagInConfiguredGroup(key);
+        if (t == null) return null;
+        if (t instanceof DoubleTag) return ((DoubleTag) t).data;
+        if (t instanceof FloatTag)  return (double) ((FloatTag)  t).data;
+        if (t instanceof IntTag)    return (double) ((IntTag)   t).data;
+        if (t instanceof LongTag)   return (double) ((LongTag)  t).data;
+        if (t instanceof ShortTag)  return (double) ((ShortTag) t).data;
+        if (t instanceof ByteTag)   return (double) ((ByteTag)  t).data;
+        if (t instanceof StringTag) {
+            try { return Double.parseDouble(((StringTag) t).data.trim()); } catch (NumberFormatException ignored) {}
+        }
+        return null;
+    }
+
+    /**
+     * Get a double int DynamicProperty.
+     *
+     * @param key the key id of the DynamicProperty
+     * @param defaultValue the default value to be returned if null.
+     * @return the double int value or defaultValue if not available.
+     */
+    public Double getDoubleDynamicProperty(String key, double defaultValue) {
+        Double d = getDoubleDynamicProperty(key);
+        return (d != null) ? d : defaultValue;
+    }
+
+    /**
+     * Get a int DynamicProperty.
+     *
+     * @param key the key id of the DynamicProperty
+     * @return the int value or defaultValue if not available.
+     */
+    public Integer getIntDynamicProperty(String key) {
+        Double d = getDoubleDynamicProperty(key);
+        if (d == null) return null;
+        return (int) Math.floor(d);
+    }
+
+    /**
+     * Get a int DynamicProperty.
+     *
+     * @param key the key id of the DynamicProperty
+     * @param defaultValue the default value to be returned if null.
+     * @return the int value or defaultValue if not available.
+     */
+    public int getIntDynamicProperty(String key, int defaultValue) {
+        Integer i = getIntDynamicProperty(key);
+        return (i != null) ? i : defaultValue;
+    }
+
+    /**
+     * Get a float DynamicProperty.
+     *
+     * @param key the key id of the DynamicProperty
+     * @return the float value or null if not available.
+     */
+    public Float getFloatDynamicProperty(String key) {
+        Double d = getDoubleDynamicProperty(key);
+        if (d == null) return null;
+        return d.floatValue();
+    }
+
+    /**
+     * Get a float DynamicProperty.
+     *
+     * @param key the key id of the DynamicProperty
+     * @param defaultValue the default value to be returned if null.
+     * @return the float value or defaultValue if not available.
+     */
+    public float getFloatDynamicProperty(String key, float defaultValue) {
+        Float f = getFloatDynamicProperty(key);
+        return (f != null) ? f : defaultValue;
+    }
+
+    /**
+     * Get a boolean DynamicProperty.
+     *
+     * @param key the key id of the DynamicProperty
+     * @return the bool value or false if not available.
+     */
+    public Boolean getBoolDynamicProperty(String key) {
+        Tag t = findDynamicPropertyTagInConfiguredGroup(key);
+        if (t == null) return null;
+        if (t instanceof ByteTag)   return ((ByteTag) t).data != 0;
+        Double d = getDoubleDynamicProperty(key);
+        if (d != null) return d != 0.0;
+        if (t instanceof StringTag) {
+            String s = ((StringTag) t).data.trim().toLowerCase();
+            if ("true".equals(s) || "1".equals(s))  return true;
+            if ("false".equals(s) || "0".equals(s)) return false;
+        }
+        return null;
+    }
+
+    /**
+     * Get a boolean DynamicProperty.
+     *
+     * @param key the key id of the DynamicProperty
+     * @param defaultValue the default value to be returned if null.
+     * @return the bool value or defaultValue if not available.
+     */
+    public boolean getBoolDynamicProperty(String key, boolean defaultValue) {
+        Boolean b = getBoolDynamicProperty(key);
+        return (b != null) ? b : defaultValue;
+    }
+
+    /**
+     * Get a string DynamicProperty.
+     *
+     * @param key the key id of the DynamicProperty
+     * @return the bool value or null if not available.
+     */
+    public String getStringDynamicProperty(String key) {
+        Tag t = findDynamicPropertyTagInConfiguredGroup(key);
+        if (t == null) return null;
+        if (t instanceof StringTag) return ((StringTag) t).data;
+        if (t instanceof DoubleTag) return String.valueOf(((DoubleTag) t).data);
+        if (t instanceof FloatTag)  return String.valueOf(((FloatTag)  t).data);
+        if (t instanceof IntTag)    return String.valueOf(((IntTag)    t).data);
+        if (t instanceof LongTag)   return String.valueOf(((LongTag)   t).data);
+        if (t instanceof ShortTag)  return String.valueOf(((ShortTag)  t).data);
+        if (t instanceof ByteTag)   return String.valueOf(((ByteTag)   t).data);
+        return null;
+    }
+
+    /**
+     * Get a string DynamicProperty.
+     *
+     * @param key the key id of the DynamicProperty
+     * @param defaultValue the default value to be returned if null.
+     * @return the string value or defaultValue if not available.
+     */
+    public String getStringDynamicProperty(String key, String defaultValue) {
+        String s = getStringDynamicProperty(key);
+        return (s != null) ? s : defaultValue;
+    }
+
+    /**
+     * Get a vec3 DynamicProperty.
+     *
+     * @param key the key id of the DynamicProperty
+     * @return the bool value or null if not available.
+     */
+    public Vector3 getVec3DynamicProperty(String key) {
+        Tag t = findDynamicPropertyTagInConfiguredGroup(key);
+        if (!(t instanceof ListTag)) return null;
+        ListTag<?> list = (ListTag<?>) t;
+        if (list.size() != 3 || !(list.get(0) instanceof FloatTag) || !(list.get(1) instanceof FloatTag) || !(list.get(2) instanceof FloatTag)) {
+            return null;
+        }
+        float x = ((FloatTag) list.get(0)).data;
+        float y = ((FloatTag) list.get(1)).data;
+        float z = ((FloatTag) list.get(2)).data;
+        return new Vector3(x, y, z);
+    }
+
+    // Dynamic Properties Helpers start
+    private static boolean isFiniteAndInRange(double v) {
+        return !Double.isNaN(v) && !Double.isInfinite(v) && Math.abs(v) <= DP_NUMBER_ABS_MAX;
+    }
+
+    private static boolean fitsUtf8Limit(String s) {
+        if (s == null) return false;
+        int byteCount = s.getBytes(StandardCharsets.UTF_8).length;
+        return byteCount <= DP_MAX_STRING_BYTES;
+    }
+
+    private CompoundTag ensureDynamicPropertiesGroup(String groupId) {
+        CompoundTag root = this.hasCompoundTag() ? this.getNamedTag() : new CompoundTag();
+        CompoundTag dyn  = root.getCompound(DP_ROOT);
+        if (dyn == null) dyn = new CompoundTag();
+        CompoundTag group = dyn.getCompound(groupId);
+        if (group == null) group = new CompoundTag();
+        dyn.putCompound(groupId, group);
+        root.putCompound(DP_ROOT, dyn);
+        this.setNamedTag(root);
+        return group;
+    }
+
+    private CompoundTag getDynamicPropertiesGroup(String groupId) {
+        CompoundTag root = this.getNamedTag();
+        if (root == null || !root.contains(DP_ROOT)) return null;
+        CompoundTag dyn = root.getCompound(DP_ROOT);
+        if (dyn == null) return null;
+        return dyn.getCompound(groupId);
+    }
+
+    private void saveDynamicPropertiesGroup(String groupId, CompoundTag group) {
+        CompoundTag root = this.hasCompoundTag() ? this.getNamedTag() : new CompoundTag();
+        CompoundTag dyn  = root.getCompound(DP_ROOT);
+        if (dyn == null) dyn = new CompoundTag();
+        dyn.putCompound(groupId, group);
+        root.putCompound(DP_ROOT, dyn);
+        this.setNamedTag(root);
+    }
+
+    private Tag findDynamicPropertyTagInConfiguredGroup(String key) {
+        CompoundTag group = getDynamicPropertiesGroup(DP_DEFAULT_GROUP_UUID());
+        if (group == null || !group.contains(key)) return null;
+        return group.get(key);
+    }
+    // Dynamic Properties Helpers end
 
     public Tag getNamedTagEntry(String name) {
         CompoundTag tag = this.getNamedTag();

--- a/src/main/java/cn/nukkit/nbt/tag/FloatTag.java
+++ b/src/main/java/cn/nukkit/nbt/tag/FloatTag.java
@@ -14,6 +14,18 @@ public class FloatTag extends NumberTag<Float> {
         this.data = data;
     }
 
+    public FloatTag(String name) {
+        this.data = 0f;
+    }
+
+    public FloatTag(String name, float data) {
+        this.data = data;
+    }
+
+    public FloatTag(String name, double data) {
+        this.data = (float) data;
+    }
+
     @Override
     public Float getData() {
         return data;


### PR DESCRIPTION
Initial commit, added support for dynamicProperties on items
For reference this is how BDS is storing dynamic properties on items, it might be the same for entities, but the support on entities will come after.
```
  "DynamicProperties": {
    "3d2b2b53-76da-4301-819e-dd4f4ab60505": {
      "boolFalse": 0b,
      "boolTrue": 1b,
      "float": 5.7d,
      "floatNegative": -5.7d,
      "int": 5.0d,
      "intNegative": -5.0d,
      "string": "stringValue",
      "vec3": [
        500.0f,
        60.0f,
        500.0f
      ]
    }
  }
```

As the DP are stored under a UUID defined in the manifest of BDS behaviors packs and it is not part of PNX, I also included a possibility to users define their own UUID on plugins, helping servers migration from BDS to PNX.
All the methods have its own description to help the usage.