### PR TITLE
enhancement: replace addSound() with playSound() for BDS naming parity, add string sound ID support

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -1345,7 +1345,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
                         respawnAnchor.setCharge(charge - 1);
                         respawnAnchor.getLevel().setBlock(respawnAnchor, spawnBlock);
                         respawnAnchor.getLevel().scheduleUpdate(respawnAnchor, 10);
-                        respawnAnchor.getLevel().addSound(this, Sound.RESPAWN_ANCHOR_DEPLETE, 1, 1, this);
+                        respawnAnchor.getLevel().playSound(this, Sound.RESPAWN_ANCHOR_DEPLETE, 1, 1, this);
                     }
                 }
             } else {//block not available

--- a/src/main/java/cn/nukkit/block/BlockAnvil.java
+++ b/src/main/java/cn/nukkit/block/BlockAnvil.java
@@ -99,12 +99,12 @@ public class BlockAnvil extends BlockFallable implements Faceable, BlockInventor
         setBlockFace(player != null ? player.getDirection().rotateYCCW() : BlockFace.SOUTH);
         this.getLevel().setBlock(this, this, true);
         if (player == null) {
-            this.getLevel().addSound(this, Sound.RANDOM_ANVIL_LAND, 1, 0.8F);
+            this.getLevel().playSound(this, Sound.RANDOM_ANVIL_LAND, 1, 0.8F);
         } else {
             Collection<Player> players = getLevel().getChunkPlayers(getChunkX(), getChunkZ()).values();
             players.remove(player);
             if (!players.isEmpty()) {
-                getLevel().addSound(this, Sound.RANDOM_ANVIL_LAND, 1, 0.8F, players);
+                getLevel().playSound(this, Sound.RANDOM_ANVIL_LAND, 1, 0.8F, players);
             }
         }
         return true;

--- a/src/main/java/cn/nukkit/block/BlockBambooDoor.java
+++ b/src/main/java/cn/nukkit/block/BlockBambooDoor.java
@@ -28,11 +28,11 @@ public class BlockBambooDoor extends BlockWoodenDoor {
 
     @Override
     public void playOpenSound() {
-        level.addSound(this, Sound.OPEN_BAMBOO_WOOD_DOOR);
+        level.playSound(this, Sound.OPEN_BAMBOO_WOOD_DOOR);
     }
 
     @Override
     public void playCloseSound() {
-        level.addSound(this, Sound.CLOSE_BAMBOO_WOOD_DOOR);
+        level.playSound(this, Sound.CLOSE_BAMBOO_WOOD_DOOR);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockBambooFenceGate.java
+++ b/src/main/java/cn/nukkit/block/BlockBambooFenceGate.java
@@ -29,11 +29,11 @@ public class BlockBambooFenceGate extends BlockFenceGate {
 
     @Override
     public void playOpenSound() {
-        level.addSound(this, Sound.OPEN_BAMBOO_WOOD_FENCE_GATE);
+        level.playSound(this, Sound.OPEN_BAMBOO_WOOD_FENCE_GATE);
     }
 
     @Override
     public void playCloseSound() {
-        level.addSound(this, Sound.CLOSE_BAMBOO_WOOD_FENCE_GATE);
+        level.playSound(this, Sound.CLOSE_BAMBOO_WOOD_FENCE_GATE);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockBambooTrapdoor.java
+++ b/src/main/java/cn/nukkit/block/BlockBambooTrapdoor.java
@@ -26,11 +26,11 @@ public class BlockBambooTrapdoor extends BlockTrapdoor {
 
     @Override
     public void playOpenSound() {
-        level.addSound(this, Sound.OPEN_BAMBOO_WOOD_TRAPDOOR);
+        level.playSound(this, Sound.OPEN_BAMBOO_WOOD_TRAPDOOR);
     }
 
     @Override
     public void playCloseSound() {
-        level.addSound(this, Sound.CLOSE_BAMBOO_WOOD_TRAPDOOR);
+        level.playSound(this, Sound.CLOSE_BAMBOO_WOOD_TRAPDOOR);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockBeehive.java
+++ b/src/main/java/cn/nukkit/block/BlockBeehive.java
@@ -113,7 +113,7 @@ public class BlockBeehive extends BlockSolid implements Faceable, BlockEntityHol
     public boolean onActivate(@NotNull Item item, Player player, BlockFace blockFace, float fx, float fy, float fz) {
         if (item.getId().equals(ItemID.SHEARS) && isFull()) {
             honeyCollected(player);
-            level.addSound(add(0.5, 0.5, 0.5), Sound.BLOCK_BEEHIVE_SHEAR);
+            level.playSound(add(0.5, 0.5, 0.5), Sound.BLOCK_BEEHIVE_SHEAR);
             item.useOn(this);
             for (int i = 0; i < 3; ++i) {
                 level.dropItem(this, Item.get(ItemID.HONEYCOMB));

--- a/src/main/java/cn/nukkit/block/BlockBigDripleaf.java
+++ b/src/main/java/cn/nukkit/block/BlockBigDripleaf.java
@@ -203,7 +203,7 @@ public class BlockBigDripleaf extends BlockFlowable implements Faceable {
                 case UNSTABLE -> setTiltAndScheduleTick(BigDripleafTilt.PARTIAL_TILT);
                 case PARTIAL_TILT -> setTiltAndScheduleTick(BigDripleafTilt.FULL_TILT);
                 case FULL_TILT -> {
-                    level.addSound(this, Sound.TILT_UP_BIG_DRIPLEAF);
+                    level.playSound(this, Sound.TILT_UP_BIG_DRIPLEAF);
                     setTilt(BigDripleafTilt.NONE);
                     level.setBlock(this, this, true, false);
                 }
@@ -220,7 +220,7 @@ public class BlockBigDripleaf extends BlockFlowable implements Faceable {
             if (!level.isBlockPowered(this))
                 return 0;
             if (tilt != BigDripleafTilt.UNSTABLE)
-                level.addSound(this, Sound.TILT_UP_BIG_DRIPLEAF);
+                level.playSound(this, Sound.TILT_UP_BIG_DRIPLEAF);
             setTilt(BigDripleafTilt.NONE);
             level.setBlock(this, this, true, false);
 
@@ -327,7 +327,7 @@ public class BlockBigDripleaf extends BlockFlowable implements Faceable {
             case FULL_TILT -> level.scheduleUpdate(this, 100);
         }
 
-        level.addSound(this, Sound.TILT_DOWN_BIG_DRIPLEAF);
+        level.playSound(this, Sound.TILT_DOWN_BIG_DRIPLEAF);
         return true;
     }
 

--- a/src/main/java/cn/nukkit/block/BlockCalibratedSculkSensor.java
+++ b/src/main/java/cn/nukkit/block/BlockCalibratedSculkSensor.java
@@ -102,8 +102,8 @@ public class BlockCalibratedSculkSensor extends BlockFlowable implements BlockEn
     }
 
     public void setPhase(int phase) {
-        if (phase == 1) this.level.addSound(this.add(0.5, 0.5, 0.5), Sound.POWER_ON_SCULK_SENSOR);
-        else this.level.addSound(this.add(0.5, 0.5, 0.5), Sound.POWER_OFF_SCULK_SENSOR);
+        if (phase == 1) this.level.playSound(this.add(0.5, 0.5, 0.5), Sound.POWER_ON_SCULK_SENSOR);
+        else this.level.playSound(this.add(0.5, 0.5, 0.5), Sound.POWER_OFF_SCULK_SENSOR);
         this.setPropertyValue(SCULK_SENSOR_PHASE, phase);
         this.level.setBlock(this, this, true, false);
     }

--- a/src/main/java/cn/nukkit/block/BlockCampfire.java
+++ b/src/main/java/cn/nukkit/block/BlockCampfire.java
@@ -118,7 +118,7 @@ public class BlockCampfire extends BlockTransparent implements Faceable, BlockEn
         boolean layer1Check = (layer1 instanceof BlockFlowingWater w && w.isSourceOrFlowingDown()) || layer1 instanceof BlockFrostedIce;
         if (defaultLayerCheck || layer1Check) {
             setExtinguished(true);
-            this.level.addSound(this, Sound.RANDOM_FIZZ, 0.5f, 2.2f);
+            this.level.playSound(this, Sound.RANDOM_FIZZ, 0.5f, 2.2f);
             this.level.setBlock(this, 1, defaultLayerCheck ? block : layer1, false, false);
         } else {
             this.level.setBlock(this, 1, Block.get(BlockID.AIR), false, false);
@@ -193,7 +193,7 @@ public class BlockCampfire extends BlockTransparent implements Faceable, BlockEn
                 if (layer1 instanceof BlockFlowingWater || layer1 instanceof BlockFrostedIce) {
                     setExtinguished(true);
                     this.level.setBlock(this, this, true, true);
-                    this.level.addSound(this, Sound.RANDOM_FIZZ, 0.5f, 2.2f);
+                    this.level.playSound(this, Sound.RANDOM_FIZZ, 0.5f, 2.2f);
                 }
             }
             return type;
@@ -214,7 +214,7 @@ public class BlockCampfire extends BlockTransparent implements Faceable, BlockEn
             if (item.isShovel()) {
                 setExtinguished(true);
                 this.level.setBlock(this, this, true, true);
-                this.level.addSound(this, Sound.RANDOM_FIZZ, 0.5f, 2.2f);
+                this.level.playSound(this, Sound.RANDOM_FIZZ, 0.5f, 2.2f);
                 itemUsed = true;
             }
         } else if (Objects.equals(item.getId(), ItemID.FLINT_AND_STEEL) || item.getEnchantment(Enchantment.ID_FIRE_ASPECT) != null) {
@@ -222,7 +222,7 @@ public class BlockCampfire extends BlockTransparent implements Faceable, BlockEn
             setExtinguished(false);
             this.level.setBlock(this, this, true, true);
             campfire.scheduleUpdate();
-            this.level.addSound(this, Sound.FIRE_IGNITE);
+            this.level.playSound(this, Sound.FIRE_IGNITE);
             itemUsed = true;
         }
 

--- a/src/main/java/cn/nukkit/block/BlockCandle.java
+++ b/src/main/java/cn/nukkit/block/BlockCandle.java
@@ -75,12 +75,12 @@ public class BlockCandle extends BlockFlowable {
 
         if (getPropertyValue(LIT) && !Objects.equals(item.getId(), ItemID.FLINT_AND_STEEL)) {
             setPropertyValue(LIT, false);
-            getLevel().addSound(this, Sound.RANDOM_FIZZ);
+            getLevel().playSound(this, Sound.RANDOM_FIZZ);
             getLevel().setBlock(this, this, true, true);
             return true;
         } else if (!getPropertyValue(LIT) && Objects.equals(item.getId(), ItemID.FLINT_AND_STEEL)) {
             setPropertyValue(LIT, true);
-            getLevel().addSound(this, Sound.FIRE_IGNITE);
+            getLevel().playSound(this, Sound.FIRE_IGNITE);
             getLevel().setBlock(this, this, true, true);
             return true;
         }

--- a/src/main/java/cn/nukkit/block/BlockCandleCake.java
+++ b/src/main/java/cn/nukkit/block/BlockCandleCake.java
@@ -123,12 +123,12 @@ public class BlockCandleCake extends BlockTransparent {
     public boolean onActivate(@NotNull Item item, Player player, BlockFace blockFace, float fx, float fy, float fz) {
         if (getPropertyValue(CommonBlockProperties.LIT) && !Objects.equals(item.getId(), ItemID.FLINT_AND_STEEL)) {
             setPropertyValue(CommonBlockProperties.LIT, false);
-            getLevel().addSound(this, Sound.RANDOM_FIZZ);
+            getLevel().playSound(this, Sound.RANDOM_FIZZ);
             getLevel().setBlock(this, this, true, true);
             return true;
         } else if (!getPropertyValue(CommonBlockProperties.LIT) && Objects.equals(item.getId(), ItemID.FLINT_AND_STEEL)) {
             setPropertyValue(CommonBlockProperties.LIT, true);
-            getLevel().addSound(this, Sound.FIRE_IGNITE);
+            getLevel().playSound(this, Sound.FIRE_IGNITE);
             getLevel().setBlock(this, this, true, true);
             return true;
         } else if (player != null && (player.getFoodData().isHungry() || player.isCreative())) {

--- a/src/main/java/cn/nukkit/block/BlockCauldron.java
+++ b/src/main/java/cn/nukkit/block/BlockCauldron.java
@@ -183,7 +183,7 @@ public class BlockCauldron extends BlockSolid implements BlockEntityHolder<Block
                         //default liquid type is water so we don't need to set it
                         cauldron.clearCustomColor();
                         this.level.setBlock(this, this, true);
-                        this.getLevel().addSound(this.add(0.5, 1, 0.5), Sound.CAULDRON_FILLWATER);
+                        this.getLevel().playSound(this.add(0.5, 1, 0.5), Sound.CAULDRON_FILLWATER);
                     } else if (bucket.isPowderSnow()) { // powder snow bucket
                         this.setFillLevel(FILL_LEVEL.getMax(), player);//fill
                         this.setCauldronLiquid(CauldronLiquid.POWDER_SNOW);
@@ -197,7 +197,7 @@ public class BlockCauldron extends BlockSolid implements BlockEntityHolder<Block
                             this.level.setBlock(this, this, true);
                             cauldron.clearCustomColor();
                             cauldron.setType(BlockEntityCauldron.PotionType.LAVA);
-                            this.getLevel().addSound(this.add(0.5, 1, 0.5), Sound.BUCKET_EMPTY_LAVA);
+                            this.getLevel().playSound(this.add(0.5, 1, 0.5), Sound.BUCKET_EMPTY_LAVA);
                         } else {
                             clearWithFizz(cauldron, player);
                         }
@@ -229,7 +229,7 @@ public class BlockCauldron extends BlockSolid implements BlockEntityHolder<Block
                     );
                     cauldron.setCustomColor(mixed);
                 }
-                this.level.addSound(this.add(0.5, 0.5, 0.5), Sound.CAULDRON_ADDDYE);
+                this.level.playSound(this.add(0.5, 0.5, 0.5), Sound.CAULDRON_ADDDYE);
 
                 break;
             case ItemID.WOLF_ARMOR:
@@ -249,7 +249,7 @@ public class BlockCauldron extends BlockSolid implements BlockEntityHolder<Block
                     player.getInventory().setItemInHand(item);
                     setFillLevel(NukkitMath.clamp(getFillLevel() - 2, FILL_LEVEL.getMin(), FILL_LEVEL.getMax()), player);
                     this.level.setBlock(this, this, true, true);
-                    this.level.addSound(add(0.5, 0.5, 0.5), Sound.CAULDRON_DYEARMOR);
+                    this.level.playSound(add(0.5, 0.5, 0.5), Sound.CAULDRON_DYEARMOR);
                 } else {
                     if (!item.hasCompoundTag()) {
                         break;
@@ -266,7 +266,7 @@ public class BlockCauldron extends BlockSolid implements BlockEntityHolder<Block
 
                     setFillLevel(NukkitMath.clamp(getFillLevel() - 2, FILL_LEVEL.getMin(), FILL_LEVEL.getMax()), player);
                     this.level.setBlock(this, this, true, true);
-                    this.getLevel().addSound(this.add(0.5, 1, 0.5), Sound.CAULDRON_TAKEWATER);
+                    this.getLevel().playSound(this.add(0.5, 1, 0.5), Sound.CAULDRON_TAKEWATER);
                 }
 
                 break;
@@ -372,7 +372,7 @@ public class BlockCauldron extends BlockSolid implements BlockEntityHolder<Block
 
                 setFillLevel(NukkitMath.clamp(getFillLevel() - 2, FILL_LEVEL.getMin(), FILL_LEVEL.getMax()), player);
                 this.level.setBlock(this, this, true, true);
-                this.getLevel().addSound(this.add(0.5, 1, 0.5), Sound.CAULDRON_TAKEWATER);
+                this.getLevel().playSound(this.add(0.5, 1, 0.5), Sound.CAULDRON_TAKEWATER);
 
                 break;
             default:
@@ -398,7 +398,7 @@ public class BlockCauldron extends BlockSolid implements BlockEntityHolder<Block
                         );
                         cauldron.setCustomColor(mixed);
                     }
-                    this.level.addSound(this.add(0.5, 0.5, 0.5), Sound.CAULDRON_ADDDYE);
+                    this.level.playSound(this.add(0.5, 0.5, 0.5), Sound.CAULDRON_ADDDYE);
                 } else {
                     return true;
                 }
@@ -433,7 +433,7 @@ public class BlockCauldron extends BlockSolid implements BlockEntityHolder<Block
                         this.setFillLevel(FILL_LEVEL.getMin(), player);//empty
                         this.level.setBlock(this, new BlockCauldron(), true);
                         cauldron.clearCustomColor();
-                        this.getLevel().addSound(this.add(0.5, 1, 0.5), Sound.BUCKET_FILL_LAVA);
+                        this.getLevel().playSound(this.add(0.5, 1, 0.5), Sound.BUCKET_FILL_LAVA);
                     }
                 } else if (bucket.isWater() || bucket.isLava()) { //water or lava bucket
                     if (isFull() && !cauldron.isCustomColor() && !cauldron.hasPotion() && item.getDamage() == 10) {
@@ -451,14 +451,14 @@ public class BlockCauldron extends BlockSolid implements BlockEntityHolder<Block
                             this.setFillLevel(FILL_LEVEL.getMax(), player);//fill
                             cauldron.clearCustomColor();
                             this.level.setBlock(this, this, true);
-                            this.getLevel().addSound(this.add(0.5, 1, 0.5), Sound.BUCKET_EMPTY_LAVA);
+                            this.getLevel().playSound(this.add(0.5, 1, 0.5), Sound.BUCKET_EMPTY_LAVA);
                         } else {
                             if (isEmpty()) {
                                 BlockCauldron blockCauldron = new BlockCauldron();
                                 blockCauldron.setFillLevel(6);
                                 this.level.setBlock(this, blockCauldron, true, true);
                                 cauldron.clearCustomColor();
-                                this.getLevel().addSound(this.add(0.5, 1, 0.5), Sound.CAULDRON_FILLWATER);
+                                this.getLevel().playSound(this.add(0.5, 1, 0.5), Sound.CAULDRON_FILLWATER);
                             } else {
                                 clearWithFizz(cauldron);
                             }
@@ -529,7 +529,7 @@ public class BlockCauldron extends BlockSolid implements BlockEntityHolder<Block
         cauldron.setType(BlockEntityCauldron.PotionType.NORMAL);
         cauldron.clearCustomColor();
         this.level.setBlock(this, new BlockCauldron(), true);
-        this.level.addSound(this.add(0.5, 0, 0.5), Sound.RANDOM_FIZZ);
+        this.level.playSound(this.add(0.5, 0, 0.5), Sound.RANDOM_FIZZ);
         for (int i = 0; i < 8; ++i) {
             this.getLevel().addParticle(new SmokeParticle(add(Math.random(), 1.2, Math.random())));
         }

--- a/src/main/java/cn/nukkit/block/BlockCherryDoor.java
+++ b/src/main/java/cn/nukkit/block/BlockCherryDoor.java
@@ -27,11 +27,11 @@ public class BlockCherryDoor extends BlockWoodenDoor {
 
     @Override
     public void playOpenSound() {
-        level.addSound(this, Sound.OPEN_CHERRY_WOOD_DOOR);
+        level.playSound(this, Sound.OPEN_CHERRY_WOOD_DOOR);
     }
 
     @Override
     public void playCloseSound() {
-        level.addSound(this, Sound.CLOSE_CHERRY_WOOD_DOOR);
+        level.playSound(this, Sound.CLOSE_CHERRY_WOOD_DOOR);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockCherryFenceGate.java
+++ b/src/main/java/cn/nukkit/block/BlockCherryFenceGate.java
@@ -30,11 +30,11 @@ public class BlockCherryFenceGate extends BlockFenceGate {
 
     @Override
     public void playOpenSound() {
-        level.addSound(this, Sound.OPEN_CHERRY_WOOD_FENCE_GATE);
+        level.playSound(this, Sound.OPEN_CHERRY_WOOD_FENCE_GATE);
     }
 
     @Override
     public void playCloseSound() {
-        level.addSound(this, Sound.CLOSE_CHERRY_WOOD_FENCE_GATE);
+        level.playSound(this, Sound.CLOSE_CHERRY_WOOD_FENCE_GATE);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockCherryTrapdoor.java
+++ b/src/main/java/cn/nukkit/block/BlockCherryTrapdoor.java
@@ -27,11 +27,11 @@ public class BlockCherryTrapdoor extends BlockTrapdoor {
 
     @Override
     public void playOpenSound() {
-        level.addSound(this, Sound.OPEN_CHERRY_WOOD_TRAPDOOR);
+        level.playSound(this, Sound.OPEN_CHERRY_WOOD_TRAPDOOR);
     }
 
     @Override
     public void playCloseSound() {
-        level.addSound(this, Sound.CLOSE_CHERRY_WOOD_TRAPDOOR);
+        level.playSound(this, Sound.CLOSE_CHERRY_WOOD_TRAPDOOR);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockChorusFlower.java
+++ b/src/main/java/cn/nukkit/block/BlockChorusFlower.java
@@ -128,7 +128,7 @@ public class BlockChorusFlower extends BlockTransparent {
                         if (!ev.isCancelled()) {
                             this.getLevel().setBlock(this, Block.get(CHORUS_PLANT));
                             this.getLevel().setBlock(block, ev.getNewState());
-                            this.getLevel().addSound(this.add(0.5, 0.5, 0.5), Sound.BLOCK_CHORUSFLOWER_GROW);
+                            this.getLevel().playSound(this.add(0.5, 0.5, 0.5), Sound.BLOCK_CHORUSFLOWER_GROW);
                         } else {
                             return Level.BLOCK_UPDATE_RANDOM;
                         }
@@ -149,7 +149,7 @@ public class BlockChorusFlower extends BlockTransparent {
                                 if (!ev.isCancelled()) {
                                     this.getLevel().setBlock(this, Block.get(CHORUS_PLANT));
                                     this.getLevel().setBlock(block, ev.getNewState());
-                                    this.getLevel().addSound(this.add(0.5, 0.5, 0.5), Sound.BLOCK_CHORUSFLOWER_GROW);
+                                    this.getLevel().playSound(this.add(0.5, 0.5, 0.5), Sound.BLOCK_CHORUSFLOWER_GROW);
                                 } else {
                                     return Level.BLOCK_UPDATE_RANDOM;
                                 }
@@ -164,7 +164,7 @@ public class BlockChorusFlower extends BlockTransparent {
                         
                         if (!ev.isCancelled()) {
                             this.getLevel().setBlock(block, ev.getNewState());
-                            this.getLevel().addSound(this.add(0.5, 0.5, 0.5), Sound.BLOCK_CHORUSFLOWER_DEATH);
+                            this.getLevel().playSound(this.add(0.5, 0.5, 0.5), Sound.BLOCK_CHORUSFLOWER_DEATH);
                         } else {
                             return Level.BLOCK_UPDATE_RANDOM;
                         }

--- a/src/main/java/cn/nukkit/block/BlockComposter.java
+++ b/src/main/java/cn/nukkit/block/BlockComposter.java
@@ -126,7 +126,7 @@ public class BlockComposter extends BlockSolid {
                 setPropertyValue(COMPOSTER_FILL_LEVEL, event.getNewLevel());
                 this.level.setBlock(this, this, true, true);
                 this.level.dropItem(add(0.5, 0.85, 0.5), event.getDrop(), event.getMotion(), false, 10);
-                this.level.addSound(add(0.5, 0.5, 0.5), Sound.BLOCK_COMPOSTER_EMPTY);
+                this.level.playSound(add(0.5, 0.5, 0.5), Sound.BLOCK_COMPOSTER_EMPTY);
             }
             return true;
         }
@@ -150,12 +150,12 @@ public class BlockComposter extends BlockSolid {
 
         if (event.isSuccess()) {
             if (incrementLevel()) {
-                level.addSound(this.add(0.5, 0.5, 0.5), Sound.BLOCK_COMPOSTER_READY);
+                level.playSound(this.add(0.5, 0.5, 0.5), Sound.BLOCK_COMPOSTER_READY);
             } else {
-                level.addSound(this.add(0.5, 0.5, 0.5), Sound.BLOCK_COMPOSTER_FILL_SUCCESS);
+                level.playSound(this.add(0.5, 0.5, 0.5), Sound.BLOCK_COMPOSTER_FILL_SUCCESS);
             }
         } else {
-            level.addSound(this.add(0.5, 0.5, 0.5), Sound.BLOCK_COMPOSTER_FILL);
+            level.playSound(this.add(0.5, 0.5, 0.5), Sound.BLOCK_COMPOSTER_FILL);
         }
 
         return true;
@@ -174,7 +174,7 @@ public class BlockComposter extends BlockSolid {
             if (item != null) {
                 this.level.dropItem(add(0.5, 0.85, 0.5), event.getDrop(), event.getMotion(), false, 10);
             }
-            this.level.addSound(add(0.5, 0.5, 0.5), Sound.BLOCK_COMPOSTER_EMPTY);
+            this.level.playSound(add(0.5, 0.5, 0.5), Sound.BLOCK_COMPOSTER_EMPTY);
             return event.getDrop();
         }
         return null;

--- a/src/main/java/cn/nukkit/block/BlockCrafter.java
+++ b/src/main/java/cn/nukkit/block/BlockCrafter.java
@@ -135,7 +135,7 @@ public class BlockCrafter extends BlockSolid implements RedstoneComponent, Block
 
         if (type == Level.BLOCK_UPDATE_SCHEDULED) {
             if(isTriggered()) {
-                getLevel().addSound(this, craft() ? Sound.CRAFTER_CRAFT : Sound.CRAFTER_FAIL);
+                getLevel().playSound(this, craft() ? Sound.CRAFTER_CRAFT : Sound.CRAFTER_FAIL);
                 updateAllAroundRedstone();
                 this.setTriggered(false);
                 setCrafting(true);
@@ -200,7 +200,7 @@ public class BlockCrafter extends BlockSolid implements RedstoneComponent, Block
                     return false;
                 }
             } else {
-                this.level.addSound(this, Sound.RANDOM_CLICK);
+                this.level.playSound(this, Sound.RANDOM_CLICK);
                 Vector3 dispensePos = this.getDispensePosition();
 
                 if (facing.getAxis() == BlockFace.Axis.Y) {

--- a/src/main/java/cn/nukkit/block/BlockCrimsonDoor.java
+++ b/src/main/java/cn/nukkit/block/BlockCrimsonDoor.java
@@ -27,11 +27,11 @@ public class BlockCrimsonDoor extends BlockWoodenDoor {
 
     @Override
     public void playOpenSound() {
-        level.addSound(this, Sound.OPEN_NETHER_WOOD_DOOR);
+        level.playSound(this, Sound.OPEN_NETHER_WOOD_DOOR);
     }
 
     @Override
     public void playCloseSound() {
-        level.addSound(this, Sound.CLOSE_NETHER_WOOD_DOOR);
+        level.playSound(this, Sound.CLOSE_NETHER_WOOD_DOOR);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockCrimsonFenceGate.java
+++ b/src/main/java/cn/nukkit/block/BlockCrimsonFenceGate.java
@@ -40,11 +40,11 @@ public class BlockCrimsonFenceGate extends BlockFenceGate {
 
     @Override
     public void playOpenSound() {
-        level.addSound(this, Sound.OPEN_NETHER_WOOD_FENCE_GATE);
+        level.playSound(this, Sound.OPEN_NETHER_WOOD_FENCE_GATE);
     }
 
     @Override
     public void playCloseSound() {
-        level.addSound(this, Sound.CLOSE_NETHER_WOOD_FENCE_GATE);
+        level.playSound(this, Sound.CLOSE_NETHER_WOOD_FENCE_GATE);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockCrimsonTrapdoor.java
+++ b/src/main/java/cn/nukkit/block/BlockCrimsonTrapdoor.java
@@ -37,11 +37,11 @@ public class BlockCrimsonTrapdoor extends BlockTrapdoor {
 
     @Override
     public void playOpenSound() {
-        level.addSound(this, Sound.OPEN_NETHER_WOOD_TRAPDOOR);
+        level.playSound(this, Sound.OPEN_NETHER_WOOD_TRAPDOOR);
     }
 
     @Override
     public void playCloseSound() {
-        level.addSound(this, Sound.CLOSE_NETHER_WOOD_TRAPDOOR);
+        level.playSound(this, Sound.CLOSE_NETHER_WOOD_TRAPDOOR);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockDirt.java
+++ b/src/main/java/cn/nukkit/block/BlockDirt.java
@@ -59,14 +59,14 @@ public class BlockDirt extends BlockSolid implements Natural {
             item.useOn(this);
             this.getLevel().setBlock(this, get(FARMLAND), true);
             if (player != null) {
-                player.getLevel().addSound(player, Sound.USE_GRASS);
+                player.getLevel().playSound(player, Sound.USE_GRASS);
             }
             return true;
         } else if (item.isShovel()) {
             item.useOn(this);
             this.getLevel().setBlock(this, get(GRASS_PATH));
             if (player != null) {
-                player.getLevel().addSound(player, Sound.USE_GRASS);
+                player.getLevel().playSound(player, Sound.USE_GRASS);
             }
             return true;
         }

--- a/src/main/java/cn/nukkit/block/BlockDirtWithRoots.java
+++ b/src/main/java/cn/nukkit/block/BlockDirtWithRoots.java
@@ -65,14 +65,14 @@ public class BlockDirtWithRoots extends BlockDirt {
             this.getLevel().setBlock(this, Block.get(DIRT), true);
             this.getLevel().dropItem(vector, new ItemBlock(Block.get(HANGING_ROOTS)));
             if (player != null) {
-                player.getLevel().addSound(player, Sound.USE_GRASS);
+                player.getLevel().playSound(player, Sound.USE_GRASS);
             }
             return true;
         } else if (item.isShovel()) {
             item.useOn(this);
             this.getLevel().setBlock(this, Block.get(GRASS_PATH));
             if (player != null) {
-                player.getLevel().addSound(player, Sound.USE_GRASS);
+                player.getLevel().playSound(player, Sound.USE_GRASS);
             }
             return true;
         }

--- a/src/main/java/cn/nukkit/block/BlockDispenser.java
+++ b/src/main/java/cn/nukkit/block/BlockDispenser.java
@@ -225,13 +225,13 @@ public class BlockDispenser extends BlockSolid implements RedstoneComponent, Fac
         pk.z = 0.5f + facing.getZOffset() * 0.7f;
 
         if (target == null) {
-            this.level.addSound(this, Sound.RANDOM_CLICK, 1.0f, 1.2f);
+            this.level.playSound(this, Sound.RANDOM_CLICK, 1.0f, 1.2f);
             getBlockEntity().setDirty();
             return;
         } else {
             if (!(getDispenseBehavior(target) instanceof DropperDispenseBehavior)
                     && !(getDispenseBehavior(target) instanceof FlintAndSteelDispenseBehavior))
-                this.level.addSound(this, Sound.RANDOM_CLICK, 1.0f, 1.0f);
+                this.level.playSound(this, Sound.RANDOM_CLICK, 1.0f, 1.0f);
         }
 
         pk.evid = LevelEventPacket.EVENT_PARTICLE_SHOOT;

--- a/src/main/java/cn/nukkit/block/BlockDoor.java
+++ b/src/main/java/cn/nukkit/block/BlockDoor.java
@@ -304,11 +304,11 @@ public abstract class BlockDoor extends BlockTransparent implements RedstoneComp
     }
 
     public void playOpenSound() {
-        level.addSound(this, Sound.RANDOM_DOOR_OPEN);
+        level.playSound(this, Sound.RANDOM_DOOR_OPEN);
     }
 
     public void playCloseSound() {
-        level.addSound(this, Sound.RANDOM_DOOR_CLOSE);
+        level.playSound(this, Sound.RANDOM_DOOR_CLOSE);
     }
 
     public boolean toggle(Player player) {

--- a/src/main/java/cn/nukkit/block/BlockEndPortalFrame.java
+++ b/src/main/java/cn/nukkit/block/BlockEndPortalFrame.java
@@ -106,7 +106,7 @@ public class BlockEndPortalFrame extends BlockTransparent implements Faceable {
         if (!this.isEndPortalEye() && player != null && item.getId().equals(Item.ENDER_EYE)) {
             this.setEndPortalEye(true);
             this.getLevel().setBlock(this, this, true, true);
-            this.getLevel().addSound(this, Sound.BLOCK_END_PORTAL_FRAME_FILL);
+            this.getLevel().playSound(this, Sound.BLOCK_END_PORTAL_FRAME_FILL);
             this.createPortal();
             return true;
         }

--- a/src/main/java/cn/nukkit/block/BlockFenceGate.java
+++ b/src/main/java/cn/nukkit/block/BlockFenceGate.java
@@ -235,11 +235,11 @@ public class BlockFenceGate extends BlockTransparent implements RedstoneComponen
     }
 
     public void playOpenSound() {
-        level.addSound(this, Sound.RANDOM_DOOR_OPEN);
+        level.playSound(this, Sound.RANDOM_DOOR_OPEN);
     }
 
     public void playCloseSound() {
-        level.addSound(this, Sound.RANDOM_DOOR_CLOSE);
+        level.playSound(this, Sound.RANDOM_DOOR_CLOSE);
     }
 
     public boolean isOpen() {

--- a/src/main/java/cn/nukkit/block/BlockFrame.java
+++ b/src/main/java/cn/nukkit/block/BlockFrame.java
@@ -218,7 +218,7 @@ public class BlockFrame extends BlockTransparent implements BlockEntityHolder<Bl
             frame = levelBlock.createBlockEntity(nbt);
         }
 
-        this.getLevel().addSound(this, Sound.BLOCK_ITEMFRAME_PLACE);
+        this.getLevel().playSound(this, Sound.BLOCK_ITEMFRAME_PLACE);
         return true;
     }
 

--- a/src/main/java/cn/nukkit/block/BlockGrassBlock.java
+++ b/src/main/java/cn/nukkit/block/BlockGrassBlock.java
@@ -59,14 +59,14 @@ public class BlockGrassBlock extends BlockDirt {
             item.useOn(this);
             this.getLevel().setBlock(this, Block.get(BlockID.FARMLAND));
             if (player != null) {
-                player.getLevel().addSound(player, Sound.USE_GRASS);
+                player.getLevel().playSound(player, Sound.USE_GRASS);
             }
             return true;
         } else if (item.isShovel()) {
             item.useOn(this);
             this.getLevel().setBlock(this, Block.get(BlockID.GRASS_PATH));
             if (player != null) {
-                player.getLevel().addSound(player, Sound.USE_GRASS);
+                player.getLevel().playSound(player, Sound.USE_GRASS);
             }
             return true;
         }

--- a/src/main/java/cn/nukkit/block/BlockGrassPath.java
+++ b/src/main/java/cn/nukkit/block/BlockGrassPath.java
@@ -60,7 +60,7 @@ public class BlockGrassPath extends BlockGrassBlock {
             item.useOn(this);
             this.getLevel().setBlock(this, get(FARMLAND), true);
             if (player != null) {
-                player.getLevel().addSound(player, Sound.USE_GRASS);
+                player.getLevel().playSound(player, Sound.USE_GRASS);
             }
             return true;
         }

--- a/src/main/java/cn/nukkit/block/BlockHoneyBlock.java
+++ b/src/main/java/cn/nukkit/block/BlockHoneyBlock.java
@@ -75,7 +75,7 @@ public class BlockHoneyBlock extends BlockSolid {
                 entity.resetFallDistance();
 
                 if (RANDOM.nextInt(10) == 0) {
-                    level.addSound(entity, Sound.LAND_HONEY_BLOCK);
+                    level.playSound(entity, Sound.LAND_HONEY_BLOCK);
                 }
             }
         }

--- a/src/main/java/cn/nukkit/block/BlockIronDoor.java
+++ b/src/main/java/cn/nukkit/block/BlockIronDoor.java
@@ -61,11 +61,11 @@ public class BlockIronDoor extends BlockDoor {
 
     @Override
     public void playOpenSound() {
-        level.addSound(this, Sound.OPEN_IRON_DOOR);
+        level.playSound(this, Sound.OPEN_IRON_DOOR);
     }
 
     @Override
     public void playCloseSound() {
-        level.addSound(this, Sound.CLOSE_IRON_DOOR);
+        level.playSound(this, Sound.CLOSE_IRON_DOOR);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockIronTrapdoor.java
+++ b/src/main/java/cn/nukkit/block/BlockIronTrapdoor.java
@@ -61,11 +61,11 @@ public class BlockIronTrapdoor extends BlockTrapdoor {
 
     @Override
     public void playOpenSound() {
-        level.addSound(this, Sound.OPEN_IRON_TRAPDOOR);
+        level.playSound(this, Sound.OPEN_IRON_TRAPDOOR);
     }
 
     @Override
     public void playCloseSound() {
-        level.addSound(this, Sound.CLOSE_IRON_TRAPDOOR);
+        level.playSound(this, Sound.CLOSE_IRON_TRAPDOOR);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockLectern.java
+++ b/src/main/java/cn/nukkit/block/BlockLectern.java
@@ -136,7 +136,7 @@ public class BlockLectern extends BlockTransparent implements RedstoneComponent,
         newBook.setCount(1);
         lectern.setBook(newBook);
         lectern.spawnToAll();
-        this.getLevel().addSound(this.add(0.5, 0.5, 0.5), Sound.ITEM_BOOK_PUT);
+        this.getLevel().playSound(this.add(0.5, 0.5, 0.5), Sound.ITEM_BOOK_PUT);
         return true;
     }
 
@@ -163,7 +163,7 @@ public class BlockLectern extends BlockTransparent implements RedstoneComponent,
         level.scheduleUpdate(this, this, 4);
         setActivated(true);
         level.setBlock(this, this, true, false);
-        level.addSound(this.add(0.5, 0.5, 0.5), Sound.ITEM_BOOK_PAGE_TURN);
+        level.playSound(this.add(0.5, 0.5, 0.5), Sound.ITEM_BOOK_PAGE_TURN);
 
         updateAroundRedstone();
         RedstoneComponent.updateAroundRedstone(getSide(BlockFace.DOWN), BlockFace.UP);

--- a/src/main/java/cn/nukkit/block/BlockLever.java
+++ b/src/main/java/cn/nukkit/block/BlockLever.java
@@ -93,7 +93,7 @@ public class BlockLever extends BlockFlowable implements RedstoneComponent, Face
         var pos = this.add(0.5, 0.5, 0.5);
         this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(player != null ? player : this, pos, isPowerOn() ? VibrationType.BLOCK_ACTIVATE : VibrationType.BLOCK_DEACTIVATE));
         this.getLevel().setBlock(this, this, false, true);
-        this.getLevel().addSound(this, Sound.RANDOM_CLICK, 0.8f, isPowerOn() ? 0.58f : 0.5f);
+        this.getLevel().playSound(this, Sound.RANDOM_CLICK, 0.8f, isPowerOn() ? 0.58f : 0.5f);
 
         LeverDirection orientation = getLeverOrientation();
         BlockFace face = orientation.getFacing();

--- a/src/main/java/cn/nukkit/block/BlockLiquid.java
+++ b/src/main/java/cn/nukkit/block/BlockLiquid.java
@@ -507,7 +507,7 @@ public abstract class BlockLiquid extends BlockTransparent {
         }
         this.level.setBlock(this, event.getTo(), true, true);
         this.level.setBlock(this, 1, Block.get(BlockID.AIR), true, true);
-        this.getLevel().addSound(this.add(0.5, 0.5, 0.5), Sound.RANDOM_FIZZ);
+        this.getLevel().playSound(this.add(0.5, 0.5, 0.5), Sound.RANDOM_FIZZ);
         return true;
     }
 

--- a/src/main/java/cn/nukkit/block/BlockLodestone.java
+++ b/src/main/java/cn/nukkit/block/BlockLodestone.java
@@ -85,7 +85,7 @@ public class BlockLodestone extends BlockSolid implements BlockEntityHolder<Bloc
             }
         }
         
-        getLevel().addSound(player.getPosition(), Sound.LODESTONE_COMPASS_LINK_COMPASS_TO_LODESTONE);
+        getLevel().playSound(player.getPosition(), Sound.LODESTONE_COMPASS_LINK_COMPASS_TO_LODESTONE);
         
         if (added) {
             try {

--- a/src/main/java/cn/nukkit/block/BlockMycelium.java
+++ b/src/main/java/cn/nukkit/block/BlockMycelium.java
@@ -106,7 +106,7 @@ public class BlockMycelium extends BlockDirt {
             item.useOn(this);
             this.getLevel().setBlock(this, Block.get(BlockID.GRASS_PATH));
             if (player != null) {
-                player.getLevel().addSound(player, Sound.USE_GRASS);
+                player.getLevel().playSound(player, Sound.USE_GRASS);
             }
             return true;
         }

--- a/src/main/java/cn/nukkit/block/BlockPistonBase.java
+++ b/src/main/java/cn/nukkit/block/BlockPistonBase.java
@@ -320,10 +320,10 @@ public abstract class BlockPistonBase extends BlockTransparent implements Faceab
 
         blockEntity.move();
         if (extending) {
-            this.getLevel().addSound(this, Sound.TILE_PISTON_OUT);
+            this.getLevel().playSound(this, Sound.TILE_PISTON_OUT);
             this.getLevel().getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.add(0.5, 0.5, 0.5), VibrationType.PISTON_EXTEND));
         } else {
-            this.getLevel().addSound(this, Sound.TILE_PISTON_IN);
+            this.getLevel().playSound(this, Sound.TILE_PISTON_IN);
             this.getLevel().getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.add(0.5, 0.5, 0.5), VibrationType.PISTON_CONTRACT));
         }
         return true;

--- a/src/main/java/cn/nukkit/block/BlockPodzol.java
+++ b/src/main/java/cn/nukkit/block/BlockPodzol.java
@@ -46,7 +46,7 @@ public class BlockPodzol extends BlockDirt {
             item.useOn(this);
             this.getLevel().setBlock(this, Block.get(BlockID.GRASS_PATH));
             if (player != null) {
-                player.getLevel().addSound(player, Sound.USE_GRASS);
+                player.getLevel().playSound(player, Sound.USE_GRASS);
             }
             return true;
         }

--- a/src/main/java/cn/nukkit/block/BlockPointedDripstone.java
+++ b/src/main/java/cn/nukkit/block/BlockPointedDripstone.java
@@ -380,7 +380,7 @@ public class BlockPointedDripstone extends BlockFallable {
                     cauldron.setCauldronLiquid(event.getLiquid());
                     cauldron.setFillLevel(cauldron.getFillLevel() + event.getLiquidLevelIncrement());
                     cauldron.level.setBlock(cauldron, cauldron, true, true);
-                    this.getLevel().addSound(this.add(0.5, 1, 0.5), Sound.CAULDRON_DRIP_LAVA_POINTED_DRIPSTONE);
+                    this.getLevel().playSound(this.add(0.5, 1, 0.5), Sound.CAULDRON_DRIP_LAVA_POINTED_DRIPSTONE);
                 }
             }
             case FLOWING_WATER -> {
@@ -393,7 +393,7 @@ public class BlockPointedDripstone extends BlockFallable {
                     cauldron.setCauldronLiquid(event.getLiquid());
                     cauldron.setFillLevel(cauldron.getFillLevel() + event.getLiquidLevelIncrement());
                     cauldron.level.setBlock(cauldron, cauldron, true, true);
-                    this.getLevel().addSound(this.add(0.5, 1, 0.5), Sound.CAULDRON_DRIP_WATER_POINTED_DRIPSTONE);
+                    this.getLevel().playSound(this.add(0.5, 1, 0.5), Sound.CAULDRON_DRIP_WATER_POINTED_DRIPSTONE);
                 }
             }
         }

--- a/src/main/java/cn/nukkit/block/BlockRespawnAnchor.java
+++ b/src/main/java/cn/nukkit/block/BlockRespawnAnchor.java
@@ -72,7 +72,7 @@ public class BlockRespawnAnchor extends Block {
 
             setCharge(charge + 1);
             getLevel().setBlock(this, this);
-            getLevel().addSound(this, Sound.RESPAWN_ANCHOR_CHARGE);
+            getLevel().playSound(this, Sound.RESPAWN_ANCHOR_CHARGE);
             return true;
         }
 
@@ -99,7 +99,7 @@ public class BlockRespawnAnchor extends Block {
             return false;
         }
         player.setSpawn(this, SpawnPointType.BLOCK);
-        getLevel().addSound(this, Sound.RESPAWN_ANCHOR_SET_SPAWN);
+        getLevel().playSound(this, Sound.RESPAWN_ANCHOR_SET_SPAWN);
         player.sendMessage(new TranslationContainer(TextFormat.GRAY + "%tile.respawn_anchor.respawnSet"));
         return true;
     }
@@ -161,7 +161,7 @@ public class BlockRespawnAnchor extends Block {
     @Override
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_SCHEDULED) {
-            getLevel().addSound(this, Sound.RESPAWN_ANCHOR_DEPLETE);
+            getLevel().playSound(this, Sound.RESPAWN_ANCHOR_DEPLETE);
             return type;
         }
         return super.onUpdate(type);

--- a/src/main/java/cn/nukkit/block/BlockSculkSensor.java
+++ b/src/main/java/cn/nukkit/block/BlockSculkSensor.java
@@ -80,8 +80,8 @@ public class BlockSculkSensor extends BlockFlowable implements BlockEntityHolder
     }
 
     public void setPhase(int phase) {
-        if (phase == 1) this.level.addSound(this.add(0.5, 0.5, 0.5), Sound.POWER_ON_SCULK_SENSOR);
-        else this.level.addSound(this.add(0.5, 0.5, 0.5), Sound.POWER_OFF_SCULK_SENSOR);
+        if (phase == 1) this.level.playSound(this.add(0.5, 0.5, 0.5), Sound.POWER_ON_SCULK_SENSOR);
+        else this.level.playSound(this.add(0.5, 0.5, 0.5), Sound.POWER_OFF_SCULK_SENSOR);
         this.setPropertyValue(SCULK_SENSOR_PHASE, phase);
         this.level.setBlock(this, this, true, false);
     }

--- a/src/main/java/cn/nukkit/block/BlockSuspiciousGravel.java
+++ b/src/main/java/cn/nukkit/block/BlockSuspiciousGravel.java
@@ -53,11 +53,11 @@ public class BlockSuspiciousGravel extends BlockFallable {
         int progress = getPropertyValue(CommonBlockProperties.BRUSHED_PROGRESS);
         if(progress < 3) {
             setPropertyValue(CommonBlockProperties.BRUSHED_PROGRESS, progress+1);
-            getLevel().addSound(this, Sound.HIT_SUSPICIOUS_GRAVEL);
+            getLevel().playSound(this, Sound.HIT_SUSPICIOUS_GRAVEL);
             getLevel().setBlock(this, this);
         } else {
             getLevel().setBlock(this, BlockGravel.PROPERTIES.getDefaultState().toBlock());
-            getLevel().addSound(this, Sound.BREAK_SUSPICIOUS_GRAVEL);
+            getLevel().playSound(this, Sound.BREAK_SUSPICIOUS_GRAVEL);
         }
         super.onTouch(vector, item, face, fx, fy, fz, player, action);
     }

--- a/src/main/java/cn/nukkit/block/BlockSuspiciousSand.java
+++ b/src/main/java/cn/nukkit/block/BlockSuspiciousSand.java
@@ -56,11 +56,11 @@ public class BlockSuspiciousSand extends BlockFallable {
         int progress = getPropertyValue(CommonBlockProperties.BRUSHED_PROGRESS);
         if(progress < 3) {
             setPropertyValue(CommonBlockProperties.BRUSHED_PROGRESS, progress+1);
-            getLevel().addSound(this, Sound.HIT_SUSPICIOUS_SAND);
+            getLevel().playSound(this, Sound.HIT_SUSPICIOUS_SAND);
             getLevel().setBlock(this, this);
         } else {
             getLevel().setBlock(this, BlockSand.PROPERTIES.getDefaultState().toBlock());
-            getLevel().addSound(this, Sound.BREAK_SUSPICIOUS_SAND);
+            getLevel().playSound(this, Sound.BREAK_SUSPICIOUS_SAND);
         }
         super.onTouch(vector, item, face, fx, fy, fz, player, action);
     }

--- a/src/main/java/cn/nukkit/block/BlockSweetBerryBush.java
+++ b/src/main/java/cn/nukkit/block/BlockSweetBerryBush.java
@@ -168,7 +168,7 @@ public class BlockSweetBerryBush extends BlockFlowable {
         if (getGrowth() > 0) {
             if (entity.positionChanged && !entity.isSneaking() && ThreadLocalRandom.current().nextInt(20) == 0) {
                 if (entity.attack(new EntityDamageByBlockEvent(this, entity, EntityDamageEvent.DamageCause.CONTACT, 1))) {
-                    getLevel().addSound(entity, Sound.BLOCK_SWEET_BERRY_BUSH_HURT);
+                    getLevel().playSound(entity, Sound.BLOCK_SWEET_BERRY_BUSH_HURT);
                 }
             }
         }

--- a/src/main/java/cn/nukkit/block/BlockTrapdoor.java
+++ b/src/main/java/cn/nukkit/block/BlockTrapdoor.java
@@ -262,11 +262,11 @@ public class BlockTrapdoor extends BlockTransparent implements RedstoneComponent
     }
 
     public void playOpenSound() {
-        this.level.addSound(this, Sound.RANDOM_DOOR_OPEN);
+        this.level.playSound(this, Sound.RANDOM_DOOR_OPEN);
     }
 
     public void playCloseSound() {
-        this.level.addSound(this, Sound.RANDOM_DOOR_CLOSE);
+        this.level.playSound(this, Sound.RANDOM_DOOR_CLOSE);
     }
 
     public boolean isOpen() {

--- a/src/main/java/cn/nukkit/block/BlockTurtleEgg.java
+++ b/src/main/java/cn/nukkit/block/BlockTurtleEgg.java
@@ -181,7 +181,7 @@ public class BlockTurtleEgg extends BlockFlowable {
                         BlockGrowEvent event = new BlockGrowEvent(this, newState);
                         this.level.getServer().getPluginManager().callEvent(event);
                         if (!event.isCancelled()) {
-                            level.addSound(this, Sound.BLOCK_TURTLE_EGG_CRACK, 0.7f, 0.9f + random.nextFloat() * 0.2f);
+                            level.playSound(this, Sound.BLOCK_TURTLE_EGG_CRACK, 0.7f, 0.9f + random.nextFloat() * 0.2f);
                             this.level.setBlock(this, event.getNewState(), true, true);
                         }
                     } else {
@@ -209,12 +209,12 @@ public class BlockTurtleEgg extends BlockFlowable {
         this.level.getServer().getPluginManager().callEvent(turtleEggHatchEvent);
         int eggsHatching = turtleEggHatchEvent.getEggsHatching();
         if (!turtleEggHatchEvent.isCancelled()) {
-            level.addSound(this, Sound.BLOCK_TURTLE_EGG_CRACK);
+            level.playSound(this, Sound.BLOCK_TURTLE_EGG_CRACK);
 
             boolean hasFailure = false;
             for (int i = 0; i < eggsHatching; i++) {
 
-                this.level.addSound(this, Sound.BLOCK_TURTLE_EGG_CRACK);
+                this.level.playSound(this, Sound.BLOCK_TURTLE_EGG_CRACK);
 
                 CreatureSpawnEvent creatureSpawnEvent = new CreatureSpawnEvent(
                         Registries.ENTITY.getEntityNetworkId(EntityID.TURTLE),
@@ -287,7 +287,7 @@ public class BlockTurtleEgg extends BlockFlowable {
     public boolean onBreak(Item item) {
         TurtleEggCount eggCount = getEggCount();
         if (item.getEnchantment(Enchantment.ID_SILK_TOUCH) == null) {
-            this.level.addSound(this, Sound.BLOCK_TURTLE_EGG_CRACK);
+            this.level.playSound(this, Sound.BLOCK_TURTLE_EGG_CRACK);
         }
         if (eggCount == TurtleEggCount.ONE_EGG) {
             return super.onBreak(item);

--- a/src/main/java/cn/nukkit/block/BlockWarpedDoor.java
+++ b/src/main/java/cn/nukkit/block/BlockWarpedDoor.java
@@ -27,11 +27,11 @@ public class BlockWarpedDoor extends BlockWoodenDoor {
 
     @Override
     public void playOpenSound() {
-        level.addSound(this, Sound.OPEN_NETHER_WOOD_DOOR);
+        level.playSound(this, Sound.OPEN_NETHER_WOOD_DOOR);
     }
 
     @Override
     public void playCloseSound() {
-        level.addSound(this, Sound.CLOSE_NETHER_WOOD_DOOR);
+        level.playSound(this, Sound.CLOSE_NETHER_WOOD_DOOR);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockWarpedFenceGate.java
+++ b/src/main/java/cn/nukkit/block/BlockWarpedFenceGate.java
@@ -40,11 +40,11 @@ public class BlockWarpedFenceGate extends BlockFenceGate {
 
     @Override
     public void playOpenSound() {
-        level.addSound(this, Sound.OPEN_NETHER_WOOD_FENCE_GATE);
+        level.playSound(this, Sound.OPEN_NETHER_WOOD_FENCE_GATE);
     }
 
     @Override
     public void playCloseSound() {
-        level.addSound(this, Sound.CLOSE_NETHER_WOOD_FENCE_GATE);
+        level.playSound(this, Sound.CLOSE_NETHER_WOOD_FENCE_GATE);
     }
 }

--- a/src/main/java/cn/nukkit/block/BlockWarpedTrapdoor.java
+++ b/src/main/java/cn/nukkit/block/BlockWarpedTrapdoor.java
@@ -37,11 +37,11 @@ public class BlockWarpedTrapdoor extends BlockTrapdoor {
 
     @Override
     public void playOpenSound() {
-        level.addSound(this, Sound.OPEN_NETHER_WOOD_TRAPDOOR);
+        level.playSound(this, Sound.OPEN_NETHER_WOOD_TRAPDOOR);
     }
 
     @Override
     public void playCloseSound() {
-        level.addSound(this, Sound.CLOSE_NETHER_WOOD_TRAPDOOR);
+        level.playSound(this, Sound.CLOSE_NETHER_WOOD_TRAPDOOR);
     }
 }

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityBeacon.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityBeacon.java
@@ -81,13 +81,13 @@ public class BlockEntityBeacon extends BlockEntitySpawnable implements BlockEnti
         //Skip beacons that do not have a pyramid or sky access
         if (newPowerLevel < 1 || !hasSkyAccess()) {
             if (oldPowerLevel > 0) {
-                this.getLevel().addSound(this, Sound.BEACON_DEACTIVATE);
+                this.getLevel().playSound(this, Sound.BEACON_DEACTIVATE);
             }
             return true;
         } else if (oldPowerLevel < 1) {
-            this.getLevel().addSound(this, Sound.BEACON_ACTIVATE);
+            this.getLevel().playSound(this, Sound.BEACON_ACTIVATE);
         } else {
-            this.getLevel().addSound(this, Sound.BEACON_AMBIENT);
+            this.getLevel().playSound(this, Sound.BEACON_AMBIENT);
         }
 
         //Get all players in game
@@ -248,7 +248,7 @@ public class BlockEntityBeacon extends BlockEntitySpawnable implements BlockEnti
         this.setPrimaryPower(primary);
         this.setSecondaryPower(secondary);
 
-        this.getLevel().addSound(this, Sound.BEACON_POWER);
+        this.getLevel().playSound(this, Sound.BEACON_POWER);
 
         BeaconInventory inv = getInventory();
 

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityBeehive.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityBeehive.java
@@ -153,9 +153,9 @@ public class BlockEntityBeehive extends BlockEntity {
 
         entity.close();
         if (playSound) {
-            entity.level.addSound(this, Sound.BLOCK_BEEHIVE_ENTER);
+            entity.level.playSound(this, Sound.BLOCK_BEEHIVE_ENTER);
             if (entity.level != null && (entity.level != level || distanceSquared(this) >= 4)) {
-                entity.level.addSound(entity, Sound.BLOCK_BEEHIVE_ENTER);
+                entity.level.playSound(entity, Sound.BLOCK_BEEHIVE_ENTER);
             }
         }
         return occupant;
@@ -301,7 +301,7 @@ public class BlockEntityBeehive extends BlockEntity {
         Entity entity = Entity.createEntity(occupant.actorIdentifier, spawnPosition.getChunk(), saveData);
         if (entity != null) {
             removeOccupant(occupant);
-            level.addSound(this, Sound.BLOCK_BEEHIVE_EXIT);
+            level.playSound(this, Sound.BLOCK_BEEHIVE_EXIT);
         }
 
         EntityBee bee = entity instanceof EntityBee ? (EntityBee) entity : null;
@@ -369,7 +369,7 @@ public class BlockEntityBeehive extends BlockEntity {
                     occupant.ticksLeftToStay = 600;
                 }
             } else if (!occupant.isMuted() && RANDOM.nextDouble() < 0.005) {
-                level.addSound(add(0.5, 0, 0.5), occupant.workSound, 1f, occupant.workSoundPitch);
+                level.playSound(add(0.5, 0, 0.5), occupant.workSound, 1f, occupant.workSoundPitch);
             }
         }
 

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityBell.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityBell.java
@@ -63,7 +63,7 @@ public class BlockEntityBell extends BlockEntitySpawnable {
     public boolean onUpdate() {
         if (ringing) {
             if (ticks == 0) {
-                level.addSound(this, Sound.BLOCK_BELL_HIT);
+                level.playSound(this, Sound.BLOCK_BELL_HIT);
                 spawnToAllWithExceptions();
                 spawnExceptions.clear();
             } else if (ticks >= 50) {

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityBrewingStand.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityBrewingStand.java
@@ -241,7 +241,7 @@ public class BlockEntityBrewingStand extends BlockEntitySpawnable implements Rec
             this.fuelAmount--;
             this.sendFuel();
 
-            this.getLevel().addSound(this, Sound.RANDOM_POTION_BREWED);
+            this.getLevel().playSound(this, Sound.RANDOM_POTION_BREWED);
         }
 
         stopBrewing();

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityConduit.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityConduit.java
@@ -96,10 +96,10 @@ public class BlockEntityConduit extends BlockEntitySpawnable {
         if (activeBeforeUpdate != active || targetBeforeUpdate != targetEntity) {
             this.spawnToAll();
             if (activeBeforeUpdate && !active) {
-                level.addSound(add(0, 0.5, 0), Sound.CONDUIT_DEACTIVATE);
+                level.playSound(add(0, 0.5, 0), Sound.CONDUIT_DEACTIVATE);
                 level.getServer().getPluginManager().callEvent(new ConduitDeactivateEvent(getBlock()));
             } else if (!activeBeforeUpdate && active) {
-                level.addSound(add(0, 0.5, 0), Sound.CONDUIT_ACTIVATE);
+                level.playSound(add(0, 0.5, 0), Sound.CONDUIT_ACTIVATE);
                 level.getServer().getPluginManager().callEvent(new ConduitActivateEvent(getBlock()));
             }
         }

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityCreakingHeart.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityCreakingHeart.java
@@ -62,7 +62,7 @@ public class BlockEntityCreakingHeart extends BlockEntitySpawnable {
     @Override
     public boolean onUpdate() {
         if(getLevel().getTick() % 40 == 0 && isBlockEntityValid() && getHeart().isActive()) {
-            getLevel().addSound(this, Sound.BLOCK_CREAKING_HEART_AMBIENT);
+            getLevel().playSound(this, Sound.BLOCK_CREAKING_HEART_AMBIENT);
         }
         if((getLinkedCreaking() == null || !getLinkedCreaking().isAlive()) && isBlockEntityValid() && getHeart().isActive() && (!getLevel().isDay() || getLevel().isRaining() || getLevel().isThundering())) {
             Position pos = new Position(
@@ -92,7 +92,7 @@ public class BlockEntityCreakingHeart extends BlockEntitySpawnable {
                     ent.close();
                 } else {
                     setLinkedCreaking((EntityCreaking) ent);
-                    this.getLevel().addSound(this, Sound.BLOCK_CREAKING_HEART_MOB_SPAWN, 1, 1);
+                    this.getLevel().playSound(this, Sound.BLOCK_CREAKING_HEART_MOB_SPAWN, 1, 1);
                     ent.spawnToAll();
                 }
             }

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityFurnace.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityFurnace.java
@@ -304,7 +304,7 @@ public class BlockEntityFurnace extends BlockEntitySpawnable implements RecipeIn
 
             if (this.crackledTime-- <= 0) {
                 this.crackledTime = ThreadLocalRandom.current().nextInt(20, 100);
-                this.getLevel().addSound(this.add(0.5, 0.5, 0.5), Sound.BLOCK_FURNACE_LIT);
+                this.getLevel().playSound(this.add(0.5, 0.5, 0.5), Sound.BLOCK_FURNACE_LIT);
             }
 
             if (smelt != null && canSmelt) {

--- a/src/main/java/cn/nukkit/dispenser/BucketDispenseBehavior.java
+++ b/src/main/java/cn/nukkit/dispenser/BucketDispenseBehavior.java
@@ -29,13 +29,13 @@ public class BucketDispenseBehavior extends DefaultDispenseBehavior {
                 Block replace = bucket.getTargetBlock();
                 var fishEntityId = bucket.getFishEntityId();
                 if (bucket instanceof ItemLavaBucket)
-                    target.level.addSound(block, Sound.BUCKET_EMPTY_LAVA);
+                    target.level.playSound(block, Sound.BUCKET_EMPTY_LAVA);
                 else if(bucket instanceof ItemPowderSnowBucket)
-                    target.level.addSound(block, Sound.BUCKET_EMPTY_POWDER_SNOW);
+                    target.level.playSound(block, Sound.BUCKET_EMPTY_POWDER_SNOW);
                 else if (fishEntityId != null)
-                    target.level.addSound(block, Sound.BUCKET_EMPTY_FISH);
+                    target.level.playSound(block, Sound.BUCKET_EMPTY_FISH);
                 else
-                    target.level.addSound(block, Sound.BUCKET_EMPTY_WATER);
+                    target.level.playSound(block, Sound.BUCKET_EMPTY_WATER);
 
                 if (target.getId().equals(BlockID.PORTAL)) {
                     target.onBreak(null);
@@ -58,16 +58,16 @@ public class BucketDispenseBehavior extends DefaultDispenseBehavior {
             if (target instanceof BlockFlowingWater flowingWater && flowingWater.getLiquidDepth() == 0) {
                 target.level.setBlock(target, Block.get(BlockID.AIR));
                 target.getLevel().getVibrationManager().callVibrationEvent(new VibrationEvent(this, target.add(0.5, 0.5, 0.5), VibrationType.FLUID_PICKUP));
-                target.level.addSound(block, Sound.BUCKET_FILL_WATER);
+                target.level.playSound(block, Sound.BUCKET_FILL_WATER);
                 return Item.get(ItemID.WATER_BUCKET, 0, 1, bucket.getCompoundTag());
             } else if (target instanceof BlockFlowingLava lava && lava.getLiquidDepth() == 0) {
                 target.level.setBlock(target, Block.get(BlockID.AIR));
                 target.getLevel().getVibrationManager().callVibrationEvent(new VibrationEvent(this, target.add(0.5, 0.5, 0.5), VibrationType.FLUID_PICKUP));
-                target.level.addSound(block, Sound.BUCKET_FILL_LAVA);
+                target.level.playSound(block, Sound.BUCKET_FILL_LAVA);
                 return Item.get(ItemID.LAVA_BUCKET, 0, 1, bucket.getCompoundTag());
             } else if (target instanceof BlockPowderSnow) {
                 target.level.setBlock(target, Block.get(BlockID.AIR));
-                target.level.addSound(block, Sound.BUCKET_FILL_POWDER_SNOW);
+                target.level.playSound(block, Sound.BUCKET_FILL_POWDER_SNOW);
                 target.getLevel().getVibrationManager().callVibrationEvent(new VibrationEvent(this, target.add(0.5, 0.5, 0.5), VibrationType.FLUID_PICKUP));
                 return Item.get(ItemID.POWDER_SNOW_BUCKET, 0, 1, bucket.getCompoundTag());
             }

--- a/src/main/java/cn/nukkit/dispenser/DropperDispenseBehavior.java
+++ b/src/main/java/cn/nukkit/dispenser/DropperDispenseBehavior.java
@@ -32,7 +32,7 @@ public class DropperDispenseBehavior extends DefaultDispenseBehavior {
                 return clone;
             }
         } else {
-            block.level.addSound(block, Sound.RANDOM_CLICK);
+            block.level.playSound(block, Sound.RANDOM_CLICK);
             return super.dispense(block, face, item);
         }
         return null;

--- a/src/main/java/cn/nukkit/dispenser/FlintAndSteelDispenseBehavior.java
+++ b/src/main/java/cn/nukkit/dispenser/FlintAndSteelDispenseBehavior.java
@@ -32,12 +32,12 @@ public class FlintAndSteelDispenseBehavior extends DefaultDispenseBehavior {
         }
 
         if (target.getId() == BlockID.AIR) {
-            block.level.addSound(block, Sound.RANDOM_CLICK, 1.0f, 1.0f);
+            block.level.playSound(block, Sound.RANDOM_CLICK, 1.0f, 1.0f);
             block.level.setBlock(target, Block.get(BlockID.FIRE));
             item.useOn(target);
             return item.getDamage() >= item.getMaxDurability() ? null : item;
         } else if (target.getId() == BlockID.TNT) {
-            block.level.addSound(block, Sound.RANDOM_CLICK, 1.0f, 1.0f);
+            block.level.playSound(block, Sound.RANDOM_CLICK, 1.0f, 1.0f);
             target.onActivate(item,null, face, 0,0 ,0 );
             item.useOn(target);
             return item.getDamage() >= item.getMaxDurability() ? null : item;
@@ -45,7 +45,7 @@ public class FlintAndSteelDispenseBehavior extends DefaultDispenseBehavior {
             this.success = false;
         }
 
-        block.level.addSound(block, Sound.RANDOM_CLICK, 1.0f, 1.2f);
+        block.level.playSound(block, Sound.RANDOM_CLICK, 1.0f, 1.2f);
         return item;
     }
 }

--- a/src/main/java/cn/nukkit/dispenser/ProjectileDispenseBehavior.java
+++ b/src/main/java/cn/nukkit/dispenser/ProjectileDispenseBehavior.java
@@ -43,7 +43,7 @@ public class ProjectileDispenseBehavior extends DefaultDispenseBehavior {
 
         projectile.spawnToAll();
 
-        source.level.addSound(source, getShootingSound());
+        source.level.playSound(source, getShootingSound());
 
         return null;
     }

--- a/src/main/java/cn/nukkit/entity/EntityHumanType.java
+++ b/src/main/java/cn/nukkit/entity/EntityHumanType.java
@@ -185,7 +185,7 @@ public abstract class EntityHumanType extends EntityCreature implements IHuman {
             }
 
             if (armor.getMaxDurability() > 0 && armor.getDamage() >= armor.getMaxDurability()) {
-                getLevel().addSound(this, Sound.RANDOM_BREAK);
+                getLevel().playSound(this, Sound.RANDOM_BREAK);
                 return Item.get(BlockID.AIR, 0, 0);
             }
         }

--- a/src/main/java/cn/nukkit/entity/EntityIntelligentHuman.java
+++ b/src/main/java/cn/nukkit/entity/EntityIntelligentHuman.java
@@ -307,7 +307,7 @@ public class EntityIntelligentHuman extends EntityIntelligent implements EntityI
             }
 
             if (armor.getMaxDurability() > 0 && armor.getDamage() >= armor.getMaxDurability()) {
-                getLevel().addSound(this, Sound.RANDOM_BREAK);
+                getLevel().playSound(this, Sound.RANDOM_BREAK);
                 return Item.get(BlockID.AIR, 0, 0);
             }
         }

--- a/src/main/java/cn/nukkit/entity/EntityLiving.java
+++ b/src/main/java/cn/nukkit/entity/EntityLiving.java
@@ -146,7 +146,7 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
                     animate.eid = getId();
 
                     this.getLevel().addChunkPacket(damager.getChunkX(), damager.getChunkZ(), animate);
-                    this.getLevel().addSound(this, Sound.GAME_PLAYER_ATTACK_STRONG);
+                    this.getLevel().playSound(this, Sound.GAME_PLAYER_ATTACK_STRONG);
 
                     source.setDamage(source.getDamage() * 1.5f);
                 }
@@ -465,7 +465,7 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
 
     protected void onBlock(Entity entity, EntityDamageEvent event, boolean animate) {
         if (animate) {
-            getLevel().addSound(this, Sound.ITEM_SHIELD_BLOCK);
+            getLevel().playSound(this, Sound.ITEM_SHIELD_BLOCK);
         }
     }
 

--- a/src/main/java/cn/nukkit/entity/ai/controller/HoppingController.java
+++ b/src/main/java/cn/nukkit/entity/ai/controller/HoppingController.java
@@ -52,7 +52,7 @@ public class HoppingController extends WalkController {
                 double diffY = entity.getScale();
                 dy += entity.getJumpingMotion(diffY);
                 Sound jumpSound = entity instanceof EntityRabbit ? Sound.MOB_RABBIT_HOP : entity instanceof EntitySlime ? Sound.JUMP_SLIME : null;
-                if(jumpSound != null) entity.getLevel().addSound(entity, jumpSound);
+                if(jumpSound != null) entity.getLevel().playSound(entity, jumpSound);
                 entity.setDataProperty(EntityDataTypes.CLIENT_EVENT, 2);
                 currentJumpCoolDown = 0;
             }

--- a/src/main/java/cn/nukkit/entity/ai/executor/BowShootExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/BowShootExecutor.java
@@ -209,7 +209,7 @@ public class BowShootExecutor implements EntityControl, IBehaviorExecutor {
                     entityShootBowEvent.getProjectile().kill();
                 } else {
                     entityShootBowEvent.getProjectile().spawnToAll();
-                    entity.getLevel().addSound(entity, Sound.RANDOM_BOW);
+                    entity.getLevel().playSound(entity, Sound.RANDOM_BOW);
                 }
             }
         }

--- a/src/main/java/cn/nukkit/entity/ai/executor/BreezeShootExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/BreezeShootExecutor.java
@@ -165,14 +165,14 @@ public class BreezeShootExecutor implements EntityControl, IBehaviorExecutor {
         if (projectev.isCancelled()) {
             projectile.kill();
         } else {
-            entity.level.addSound(entity, Sound.MOB_BREEZE_SHOOT);
+            entity.level.playSound(entity, Sound.MOB_BREEZE_SHOOT);
             projectile.spawnToAll();
         }
     }
 
     private void startShootSequence(Entity entity) {
         entity.setDataProperty(EntityDataTypes.TARGET_EID, this.target.getId());
-        entity.level.addSound(entity, Sound.MOB_BREEZE_CHARGE);
+        entity.level.playSound(entity, Sound.MOB_BREEZE_CHARGE);
     }
 
     private void endShootSequence(Entity entity) {

--- a/src/main/java/cn/nukkit/entity/ai/executor/CrossBowShootExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/CrossBowShootExecutor.java
@@ -196,7 +196,7 @@ public class CrossBowShootExecutor implements EntityControl, IBehaviorExecutor {
                     entityShootBowEvent.getProjectile().kill();
                 } else {
                     entityShootBowEvent.getProjectile().spawnToAll();
-                    entity.getLevel().addSound(entity, Sound.RANDOM_BOW);
+                    entity.getLevel().playSound(entity, Sound.RANDOM_BOW);
                 }
             }
         }
@@ -204,14 +204,14 @@ public class CrossBowShootExecutor implements EntityControl, IBehaviorExecutor {
 
     private void playBowAnimation(Entity entity, int chargeAmount) {
         if(chargeAmount == 0) {
-            entity.level.addSound(entity, Sound.CROSSBOW_LOADING_START);
+            entity.level.playSound(entity, Sound.CROSSBOW_LOADING_START);
             entity.setDataProperty(EntityDataTypes.TARGET_EID, this.target.getId());
             entity.setDataFlag(EntityFlag.USING_ITEM);
         } else entity.setDataProperty(EntityDataTypes.CHARGE_AMOUNT, chargeAmount*2);
-        if(chargeAmount == 30) entity.level.addSound(entity, Sound.CROSSBOW_LOADING_MIDDLE);
+        if(chargeAmount == 30) entity.level.playSound(entity, Sound.CROSSBOW_LOADING_MIDDLE);
         if(chargeAmount == 60) {
             entity.setDataFlag(EntityFlag.CHARGED);
-            entity.level.addSound(entity, Sound.CROSSBOW_LOADING_END);
+            entity.level.playSound(entity, Sound.CROSSBOW_LOADING_END);
         }
     }
 

--- a/src/main/java/cn/nukkit/entity/ai/executor/EntityExplosionExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/EntityExplosionExecutor.java
@@ -42,7 +42,7 @@ public class EntityExplosionExecutor implements IBehaviorExecutor {
 
         currentTick++;
         if (explodeTime > currentTick) {
-            entity.level.addSound(entity, Sound.RANDOM_FUSE);
+            entity.level.playSound(entity, Sound.RANDOM_FUSE);
             entity.setDataProperty(FUSE_TIME, currentTick);
             entity.setDataFlag(EntityFlag.IGNITED, true);
             return true;

--- a/src/main/java/cn/nukkit/entity/ai/executor/HoglinTransformExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/HoglinTransformExecutor.java
@@ -48,7 +48,7 @@ public class HoglinTransformExecutor implements EntityControl, IBehaviorExecutor
         zoglin.setRotation(entity.yaw, entity.pitch);
         zoglin.setBaby(entity.isBaby());
         zoglin.spawnToAll();
-        zoglin.level.addSound(zoglin, Sound.MOB_HOGLIN_CONVERTED_TO_ZOMBIFIED);
+        zoglin.level.playSound(zoglin, Sound.MOB_HOGLIN_CONVERTED_TO_ZOMBIFIED);
         zoglin.addEffect(Effect.get(EffectType.NAUSEA).setDuration(15));
     }
 

--- a/src/main/java/cn/nukkit/entity/ai/executor/PiglinTradeExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/PiglinTradeExecutor.java
@@ -29,7 +29,7 @@ public class PiglinTradeExecutor implements EntityControl, IBehaviorExecutor {
         tick++;
         if(tick < 160) {
             if(tick % 30 == 0 && ThreadLocalRandom.current().nextBoolean()) {
-                entity.level.addSound(entity, Sound.MOB_PIGLIN_ADMIRING_ITEM);
+                entity.level.playSound(entity, Sound.MOB_PIGLIN_ADMIRING_ITEM);
             }
             return true;
         } else {

--- a/src/main/java/cn/nukkit/entity/ai/executor/PiglinTransformExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/PiglinTransformExecutor.java
@@ -48,7 +48,7 @@ public class PiglinTransformExecutor implements EntityControl, IBehaviorExecutor
         entityZombiePigman.setPosition(entity);
         entityZombiePigman.setRotation(entity.yaw, entity.pitch);
         entityZombiePigman.spawnToAll();
-        entityZombiePigman.level.addSound(entityZombiePigman, Sound.MOB_PIGLIN_CONVERTED_TO_ZOMBIFIED);
+        entityZombiePigman.level.playSound(entityZombiePigman, Sound.MOB_PIGLIN_CONVERTED_TO_ZOMBIFIED);
         Inventory inventory = entityZombiePigman.getEquipmentInventory();
         for(int i = 2; i < inventory.getSize(); i++) {
             entityZombiePigman.level.dropItem(entityZombiePigman, inventory.getItem(i));

--- a/src/main/java/cn/nukkit/entity/ai/executor/PlaySoundExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/PlaySoundExecutor.java
@@ -26,7 +26,7 @@ public class PlaySoundExecutor implements IBehaviorExecutor {
     public boolean execute(EntityIntelligent entity) {
         float volume = minVolume == maxVolume ? minVolume : ThreadLocalRandom.current().nextFloat(minVolume, maxVolume);
         float pitch = minPitch == maxPitch ? minPitch : ThreadLocalRandom.current().nextFloat(minPitch, maxPitch);
-        entity.getValidLevel().addSound(entity, sound, volume, pitch);
+        entity.getValidLevel().playSound(entity, sound, volume, pitch);
         return false;
     }
 }

--- a/src/main/java/cn/nukkit/entity/ai/executor/ShulkerAttackExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/ShulkerAttackExecutor.java
@@ -59,7 +59,7 @@ public class ShulkerAttackExecutor implements IBehaviorExecutor {
                 bullet.getMemoryStorage().put(CoreMemoryTypes.ATTACK_TARGET, target);
             }
             bulletEntity.spawnToAll();
-            entity.getLevel().addSound(entity, Sound.MOB_SHULKER_SHOOT);
+            entity.getLevel().playSound(entity, Sound.MOB_SHULKER_SHOOT);
         }
         return new AllMatchEvaluator(new EntityCheckEvaluator(this.target), new DistanceEvaluator(this.target, 16), new NotMatchEvaluator(new PassByTimeEvaluator(CoreMemoryTypes.LAST_BE_ATTACKED_TIME, 0, 60))).evaluate(entity);
     }

--- a/src/main/java/cn/nukkit/entity/ai/executor/ShulkerIdleExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/ShulkerIdleExecutor.java
@@ -25,7 +25,7 @@ public class ShulkerIdleExecutor implements IBehaviorExecutor {
         stayTicks = Utils.rand(20, 61);
         if(entity instanceof EntityShulker shulker) {
             shulker.setPeeking(30);
-            shulker.getLevel().addSound(shulker, Sound.MOB_SHULKER_OPEN);
+            shulker.getLevel().playSound(shulker, Sound.MOB_SHULKER_OPEN);
         }
     }
 
@@ -33,7 +33,7 @@ public class ShulkerIdleExecutor implements IBehaviorExecutor {
     public void onStop(EntityIntelligent entity) {
         if(entity instanceof EntityShulker shulker) {
             shulker.setPeeking(0);
-            shulker.getLevel().addSound(shulker, Sound.MOB_SHULKER_CLOSE);
+            shulker.getLevel().playSound(shulker, Sound.MOB_SHULKER_CLOSE);
         }
     }
 

--- a/src/main/java/cn/nukkit/entity/ai/executor/SnowGolemShootExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/SnowGolemShootExecutor.java
@@ -158,7 +158,7 @@ public class SnowGolemShootExecutor implements EntityControl, IBehaviorExecutor 
             projectile.kill();
         } else {
             projectile.spawnToAll();
-            entity.level.addSound(entity, Sound.MOB_SNOWGOLEM_SHOOT);
+            entity.level.playSound(entity, Sound.MOB_SNOWGOLEM_SHOOT);
         }
     }
 

--- a/src/main/java/cn/nukkit/entity/ai/executor/StaringAttackTargetExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/StaringAttackTargetExecutor.java
@@ -14,7 +14,7 @@ public class StaringAttackTargetExecutor implements IBehaviorExecutor {
         if(entity.getMemoryStorage().isEmpty(CoreMemoryTypes.ATTACK_TARGET)) {
             if(!entity.getMemoryStorage().isEmpty(CoreMemoryTypes.STARING_PLAYER) && new EntityCheckEvaluator(CoreMemoryTypes.STARING_PLAYER).evaluate(entity)) {
                 entity.getMemoryStorage().put(CoreMemoryTypes.ATTACK_TARGET, entity.getMemoryStorage().get(CoreMemoryTypes.STARING_PLAYER));
-                entity.level.addSound(entity, Sound.MOB_ENDERMEN_STARE);
+                entity.level.playSound(entity, Sound.MOB_ENDERMEN_STARE);
             } else if(!entity.getMemoryStorage().isEmpty(CoreMemoryTypes.NEAREST_ENDERMITE)) {
                 entity.getMemoryStorage().put(CoreMemoryTypes.ATTACK_TARGET, entity.getMemoryStorage().get(CoreMemoryTypes.NEAREST_ENDERMITE));
             }

--- a/src/main/java/cn/nukkit/entity/ai/executor/TeleportExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/TeleportExecutor.java
@@ -42,7 +42,7 @@ public class TeleportExecutor implements IBehaviorExecutor {
         }
         if(entity.distance(location) > minDistance) {
             entity.teleport(location);
-            location.level.addSound(location, Sound.MOB_ENDERMEN_PORTAL);
+            location.level.playSound(location, Sound.MOB_ENDERMEN_PORTAL);
         }
         return true;
     }

--- a/src/main/java/cn/nukkit/entity/ai/executor/TridentThrowExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/TridentThrowExecutor.java
@@ -178,7 +178,7 @@ public class TridentThrowExecutor implements EntityControl, IBehaviorExecutor {
         if (projectev.isCancelled()) {
             projectile.kill();
         } else {
-            entity.level.addSound(entity, Sound.MOB_BREEZE_SHOOT);
+            entity.level.playSound(entity, Sound.MOB_BREEZE_SHOOT);
             projectile.spawnToAll();
         }
     }

--- a/src/main/java/cn/nukkit/entity/ai/executor/WardenMeleeAttackExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/WardenMeleeAttackExecutor.java
@@ -63,7 +63,7 @@ public class WardenMeleeAttackExecutor implements EntityControl, IBehaviorExecut
             ev.setBreakShield(true);
             target.attack(ev);
             playAttackAnimation(entity);
-            entity.level.addSound(target, Sound.MOB_WARDEN_ATTACK);
+            entity.level.playSound(target, Sound.MOB_WARDEN_ATTACK);
             attackTick = 0;
             return target.isUndead();
         }

--- a/src/main/java/cn/nukkit/entity/ai/executor/WardenRangedAttackExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/WardenRangedAttackExecutor.java
@@ -43,7 +43,7 @@ public class WardenRangedAttackExecutor implements IBehaviorExecutor {
             sendAttackParticle(entity, entity.add(0, 1.5), target.add(0, target.getHeight() / 2));
 
             //sound
-            entity.level.addSound(entity, Sound.MOB_WARDEN_SONIC_BOOM);
+            entity.level.playSound(entity, Sound.MOB_WARDEN_SONIC_BOOM);
 //            LevelSoundEventPacketV2 pk = new LevelSoundEventPacketV2();
 //            pk.sound = LevelSoundEvent.SONIC_BOOM;
 //            pk.entityIdentifier = "minecraft:warden";
@@ -64,7 +64,7 @@ public class WardenRangedAttackExecutor implements IBehaviorExecutor {
 
             EntityDamageByEntityEvent ev = new EntityDamageByEntityEvent(entity, target, EntityDamageEvent.DamageCause.MAGIC, damages, 0.6f, null);
 
-            entity.level.addSound(target, Sound.MOB_WARDEN_ATTACK);
+            entity.level.playSound(target, Sound.MOB_WARDEN_ATTACK);
             target.attack(ev);
         }
         if (currentTick > this.totalRunningTime) {
@@ -91,7 +91,7 @@ public class WardenRangedAttackExecutor implements IBehaviorExecutor {
         entity.setDataFlag(EntityFlag.SONIC_BOOM, true);
         entity.setDataFlagExtend(EntityFlag.SONIC_BOOM, true);
 
-        entity.level.addSound(entity, Sound.MOB_WARDEN_SONIC_CHARGE);
+        entity.level.playSound(entity, Sound.MOB_WARDEN_SONIC_CHARGE);
 //        LevelSoundEventPacketV2 pk = new LevelSoundEventPacketV2();
 //        pk.sound = LevelSoundEvent.SONIC_CHARGE;
 //        pk.entityIdentifier = "minecraft:warden";

--- a/src/main/java/cn/nukkit/entity/ai/executor/WardenSniffExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/WardenSniffExecutor.java
@@ -31,7 +31,7 @@ public class WardenSniffExecutor implements IBehaviorExecutor {
         this.endTime = entity.getLevel().getTick() + this.duration;
         entity.setDataFlag(EntityFlag.SNIFFING, true);
         entity.setDataFlagExtend(EntityFlag.SNIFFING, true);
-        entity.level.addSound(entity.clone(), Sound.MOB_WARDEN_SNIFF);
+        entity.level.playSound(entity.clone(), Sound.MOB_WARDEN_SNIFF);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/ai/executor/WitherShootExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/WitherShootExecutor.java
@@ -81,7 +81,7 @@ public class WitherShootExecutor implements EntityControl, IBehaviorExecutor {
             projectile.kill();
         } else {
             projectile.spawnToAll();
-            entity.level.addSound(entity, Sound.MOB_WITHER_SHOOT);
+            entity.level.playSound(entity, Sound.MOB_WITHER_SHOOT);
         }
     }
 }

--- a/src/main/java/cn/nukkit/entity/ai/executor/armadillo/ShedExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/armadillo/ShedExecutor.java
@@ -19,7 +19,7 @@ public class ShedExecutor implements EntityControl, IBehaviorExecutor {
     @Override
     public void onStart(EntityIntelligent entity) {
         entity.getLevel().dropItem(entity, Item.get(Item.ARMADILLO_SCUTE));
-        entity.getLevel().addSound(entity, Sound.MOB_ARMADILLO_SCUTE_DROP);
+        entity.getLevel().playSound(entity, Sound.MOB_ARMADILLO_SCUTE_DROP);
         entity.getMemoryStorage().put(CoreMemoryTypes.NEXT_SHED, entity.getLevel().getTick() + Utils.rand(6_000, 10_800));
     }
 }

--- a/src/main/java/cn/nukkit/entity/ai/executor/evocation/ColorConversionExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/evocation/ColorConversionExecutor.java
@@ -42,7 +42,7 @@ public class ColorConversionExecutor extends FangLineExecutor {
     @Override
     protected void startSpell(EntityIntelligent entity) {
         tick = 0;
-        entity.level.addSound(entity, Sound.MOB_EVOCATION_ILLAGER_PREPARE_WOLOLO);
+        entity.level.playSound(entity, Sound.MOB_EVOCATION_ILLAGER_PREPARE_WOLOLO);
         entity.setDataProperty(EntityDataTypes.EVOKER_SPELL_CASTING_COLOR, BlockColor.ORANGE_BLOCK_COLOR.getARGB());
         entity.getMemoryStorage().put(LAST_MAGIC, EntityEvocationIllager.SPELL.COLOR_CONVERSION);
         entity.setDataFlag(EntityFlag.CASTING);

--- a/src/main/java/cn/nukkit/entity/ai/executor/evocation/FangLineExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/evocation/FangLineExecutor.java
@@ -75,7 +75,7 @@ public class FangLineExecutor implements EntityControl, IBehaviorExecutor {
 
     protected void startSpell(EntityIntelligent entity) {
         tick = 0;
-        entity.level.addSound(entity, Sound.MOB_EVOCATION_ILLAGER_PREPARE_SUMMON);
+        entity.level.playSound(entity, Sound.MOB_EVOCATION_ILLAGER_PREPARE_SUMMON);
         entity.setDataProperty(EntityDataTypes.EVOKER_SPELL_CASTING_COLOR, BlockColor.PURPLE_BLOCK_COLOR.getARGB());
         entity.getMemoryStorage().put(LAST_MAGIC, EntityEvocationIllager.SPELL.CAST_LINE);
         entity.setDataFlag(EntityFlag.CASTING);

--- a/src/main/java/cn/nukkit/entity/ai/executor/evocation/VexSummonExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/evocation/VexSummonExecutor.java
@@ -53,7 +53,7 @@ public class VexSummonExecutor extends FangLineExecutor {
     @Override
     protected void startSpell(EntityIntelligent entity) {
         tick = 0;
-        entity.level.addSound(entity, Sound.MOB_EVOCATION_ILLAGER_PREPARE_SUMMON);
+        entity.level.playSound(entity, Sound.MOB_EVOCATION_ILLAGER_PREPARE_SUMMON);
         entity.setDataProperty(EntityDataTypes.EVOKER_SPELL_CASTING_COLOR, BlockColor.WHITE_BLOCK_COLOR.getARGB());
         entity.getMemoryStorage().put(LAST_MAGIC, EntityEvocationIllager.SPELL.SUMMON);
         entity.setDataFlag(EntityFlag.CASTING);

--- a/src/main/java/cn/nukkit/entity/ai/executor/panda/EatingExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/panda/EatingExecutor.java
@@ -16,7 +16,7 @@ public class EatingExecutor implements EntityControl, IBehaviorExecutor {
 
     @Override
     public boolean execute(EntityIntelligent entity) {
-        if(ticks % 10 == 0) entity.getLevel().addSound(entity, Sound.MOB_PANDA_EAT);
+        if(ticks % 10 == 0) entity.getLevel().playSound(entity, Sound.MOB_PANDA_EAT);
         return ticks-- >= 0;
     }
 

--- a/src/main/java/cn/nukkit/entity/ai/executor/panda/SneezingExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/panda/SneezingExecutor.java
@@ -26,13 +26,13 @@ public class SneezingExecutor implements EntityControl, IBehaviorExecutor {
     @Override
     public void onStart(EntityIntelligent entity) {
         ticks = 0;
-        entity.getLevel().addSound(entity, Sound.MOB_PANDA_PRESNEEZE);
+        entity.getLevel().playSound(entity, Sound.MOB_PANDA_PRESNEEZE);
     }
 
     @Override
     public void onStop(EntityIntelligent entity) {
         entity.setDataFlag(EntityFlag.SNEEZING);
-        entity.getLevel().addSound(entity, Sound.MOB_PANDA_SNEEZE);
+        entity.getLevel().playSound(entity, Sound.MOB_PANDA_SNEEZE);
         for(Entity entity1 : Arrays.stream(entity.getLevel().getEntities()).filter(entity1 -> entity1 instanceof EntityPanda && entity1.isOnGround() && entity1.distance(entity) < 10).toList()) {
             if(entity1 != entity) ((EntityPanda) entity1).addTmpMoveMotion(new Vector3(0, ((EntityPanda) entity1).getJumpingMotion(1), 0));
         }

--- a/src/main/java/cn/nukkit/entity/ai/executor/villager/WorkExecutor.java
+++ b/src/main/java/cn/nukkit/entity/ai/executor/villager/WorkExecutor.java
@@ -33,7 +33,7 @@ public class WorkExecutor extends NearbyFlatRandomRoamExecutor {
                 if(site.distance(villager) < 1.5f) {
                     setLookTarget(villager, site);
                     stayTick++;
-                    if(stayTick == 40 || stayTick == 90) villager.getLevel().addSound(villager, Profession.getProfession(villager.getProfession()).getWorkSound());
+                    if(stayTick == 40 || stayTick == 90) villager.getLevel().playSound(villager, Profession.getProfession(villager.getProfession()).getWorkSound());
                 }
                 if(stayTick == 99) removeRouteTarget(villager);
             } else {

--- a/src/main/java/cn/nukkit/entity/item/EntityArmorStand.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityArmorStand.java
@@ -221,7 +221,7 @@ public class EntityArmorStand extends Entity implements EntityInventoryHolder, E
         }
 
         if (changed) {
-            level.addSound(this, Sound.MOB_ARMOR_STAND_PLACE);
+            level.playSound(this, Sound.MOB_ARMOR_STAND_PLACE);
         }
 
         return false; // Returning true would consume the item but tryChangeEquipment already manages the inventory
@@ -340,7 +340,7 @@ public class EntityArmorStand extends Entity implements EntityInventoryHolder, E
     public void fall(float fallDistance) {
         super.fall(fallDistance);
 
-        this.getLevel().addSound(this, Sound.MOB_ARMOR_STAND_LAND);
+        this.getLevel().playSound(this, Sound.MOB_ARMOR_STAND_LAND);
     }
 
     @Override
@@ -367,7 +367,7 @@ public class EntityArmorStand extends Entity implements EntityInventoryHolder, E
         level.dropItem(pos, armorInventory.getHelmet());
         armorInventory.clearAll();
 
-        level.addSound(this, Sound.MOB_ARMOR_STAND_BREAK);
+        level.playSound(this, Sound.MOB_ARMOR_STAND_BREAK);
 
         //todo: initiator should be a entity who kill it but not itself
         level.getVibrationManager().callVibrationEvent(new VibrationEvent(this.getLastDamageCause() instanceof EntityDamageByEntityEvent byEntity ? byEntity.getDamager() : this, this.getVector3(), VibrationType.ENTITY_DIE));
@@ -379,7 +379,7 @@ public class EntityArmorStand extends Entity implements EntityInventoryHolder, E
         switch (source.getCause()) {
             case FALL:
                 source.setCancelled(true);
-                level.addSound(this, Sound.MOB_ARMOR_STAND_LAND);
+                level.playSound(this, Sound.MOB_ARMOR_STAND_LAND);
                 break;
             case CONTACT:
             case HUNGER:
@@ -431,7 +431,7 @@ public class EntityArmorStand extends Entity implements EntityInventoryHolder, E
         }
 
         setDataProperty(HURT_TICKS, 9, true);
-        level.addSound(this, Sound.MOB_ARMOR_STAND_HIT);
+        level.playSound(this, Sound.MOB_ARMOR_STAND_HIT);
 
         return true;
     }
@@ -503,7 +503,7 @@ public class EntityArmorStand extends Entity implements EntityInventoryHolder, E
             updateMovement();
             hasUpdate = true;
             if (onGround && (highestPosition - y) >= 3) {
-                level.addSound(this, Sound.MOB_ARMOR_STAND_LAND);
+                level.playSound(this, Sound.MOB_ARMOR_STAND_LAND);
             }
         }
 

--- a/src/main/java/cn/nukkit/entity/item/EntityFireworksRocket.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityFireworksRocket.java
@@ -129,7 +129,7 @@ public class EntityFireworksRocket extends Entity {
 
 
             if (this.fireworkAge == 0) {
-                this.getLevel().addSound(this, Sound.FIREWORK_LAUNCH);
+                this.getLevel().playSound(this, Sound.FIREWORK_LAUNCH);
             }
 
             this.fireworkAge++;

--- a/src/main/java/cn/nukkit/entity/item/EntitySplashPotion.java
+++ b/src/main/java/cn/nukkit/entity/item/EntitySplashPotion.java
@@ -142,7 +142,7 @@ public class EntitySplashPotion extends EntityProjectile {
         Particle particle = new SpellParticle(this, r, g, b);
 
         this.getLevel().addParticle(particle);
-        this.getLevel().addSound(this, Sound.RANDOM_GLASS);
+        this.getLevel().playSound(this, Sound.RANDOM_GLASS);
 
         Entity[] entities = this.getLevel().getNearbyEntities(this.getBoundingBox().grow(4.125, 2.125, 4.125));
         for (Entity anEntity : entities) {

--- a/src/main/java/cn/nukkit/entity/item/EntityTnt.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityTnt.java
@@ -92,7 +92,7 @@ public class EntityTnt extends Entity implements EntityExplosive {
         this.setDataFlag(EntityFlag.IGNITED, true);
         this.setDataProperty(FUSE_TIME, fuse);
 
-        this.getLevel().addSound(this, Sound.RANDOM_FUSE);
+        this.getLevel().playSound(this, Sound.RANDOM_FUSE);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/item/EntityTntMinecart.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityTntMinecart.java
@@ -101,7 +101,7 @@ public class EntityTntMinecart extends EntityMinecartAbstract implements EntityE
 
     @Override
     public void activate(int x, int y, int z, boolean flag) {
-        level.addSound(this, Sound.FIRE_IGNITE);
+        level.playSound(this, Sound.FIRE_IGNITE);
         this.fuse = 79;
     }
 
@@ -164,7 +164,7 @@ public class EntityTntMinecart extends EntityMinecartAbstract implements EntityE
     public boolean onInteract(Player player, Item item, Vector3 clickedPos) {
         boolean interact = super.onInteract(player, item, clickedPos);
         if (item.getId().equals(Item.FLINT_AND_STEEL) || item.getId().equals(Item.FIRE_CHARGE)) {
-            level.addSound(this, Sound.FIRE_IGNITE);
+            level.playSound(this, Sound.FIRE_IGNITE);
             this.fuse = 79;
             return true;
         }

--- a/src/main/java/cn/nukkit/entity/item/EntityXpBottle.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityXpBottle.java
@@ -96,7 +96,7 @@ public class EntityXpBottle extends EntityProjectile {
 
     @Override
     protected void addHitEffect() {
-        this.getLevel().addSound(this, Sound.RANDOM_GLASS);
+        this.getLevel().playSound(this, Sound.RANDOM_GLASS);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/mob/EntityCreaking.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityCreaking.java
@@ -237,9 +237,9 @@ public class EntityCreaking extends EntityMob {
             Player after = entity.getMemoryStorage().get(CoreMemoryTypes.NEAREST_PLAYER);
             if(before != after) {
                 if(before == null) {
-                    entity.level.addSound(entity, Sound.MOB_CREAKING_ACTIVATE);
+                    entity.level.playSound(entity, Sound.MOB_CREAKING_ACTIVATE);
                 } else if(after == null) {
-                    entity.level.addSound(entity, Sound.MOB_CREAKING_DEACTIVATE);
+                    entity.level.playSound(entity, Sound.MOB_CREAKING_DEACTIVATE);
                 }
             }
         }
@@ -258,9 +258,9 @@ public class EntityCreaking extends EntityMob {
             Player after = entity.getMemoryStorage().get(CoreMemoryTypes.STARING_PLAYER);
             if(before != after) {
                 if(before == null) {
-                    entity.level.addSound(entity, Sound.MOB_CREAKING_FREEZE);
+                    entity.level.playSound(entity, Sound.MOB_CREAKING_FREEZE);
                 } else if(after == null) {
-                    entity.level.addSound(entity, Sound.MOB_CREAKING_UNFREEZE);
+                    entity.level.playSound(entity, Sound.MOB_CREAKING_UNFREEZE);
                 }
             }
         }

--- a/src/main/java/cn/nukkit/entity/mob/EntityCreeper.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityCreeper.java
@@ -182,7 +182,7 @@ public class EntityCreeper extends EntityMob implements EntityWalkable, EntityIn
         if (item.getId() == Item.FLINT_AND_STEEL && (memoryStorage.isEmpty(CoreMemoryTypes.SHOULD_EXPLODE) || memoryStorage.compareDataTo(CoreMemoryTypes.SHOULD_EXPLODE, false))) {
             memoryStorage.put(CoreMemoryTypes.SHOULD_EXPLODE, true);
             memoryStorage.put(CoreMemoryTypes.EXPLODE_CANCELLABLE, false);
-            this.level.addSound(this, Sound.FIRE_IGNITE);
+            this.level.playSound(this, Sound.FIRE_IGNITE);
             return true;
         }
         return super.onInteract(player, item, clickedPos);

--- a/src/main/java/cn/nukkit/entity/mob/EntityHoglin.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityHoglin.java
@@ -202,7 +202,7 @@ public class EntityHoglin extends EntityMob implements EntityWalkable {
         public void onStart(EntityIntelligent entity) {
             super.onStart(entity);
             if(entity.distance(entity.getMemoryStorage().get(getMemory())) < 8) {
-                entity.getLevel().addSound(entity, Sound.MOB_HOGLIN_RETREAT);
+                entity.getLevel().playSound(entity, Sound.MOB_HOGLIN_RETREAT);
             }
         }
     }

--- a/src/main/java/cn/nukkit/entity/mob/EntityHusk.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityHusk.java
@@ -126,6 +126,6 @@ public class EntityHusk extends EntityZombie {
         drowned.setPosition(this);
         drowned.setRotation(this.yaw, this.pitch);
         drowned.spawnToAll();
-        drowned.level.addSound(drowned, Sound.MOB_HUSK_CONVERT_TO_ZOMBIE);
+        drowned.level.playSound(drowned, Sound.MOB_HUSK_CONVERT_TO_ZOMBIE);
     }
 }

--- a/src/main/java/cn/nukkit/entity/mob/EntityIronGolem.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityIronGolem.java
@@ -136,7 +136,7 @@ public class EntityIronGolem extends EntityGolem implements EntityOwnable {
     @Override
     public boolean onInteract(Player player, Item item, Vector3 clickedPos) {
         if(item instanceof ItemIronIngot && getHealth() <= getMaxHealth()*0.75f) {
-            this.level.addSound(this, Sound.MOB_IRONGOLEM_REPAIR);
+            this.level.playSound(this, Sound.MOB_IRONGOLEM_REPAIR);
             if(player.getGamemode() != Player.CREATIVE) player.getInventory().getItemInHand().decrement(1);
             heal(25);
         }
@@ -170,7 +170,7 @@ public class EntityIronGolem extends EntityGolem implements EntityOwnable {
         if(!super.attack(source)) return false;
         for(int i : new int[] {74, 50, 25}) {
             if(health > i && getHealth() <= i) {
-                this.level.addSound(this, Sound.MOB_IRONGOLEM_CRACK);
+                this.level.playSound(this, Sound.MOB_IRONGOLEM_CRACK);
             }
         }
         return true;

--- a/src/main/java/cn/nukkit/entity/mob/EntityMob.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityMob.java
@@ -224,7 +224,7 @@ public abstract class EntityMob extends EntityIntelligent implements EntityInven
         }
 
         if (armor.getMaxDurability() > 0 && armor.getDamage() >= armor.getMaxDurability()) {
-            getLevel().addSound(this, Sound.RANDOM_BREAK);
+            getLevel().playSound(this, Sound.RANDOM_BREAK);
             return Item.get(BlockID.AIR, 0, 0);
         }
 

--- a/src/main/java/cn/nukkit/entity/mob/EntityPhantom.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityPhantom.java
@@ -140,7 +140,7 @@ public class EntityPhantom extends EntityMob implements EntityFlyable, EntitySmi
         @Override
         public void onStart(EntityIntelligent entity) {
             super.onStart(entity);
-            entity.level.addSound(entity, Sound.MOB_PHANTOM_SWOOP);
+            entity.level.playSound(entity, Sound.MOB_PHANTOM_SWOOP);
         }
     }
 }

--- a/src/main/java/cn/nukkit/entity/mob/EntityPiglin.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityPiglin.java
@@ -251,7 +251,7 @@ public class EntityPiglin extends EntityMob implements EntityWalkable {
                             builder.nextState("r");
                             builder.blendOutTime(1);
                             Entity.playAnimationOnEntities(builder.build(), entities);
-                            entities.forEach(entity1 -> entity1.level.addSound(entity1, Sound.MOB_PIGLIN_CELEBRATE));
+                            entities.forEach(entity1 -> entity1.level.playSound(entity1, Sound.MOB_PIGLIN_CELEBRATE));
                         }
                         yield true;
                     }
@@ -319,7 +319,7 @@ public class EntityPiglin extends EntityMob implements EntityWalkable {
         public void onStart(EntityIntelligent entity) {
             super.onStart(entity);
             if(entity.distance(entity.getMemoryStorage().get(getMemory())) < 8) {
-                entity.getLevel().addSound(entity, Sound.MOB_PIGLIN_RETREAT);
+                entity.getLevel().playSound(entity, Sound.MOB_PIGLIN_RETREAT);
             }
         }
     }

--- a/src/main/java/cn/nukkit/entity/mob/EntityShulkerBullet.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityShulkerBullet.java
@@ -88,7 +88,7 @@ public class EntityShulkerBullet extends EntityMob implements EntityFlyable {
         close();
         for(Entity entity : collidingEntities) {
             if(entity.attack(new EntityDamageByEntityEvent(this, entity, EntityDamageEvent.DamageCause.CONTACT, 4))) {
-                getLevel().addSound(entity, Sound.MOB_SHULKER_BULLET_HIT);
+                getLevel().playSound(entity, Sound.MOB_SHULKER_BULLET_HIT);
                 entity.addEffect(Effect.get(EffectType.LEVITATION).setDuration(200));
             }
         }

--- a/src/main/java/cn/nukkit/entity/mob/EntityVex.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityVex.java
@@ -176,7 +176,7 @@ public class EntityVex extends EntityMob implements EntityFlyable {
         public void onStart(EntityIntelligent entity) {
             super.onStart(entity);
             entity.setDataFlag(EntityFlag.CHARGING);
-            entity.level.addSound(entity, Sound.MOB_VEX_CHARGE);
+            entity.level.playSound(entity, Sound.MOB_VEX_CHARGE);
         }
 
         @Override

--- a/src/main/java/cn/nukkit/entity/mob/EntityWarden.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityWarden.java
@@ -226,8 +226,8 @@ public class EntityWarden extends EntityMob implements EntityWalkable, Vibration
         }
 
         if (this.getMemoryStorage().notEmpty(CoreMemoryTypes.ATTACK_TARGET))
-            this.level.addSound(this, Sound.MOB_WARDEN_LISTENING_ANGRY);
-        else this.level.addSound(this, Sound.MOB_WARDEN_LISTENING);
+            this.level.playSound(this, Sound.MOB_WARDEN_LISTENING_ANGRY);
+        else this.level.playSound(this, Sound.MOB_WARDEN_LISTENING);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/mob/EntityWither.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityWither.java
@@ -260,7 +260,7 @@ public class EntityWither extends EntityBoss implements EntityFlyable, EntitySmi
             if (this.age == 200) {
                 this.explode();
                 setHealth(getMaxHealth());
-                getLevel().addSound(this, Sound.MOB_WITHER_SPAWN);
+                getLevel().playSound(this, Sound.MOB_WITHER_SPAWN);
             } else if(age < 200) {
                 heal(getMaxHealth()/200f);
             }
@@ -321,7 +321,7 @@ public class EntityWither extends EntityBoss implements EntityFlyable, EntitySmi
         if((age%40==0 || getDataFlag(EntityFlag.CAN_DASH) && age > 200)) {
             Block[] blocks = level.getCollisionBlocks(getBoundingBox().grow(1, 1, 1));
             if(blocks.length > 0) {
-                if(blockBreakSound != null) level.addSound(this, blockBreakSound);
+                if(blockBreakSound != null) level.playSound(this, blockBreakSound);
                 for (Block collisionBlock : blocks) {
                     if(!(collisionBlock instanceof BlockBedrock)) {
                         level.breakBlock(collisionBlock);

--- a/src/main/java/cn/nukkit/entity/mob/EntityZombie.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityZombie.java
@@ -195,6 +195,6 @@ public class EntityZombie extends EntityMob implements EntityWalkable, EntitySmi
         drowned.setRotation(this.yaw, this.pitch);
         drowned.spawnToAll();
         drowned.namedTag.putBoolean("Transformed", true);
-        drowned.level.addSound(drowned, Sound.ENTITY_ZOMBIE_CONVERTED_TO_DROWNED);
+        drowned.level.playSound(drowned, Sound.ENTITY_ZOMBIE_CONVERTED_TO_DROWNED);
     }
 }

--- a/src/main/java/cn/nukkit/entity/mob/EntityZombieVillager.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityZombieVillager.java
@@ -86,7 +86,7 @@ public class EntityZombieVillager extends EntityZombie implements EntityWalkable
                         this.namedTag.putString("purifyPlayer", player.getLoginChainData().getXUID());
                         player.getInventory().decreaseCount(player.getInventory().getHeldItemIndex());
                     }
-                    getLevel().addSound(this, Sound.MOB_ZOMBIE_REMEDY);
+                    getLevel().playSound(this, Sound.MOB_ZOMBIE_REMEDY);
                 }
             }
         }
@@ -127,7 +127,7 @@ public class EntityZombieVillager extends EntityZombie implements EntityWalkable
         villager.setPosition(this);
         villager.setRotation(this.yaw, this.pitch);
         villager.spawnToAll();
-        villager.level.addSound(villager, Sound.MOB_ZOMBIE_UNFECT);
+        villager.level.playSound(villager, Sound.MOB_ZOMBIE_UNFECT);
     }
 
 }

--- a/src/main/java/cn/nukkit/entity/passive/EntityAllay.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityAllay.java
@@ -153,7 +153,7 @@ public class EntityAllay extends EntityMob implements EntityFlyable, EntityOwnab
                             item.setCount(item.getCount() + currentItem.getCount());
                             getInventory().setItem(0, item);
                         }
-                        this.level.addSound(this, Sound.RANDOM_POP);
+                        this.level.playSound(this, Sound.RANDOM_POP);
                         nearestItem.close();
                     }
                 }

--- a/src/main/java/cn/nukkit/entity/passive/EntityArmadillo.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityArmadillo.java
@@ -123,10 +123,10 @@ public class EntityArmadillo extends EntityAnimal {
     public boolean onInteract(Player player, Item item, Vector3 clickedPos) {
         if(player.getInventory().getUnclonedItem(player.getInventory().getHeldItemIndex()) instanceof ItemBrush brush) {
             getLevel().dropItem(this, Item.get(Item.ARMADILLO_SCUTE));
-            getLevel().addSound(player, Sound.MOB_ARMADILLO_BRUSH);
+            getLevel().playSound(player, Sound.MOB_ARMADILLO_BRUSH);
             brush.incDamage(16);
             if(brush.getDamage() >= brush.getMaxDurability()) {
-                player.getLevel().addSound(player, Sound.RANDOM_BREAK);
+                player.getLevel().playSound(player, Sound.RANDOM_BREAK);
                 player.getInventory().clear(player.getInventory().getHeldItemIndex());
             }
         }

--- a/src/main/java/cn/nukkit/entity/passive/EntityBee.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityBee.java
@@ -157,7 +157,7 @@ public class EntityBee extends EntityAnimal implements EntityFlyable {
                                 this.kill();
                             } else if(stayAtFlower) {
                                 this.setNectar(true);
-                                this.getLevel().addSound(this, Sound.MOB_BEE_POLLINATE);
+                                this.getLevel().playSound(this, Sound.MOB_BEE_POLLINATE);
                             }
                             stayAtFlower = !stayAtFlower;
                         });

--- a/src/main/java/cn/nukkit/entity/passive/EntityCat.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityCat.java
@@ -225,7 +225,7 @@ public class EntityCat extends EntityAnimal implements EntityWalkable, EntityOwn
         }
         int healable = this.getHealingAmount(item);
         if (this.isBreedingItem(item)) {
-            this.getLevel().addSound(this, Sound.MOB_CAT_EAT);
+            this.getLevel().playSound(this, Sound.MOB_CAT_EAT);
             if (!this.hasOwner()) {
                 player.getInventory().decreaseCount(player.getInventory().getHeldItemIndex());
                 if (Utils.rand(1, 3) == 3) {
@@ -251,7 +251,7 @@ public class EntityCat extends EntityAnimal implements EntityWalkable, EntityOwn
                 }
             } else {
                 player.getInventory().decreaseCount(player.getInventory().getHeldItemIndex());
-                this.getLevel().addSound(this, Sound.MOB_CAT_EAT);
+                this.getLevel().playSound(this, Sound.MOB_CAT_EAT);
                 this.getLevel().addParticle(new ItemBreakParticle(this.add(0, getHeight() * 0.75F, 0), Item.get(item.getId(), 0, 1)));
 
                 if (healable != 0) {

--- a/src/main/java/cn/nukkit/entity/passive/EntityChicken.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityChicken.java
@@ -97,7 +97,7 @@ public class EntityChicken extends EntityAnimal implements EntityWalkable, Clima
                         new Behavior(entity -> {
                             entity.getMemoryStorage().put(CoreMemoryTypes.LAST_EGG_SPAWN_TIME, getLevel().getTick());
                             entity.getLevel().dropItem(entity, getEgg());
-                            entity.getLevel().addSound(entity, Sound.MOB_CHICKEN_PLOP);
+                            entity.getLevel().playSound(entity, Sound.MOB_CHICKEN_PLOP);
                             return false;
                         }, any(
                                 all(

--- a/src/main/java/cn/nukkit/entity/passive/EntityMooshroom.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityMooshroom.java
@@ -138,7 +138,7 @@ public class EntityMooshroom extends EntityAnimal implements EntityWalkable, Ent
     public boolean shear() {
         this.close();
         this.level.dropItem(this, Item.get(BlockID.RED_MUSHROOM, 0, 5));
-        this.level.addSound(this, Sound.MOB_MOOSHROOM_CONVERT);
+        this.level.playSound(this, Sound.MOB_MOOSHROOM_CONVERT);
         this.level.addParticleEffect(this.add(0, this.getHeight(), 0), ParticleEffect.LARGE_EXPLOSION_LEVEL);
         EntityCow cow = new EntityCow(this.getChunk(), this.namedTag);
         cow.setPosition(this);

--- a/src/main/java/cn/nukkit/entity/passive/EntityPanda.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityPanda.java
@@ -291,7 +291,7 @@ public class EntityPanda extends EntityAnimal implements EntityWalkable, EntityC
                 if(variant.getVariant() != AGRESSIVE) {
                     stop(entity);
                 }
-                entity.getLevel().addSound(entity, Sound.MOB_PANDA_BITE);
+                entity.getLevel().playSound(entity, Sound.MOB_PANDA_BITE);
             }
         }
 

--- a/src/main/java/cn/nukkit/entity/passive/EntitySheep.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntitySheep.java
@@ -178,7 +178,7 @@ public class EntitySheep extends EntityAnimal implements EntityWalkable, EntityS
         woolItem.setCount(ThreadLocalRandom.current().nextInt(2) + 1);
         this.level.dropItem(this, woolItem);
 
-        level.addSound(this, Sound.MOB_SHEEP_SHEAR);
+        level.playSound(this, Sound.MOB_SHEEP_SHEAR);
         level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.getVector3(), VibrationType.SHEAR));
         return true;
     }

--- a/src/main/java/cn/nukkit/entity/passive/EntityWolf.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityWolf.java
@@ -322,7 +322,7 @@ public class EntityWolf extends EntityAnimal implements EntityWalkable, EntityOw
             }
         } else if (this.isBreedingItem(item)) {
             player.getInventory().decreaseCount(player.getInventory().getHeldItemIndex());
-            this.getLevel().addSound(this, Sound.RANDOM_EAT);
+            this.getLevel().playSound(this, Sound.RANDOM_EAT);
             this.getLevel().addParticle(new ItemBreakParticle(this.add(0, getHeight() * 0.75F, 0), Item.get(item.getId(), 0, 1)));
 
             if (healable != 0) {
@@ -479,7 +479,7 @@ public class EntityWolf extends EntityAnimal implements EntityWalkable, EntityOw
         armor.setDamage(armor.getDamage() + amount);
 
         if (armor.getDamage() >= armor.getMaxDurability()) {
-            getLevel().addSound(this, Sound.RANDOM_BREAK);
+            getLevel().playSound(this, Sound.RANDOM_BREAK);
             return Item.get(BlockID.AIR, 0, 0);
         }
 

--- a/src/main/java/cn/nukkit/entity/projectile/EntityArrow.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntityArrow.java
@@ -156,7 +156,7 @@ public class EntityArrow extends SlenderProjectile {
 
     @Override
     protected void addHitEffect() {
-        this.level.addSound(this, Sound.RANDOM_BOWHIT);
+        this.level.playSound(this, Sound.RANDOM_BOWHIT);
         EntityEventPacket packet = new EntityEventPacket();
         packet.eid = getId();
         packet.event = EntityEventPacket.ARROW_SHAKE;

--- a/src/main/java/cn/nukkit/entity/projectile/EntityThrownTrident.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntityThrownTrident.java
@@ -213,7 +213,7 @@ public class EntityThrownTrident extends SlenderProjectile {
         }
 
         if (this.isCollided && !this.hadCollision) {
-            this.getLevel().addSound(this, Sound.ITEM_TRIDENT_HIT_GROUND);
+            this.getLevel().playSound(this, Sound.ITEM_TRIDENT_HIT_GROUND);
         }
 
         boolean hasUpdate = super.onUpdate(currentTick);
@@ -285,7 +285,7 @@ public class EntityThrownTrident extends SlenderProjectile {
             ev = new EntityDamageByChildEntityEvent(this.shootingEntity, this, entity, DamageCause.PROJECTILE, damage);
         }
         entity.attack(ev);
-        this.getLevel().addSound(this, Sound.ITEM_TRIDENT_HIT);
+        this.getLevel().playSound(this, Sound.ITEM_TRIDENT_HIT);
         this.hadCollision = true;
         this.alreadyCollided = true;
         this.setCollisionPos(this);
@@ -296,12 +296,12 @@ public class EntityThrownTrident extends SlenderProjectile {
                 Position pos = this.getPosition();
                 EntityLightningBolt lighting = new EntityLightningBolt(pos.getChunk(), getDefaultNBT(pos));
                 lighting.spawnToAll();
-                this.getLevel().addSound(this, Sound.ITEM_TRIDENT_THUNDER);
+                this.getLevel().playSound(this, Sound.ITEM_TRIDENT_THUNDER);
             }
         }
 
         if (this.canReturnToShooter()) {
-            this.getLevel().addSound(this, Sound.ITEM_TRIDENT_RETURN);
+            this.getLevel().playSound(this, Sound.ITEM_TRIDENT_RETURN);
             this.setNoClip(true);
             this.hadCollision = false;
             this.setTridentRope(true);
@@ -325,7 +325,7 @@ public class EntityThrownTrident extends SlenderProjectile {
         for (Block collisionBlock : level.getCollisionBlocks(getBoundingBox().grow(0.1, 0.1, 0.1))) {
             this.setStuckToBlockPos(new BlockVector3(collisionBlock.getFloorX(), collisionBlock.getFloorY(), collisionBlock.getFloorZ()));
             if (this.canReturnToShooter()) {
-                this.getLevel().addSound(this, Sound.ITEM_TRIDENT_RETURN);
+                this.getLevel().playSound(this, Sound.ITEM_TRIDENT_RETURN);
                 this.setNoClip(true);
                 this.setTridentRope(true);
                 return;

--- a/src/main/java/cn/nukkit/entity/weather/EntityLightningBolt.java
+++ b/src/main/java/cn/nukkit/entity/weather/EntityLightningBolt.java
@@ -117,8 +117,8 @@ public class EntityLightningBolt extends Entity implements EntityLightningStrike
         this.entityBaseTick(tickDiff);
 
         if (this.state == 2) {
-            this.level.addSound(this, Sound.AMBIENT_WEATHER_THUNDER);
-            this.level.addSound(this, Sound.RANDOM_EXPLODE);
+            this.level.playSound(this, Sound.AMBIENT_WEATHER_THUNDER);
+            this.level.playSound(this, Sound.RANDOM_EXPLODE);
 
             Block down = getLevel().getBlock(down());
             if (isVulnerableOxidizable(down)) {

--- a/src/main/java/cn/nukkit/inventory/BarrelInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BarrelInventory.java
@@ -43,7 +43,7 @@ public class BarrelInventory extends ContainerInventory implements BlockEntityIn
                     if (!blockBarrel.isOpen()) {
                         blockBarrel.setOpen(true);
                         level.setBlock(blockBarrel, blockBarrel, true, true);
-                        level.addSound(blockBarrel, Sound.BLOCK_BARREL_OPEN);
+                        level.playSound(blockBarrel, Sound.BLOCK_BARREL_OPEN);
                     }
                 }
             }
@@ -63,7 +63,7 @@ public class BarrelInventory extends ContainerInventory implements BlockEntityIn
                     if (blockBarrel.isOpen()) {
                         blockBarrel.setOpen(false);
                         level.setBlock(blockBarrel, blockBarrel, true, true);
-                        level.addSound(blockBarrel, Sound.BLOCK_BARREL_CLOSE);
+                        level.playSound(blockBarrel, Sound.BLOCK_BARREL_CLOSE);
                     }
                 }
             }

--- a/src/main/java/cn/nukkit/inventory/ChestInventory.java
+++ b/src/main/java/cn/nukkit/inventory/ChestInventory.java
@@ -64,7 +64,7 @@ public class ChestInventory extends ContainerInventory implements BlockEntityInv
 
             Level level = this.getHolder().getLevel();
             if (level != null) {
-                level.addSound(this.getHolder().add(0.5, 0.5, 0.5), Sound.RANDOM_CHESTOPEN);
+                level.playSound(this.getHolder().add(0.5, 0.5, 0.5), Sound.RANDOM_CHESTOPEN);
                 level.addChunkPacket((int) this.getHolder().getX() >> 4, (int) this.getHolder().getZ() >> 4, pk);
             }
         }
@@ -92,7 +92,7 @@ public class ChestInventory extends ContainerInventory implements BlockEntityInv
 
             Level level = this.getHolder().getLevel();
             if (level != null) {
-                level.addSound(this.getHolder().add(0.5, 0.5, 0.5), Sound.RANDOM_CHESTCLOSED);
+                level.playSound(this.getHolder().add(0.5, 0.5, 0.5), Sound.RANDOM_CHESTCLOSED);
                 level.addChunkPacket((int) this.getHolder().getX() >> 4, (int) this.getHolder().getZ() >> 4, pk);
             }
         }

--- a/src/main/java/cn/nukkit/inventory/DoubleChestInventory.java
+++ b/src/main/java/cn/nukkit/inventory/DoubleChestInventory.java
@@ -132,7 +132,7 @@ public class DoubleChestInventory extends ContainerInventory {
             pk1.value = 2;
             Level level = this.left.getHolder().getLevel();
             if (level != null) {
-                level.addSound(this.left.getHolder().add(0.5, 0.5, 0.5), Sound.RANDOM_CHESTOPEN);
+                level.playSound(this.left.getHolder().add(0.5, 0.5, 0.5), Sound.RANDOM_CHESTOPEN);
                 level.addChunkPacket((int) this.left.getHolder().getX() >> 4, (int) this.left.getHolder().getZ() >> 4, pk1);
             }
 
@@ -145,7 +145,7 @@ public class DoubleChestInventory extends ContainerInventory {
 
             level = this.right.getHolder().getLevel();
             if (level != null) {
-                level.addSound(this.right.getHolder().add(0.5, 0.5, 0.5), Sound.RANDOM_CHESTOPEN);
+                level.playSound(this.right.getHolder().add(0.5, 0.5, 0.5), Sound.RANDOM_CHESTOPEN);
                 level.addChunkPacket((int) this.right.getHolder().getX() >> 4, (int) this.right.getHolder().getZ() >> 4, pk2);
             }
         }
@@ -163,7 +163,7 @@ public class DoubleChestInventory extends ContainerInventory {
 
             Level level = this.right.getHolder().getLevel();
             if (level != null) {
-                level.addSound(this.right.getHolder().add(0.5, 0.5, 0.5), Sound.RANDOM_CHESTCLOSED);
+                level.playSound(this.right.getHolder().add(0.5, 0.5, 0.5), Sound.RANDOM_CHESTCLOSED);
                 level.addChunkPacket((int) this.right.getHolder().getX() >> 4, (int) this.right.getHolder().getZ() >> 4, pk1);
             }
 
@@ -176,7 +176,7 @@ public class DoubleChestInventory extends ContainerInventory {
 
             level = this.left.getHolder().getLevel();
             if (level != null) {
-                level.addSound(this.left.getHolder().add(0.5, 0.5, 0.5), Sound.RANDOM_CHESTCLOSED);
+                level.playSound(this.left.getHolder().add(0.5, 0.5, 0.5), Sound.RANDOM_CHESTCLOSED);
                 level.addChunkPacket((int) this.left.getHolder().getX() >> 4, (int) this.left.getHolder().getZ() >> 4, pk2);
             }
         }

--- a/src/main/java/cn/nukkit/inventory/HorseInventory.java
+++ b/src/main/java/cn/nukkit/inventory/HorseInventory.java
@@ -76,7 +76,7 @@ public class HorseInventory extends BaseInventory {
             }
         } else if (index == 1) {
             if (!this.getHorseArmor().isNull()) {
-                this.getHolder().getLevel().addSound(this.getHolder(), Sound.MOB_HORSE_ARMOR);
+                this.getHolder().getLevel().playSound(this.getHolder(), Sound.MOB_HORSE_ARMOR);
             }
             MobArmorEquipmentPacket mobArmorEquipmentPacket = new MobArmorEquipmentPacket();
             mobArmorEquipmentPacket.eid = this.getHolder().getId();

--- a/src/main/java/cn/nukkit/inventory/HumanEnderChestInventory.java
+++ b/src/main/java/cn/nukkit/inventory/HumanEnderChestInventory.java
@@ -75,7 +75,7 @@ public class HumanEnderChestInventory extends BaseInventory implements BlockEnti
 
         Level level = this.getHolder().getLevel();
         if (level != null) {
-            level.addSound(this.getHolder().getVector3().add(0.5, 0.5, 0.5), Sound.RANDOM_ENDERCHESTOPEN);
+            level.playSound(this.getHolder().getVector3().add(0.5, 0.5, 0.5), Sound.RANDOM_ENDERCHESTOPEN);
             level.addChunkPacket((int) this.getHolder().getX() >> 4, (int) this.getHolder().getZ() >> 4, blockEventPacket);
         }
     }
@@ -111,7 +111,7 @@ public class HumanEnderChestInventory extends BaseInventory implements BlockEnti
 
         Level level = this.getHolder().getLevel();
         if (level != null) {
-            level.addSound(this.getHolder().getVector3().add(0.5, 0.5, 0.5), Sound.RANDOM_ENDERCHESTCLOSED);
+            level.playSound(this.getHolder().getVector3().add(0.5, 0.5, 0.5), Sound.RANDOM_ENDERCHESTCLOSED);
             level.addChunkPacket((int) this.getHolder().getX() >> 4, (int) this.getHolder().getZ() >> 4, blockEventPacket);
         }
         setBlockEntityEnderChest(who, null);

--- a/src/main/java/cn/nukkit/inventory/ShulkerBoxInventory.java
+++ b/src/main/java/cn/nukkit/inventory/ShulkerBoxInventory.java
@@ -46,7 +46,7 @@ public class ShulkerBoxInventory extends ContainerInventory {
 
             Level level = this.getHolder().getLevel();
             if (level != null) {
-                level.addSound(this.getHolder().add(0.5, 0.5, 0.5), Sound.RANDOM_SHULKERBOXOPEN);
+                level.playSound(this.getHolder().add(0.5, 0.5, 0.5), Sound.RANDOM_SHULKERBOXOPEN);
                 level.addChunkPacket((int) this.getHolder().getX() >> 4, (int) this.getHolder().getZ() >> 4, pk);
             }
         }
@@ -64,7 +64,7 @@ public class ShulkerBoxInventory extends ContainerInventory {
 
             Level level = this.getHolder().getLevel();
             if (level != null) {
-                level.addSound(this.getHolder().add(0.5, 0.5, 0.5), Sound.RANDOM_SHULKERBOXCLOSED);
+                level.playSound(this.getHolder().add(0.5, 0.5, 0.5), Sound.RANDOM_SHULKERBOXCLOSED);
                 level.addChunkPacket((int) this.getHolder().getX() >> 4, (int) this.getHolder().getZ() >> 4, pk);
             }
         }

--- a/src/main/java/cn/nukkit/inventory/request/CraftRecipeOptionalProcessor.java
+++ b/src/main/java/cn/nukkit/inventory/request/CraftRecipeOptionalProcessor.java
@@ -116,7 +116,7 @@ public class CraftRecipeOptionalProcessor implements ItemStackRequestActionProce
                 }
             } else {
                 if (!enchantedBook && (!Objects.equals(result.getId(), sacrifice.getId()) || result.getMaxDurability() == -1)) {//Anvil - ench
-                    player.getLevel().addSound(player, Sound.RANDOM_ANVIL_USE, 1, 1);
+                    player.getLevel().playSound(player, Sound.RANDOM_ANVIL_USE, 1, 1);
                     return null;
                 }
 
@@ -218,7 +218,7 @@ public class CraftRecipeOptionalProcessor implements ItemStackRequestActionProce
 
         //Anvil - rename
         if (StringUtil.isNullOrEmpty(filterString)) {
-            player.getLevel().addSound(player, Sound.RANDOM_ANVIL_USE, 1, 1);
+            player.getLevel().playSound(player, Sound.RANDOM_ANVIL_USE, 1, 1);
             if (target.hasCustomName()) {
                 costHelper = 1;
                 extraCost += costHelper;

--- a/src/main/java/cn/nukkit/item/ItemArmor.java
+++ b/src/main/java/cn/nukkit/item/ItemArmor.java
@@ -96,25 +96,25 @@ abstract public class ItemArmor extends Item implements ItemDurable {
             final int tier = this.getTier();
             switch (tier) {
                 case TIER_CHAIN:
-                    player.getLevel().addSound(player, Sound.ARMOR_EQUIP_CHAIN);
+                    player.getLevel().playSound(player, Sound.ARMOR_EQUIP_CHAIN);
                     break;
                 case TIER_DIAMOND:
-                    player.getLevel().addSound(player, Sound.ARMOR_EQUIP_DIAMOND);
+                    player.getLevel().playSound(player, Sound.ARMOR_EQUIP_DIAMOND);
                     break;
                 case TIER_GOLD:
-                    player.getLevel().addSound(player, Sound.ARMOR_EQUIP_GOLD);
+                    player.getLevel().playSound(player, Sound.ARMOR_EQUIP_GOLD);
                     break;
                 case TIER_IRON:
-                    player.getLevel().addSound(player, Sound.ARMOR_EQUIP_IRON);
+                    player.getLevel().playSound(player, Sound.ARMOR_EQUIP_IRON);
                     break;
                 case TIER_LEATHER:
-                    player.getLevel().addSound(player, Sound.ARMOR_EQUIP_LEATHER);
+                    player.getLevel().playSound(player, Sound.ARMOR_EQUIP_LEATHER);
                     break;
                 case TIER_NETHERITE:
-                    player.getLevel().addSound(player, Sound.ARMOR_EQUIP_NETHERITE);
+                    player.getLevel().playSound(player, Sound.ARMOR_EQUIP_NETHERITE);
                     break;
                 default:
-                    player.getLevel().addSound(player, Sound.ARMOR_EQUIP_GENERIC);
+                    player.getLevel().playSound(player, Sound.ARMOR_EQUIP_GENERIC);
             }
         }
 

--- a/src/main/java/cn/nukkit/item/ItemArmorStand.java
+++ b/src/main/java/cn/nukkit/item/ItemArmorStand.java
@@ -73,7 +73,7 @@ public class ItemArmorStand extends Item {
         }
 
         entity.spawnToAll();
-        player.getLevel().addSound(entity, Sound.MOB_ARMOR_STAND_PLACE);
+        player.getLevel().playSound(entity, Sound.MOB_ARMOR_STAND_PLACE);
         return true;
     }
 

--- a/src/main/java/cn/nukkit/item/ItemBow.java
+++ b/src/main/java/cn/nukkit/item/ItemBow.java
@@ -151,7 +151,7 @@ public class ItemBow extends ItemTool {
                     if (!(durability != null && durability.getLevel() > 0 && (100 / (durability.getLevel() + 1)) <= new Random().nextInt(100))) {
                         this.setDamage(this.getDamage() + 1);
                         if (this.getDamage() >= getMaxDurability()) {
-                            player.getLevel().addSound(player, Sound.RANDOM_BREAK);
+                            player.getLevel().playSound(player, Sound.RANDOM_BREAK);
                             this.count--;
                         }
                         player.getInventory().setItemInHand(this);
@@ -165,7 +165,7 @@ public class ItemBow extends ItemTool {
                     entityShootBowEvent.getProjectile().kill();
                 } else {
                     entityShootBowEvent.getProjectile().spawnToAll();
-                    player.getLevel().addSound(player, Sound.RANDOM_BOW);
+                    player.getLevel().playSound(player, Sound.RANDOM_BOW);
                 }
             }
         }

--- a/src/main/java/cn/nukkit/item/ItemBucket.java
+++ b/src/main/java/cn/nukkit/item/ItemBucket.java
@@ -244,11 +244,11 @@ public class ItemBucket extends Item {
                     }
 
                     if (target instanceof BlockFlowingLava) {
-                        level.addSound(block, Sound.BUCKET_FILL_LAVA);
+                        level.playSound(block, Sound.BUCKET_FILL_LAVA);
                     } else if (target instanceof BlockFlowingWater) {
-                        level.addSound(block, Sound.BUCKET_FILL_WATER);
+                        level.playSound(block, Sound.BUCKET_FILL_WATER);
                     } else if (target instanceof BlockPowderSnow) {
-                        level.addSound(block, Sound.BUCKET_FILL_POWDER_SNOW);
+                        level.playSound(block, Sound.BUCKET_FILL_POWDER_SNOW);
                     }
 
                     return true;
@@ -321,7 +321,7 @@ public class ItemBucket extends Item {
             PlayerBucketEmptyEvent ev = new PlayerBucketEmptyEvent(player, targetBlock, face, target, this, result);
             if (!ev.isCancelled()) {
                 target.getLevel().setBlock(target, targetBlock, true, true);
-                player.getLevel().addSound(target, Sound.BUCKET_FILL_POWDER_SNOW);
+                player.getLevel().playSound(target, Sound.BUCKET_FILL_POWDER_SNOW);
 
                 updateBucketItem(player, ev);
 
@@ -364,9 +364,9 @@ public class ItemBucket extends Item {
      */
     protected void afterUse(Level level, Block block) {
         if (isLava()) {
-            level.addSound(block, Sound.BUCKET_EMPTY_LAVA);
+            level.playSound(block, Sound.BUCKET_EMPTY_LAVA);
         } else {
-            level.addSound(block, Sound.BUCKET_EMPTY_WATER);
+            level.playSound(block, Sound.BUCKET_EMPTY_WATER);
         }
 
         spawnFishEntity(block.add(0.5, 0.5, 0.5));

--- a/src/main/java/cn/nukkit/item/ItemBundle.java
+++ b/src/main/java/cn/nukkit/item/ItemBundle.java
@@ -81,7 +81,7 @@ public class ItemBundle extends Item implements INBT, InventoryHolder {
             getInventory().remove(instance);
             player.dropItem(instance);
             getInventory().sendContents(player);
-            getLevel().addSound(getVector3(), Sound.BUNDLE_DROP_CONTENTS);
+            getLevel().playSound(getVector3(), Sound.BUNDLE_DROP_CONTENTS);
             return true;
         } else return false;
     }

--- a/src/main/java/cn/nukkit/item/ItemCarrotOnAStick.java
+++ b/src/main/java/cn/nukkit/item/ItemCarrotOnAStick.java
@@ -34,7 +34,7 @@ public class ItemCarrotOnAStick extends ItemTool {
                     if (!this.isUnbreakable() && !player.isCreative()) {
                         this.setDamage(getDamage() + 7);
                         if (this.getDamage() >= getMaxDurability()) {
-                            player.getLevel().addSound(player, Sound.RANDOM_BREAK);
+                            player.getLevel().playSound(player, Sound.RANDOM_BREAK);
                             player.getInventory().setItem(player.getInventory().getHeldItemIndex(), Item.get(Item.FISHING_ROD));
                         } else player.getInventory().setItemInHand(this);
                     }

--- a/src/main/java/cn/nukkit/item/ItemCrossbow.java
+++ b/src/main/java/cn/nukkit/item/ItemCrossbow.java
@@ -131,7 +131,7 @@ public class ItemCrossbow extends ItemTool {
                 EntityCrossbowFirework entity = new EntityCrossbowFirework(player.chunk, nbt);
                 entity.setMotion(new Vector3(mX, mY, mZ));
                 entity.spawnToAll();
-                player.getLevel().addSound(player, Sound.CROSSBOW_SHOOT);
+                player.getLevel().playSound(player, Sound.CROSSBOW_SHOOT);
                 removeChargedItem(player);
             } else {
                 EntityArrow entity = new EntityArrow(player.chunk, nbt, player, true);
@@ -152,7 +152,7 @@ public class ItemCrossbow extends ItemTool {
                             proj.close();
                         } else {
                             proj.spawnToAll();
-                            player.getLevel().addSound(player, Sound.CROSSBOW_SHOOT);
+                            player.getLevel().playSound(player, Sound.CROSSBOW_SHOOT);
                             removeChargedItem(player);
                         }
                     }
@@ -183,7 +183,7 @@ public class ItemCrossbow extends ItemTool {
             );
             this.setCompoundTag(tag);
             player.getInventory().setItemInHand(this);
-            player.getLevel().addSound(player, Sound.CROSSBOW_LOADING_END);
+            player.getLevel().playSound(player, Sound.CROSSBOW_LOADING_END);
         }
     }
 

--- a/src/main/java/cn/nukkit/item/ItemFlintAndSteel.java
+++ b/src/main/java/cn/nukkit/item/ItemFlintAndSteel.java
@@ -82,7 +82,7 @@ public class ItemFlintAndSteel extends ItemTool {
                 player.getInventory().setItemInHand(this);
             }
         }
-        block.getLevel().addSound(block, Sound.FIRE_IGNITE);
+        block.getLevel().playSound(block, Sound.FIRE_IGNITE);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/item/ItemFood.java
+++ b/src/main/java/cn/nukkit/item/ItemFood.java
@@ -76,7 +76,7 @@ public abstract class ItemFood extends Item {
                 --this.count;
                 player.getInventory().setItemInHand(this);
 
-                player.getLevel().addSound(player, Sound.RANDOM_BURP);
+                player.getLevel().playSound(player, Sound.RANDOM_BURP);
             }
         }
 

--- a/src/main/java/cn/nukkit/item/ItemGlassBottle.java
+++ b/src/main/java/cn/nukkit/item/ItemGlassBottle.java
@@ -44,7 +44,7 @@ public class ItemGlassBottle extends Item {
         } else if (target instanceof BlockBeehive && ((BlockBeehive) target).isFull()) {
             filled = Item.get(HONEY_BOTTLE);
             ((BlockBeehive) target).honeyCollected(player);
-            level.addSound(player, Sound.BUCKET_FILL_WATER);
+            level.playSound(player, Sound.BUCKET_FILL_WATER);
         }
         
         if (filled != null) {

--- a/src/main/java/cn/nukkit/item/ItemGlowBerries.java
+++ b/src/main/java/cn/nukkit/item/ItemGlowBerries.java
@@ -38,7 +38,7 @@ public class ItemGlowBerries extends ItemFood {
             var tmp = new BlockCaveVines();
             tmp.setPropertyValue(CommonBlockProperties.GROWING_PLANT_AGE, ThreadLocalRandom.current().nextInt(26));
             level.setBlock(target.down(), tmp);
-            level.addSound(target.down(), Sound.DIG_CAVE_VINES);
+            level.playSound(target.down(), Sound.DIG_CAVE_VINES);
             if (player.isAdventure() || player.isSurvival()) {
                 --this.count;
                 player.getInventory().setItemInHand(this);

--- a/src/main/java/cn/nukkit/item/ItemGoatHorn.java
+++ b/src/main/java/cn/nukkit/item/ItemGoatHorn.java
@@ -46,14 +46,14 @@ public class ItemGoatHorn extends Item {
 
     public void playSound(Player player) {
         switch (this.meta) {
-            case 0 -> player.getLevel().addSound(player, Sound.HORN_CALL_0);
-            case 1 -> player.getLevel().addSound(player, Sound.HORN_CALL_1);
-            case 2 -> player.getLevel().addSound(player, Sound.HORN_CALL_2);
-            case 3 -> player.getLevel().addSound(player, Sound.HORN_CALL_3);
-            case 4 -> player.getLevel().addSound(player, Sound.HORN_CALL_4);
-            case 5 -> player.getLevel().addSound(player, Sound.HORN_CALL_5);
-            case 6 -> player.getLevel().addSound(player, Sound.HORN_CALL_6);
-            case 7 -> player.getLevel().addSound(player, Sound.HORN_CALL_7);
+            case 0 -> player.getLevel().playSound(player, Sound.HORN_CALL_0);
+            case 1 -> player.getLevel().playSound(player, Sound.HORN_CALL_1);
+            case 2 -> player.getLevel().playSound(player, Sound.HORN_CALL_2);
+            case 3 -> player.getLevel().playSound(player, Sound.HORN_CALL_3);
+            case 4 -> player.getLevel().playSound(player, Sound.HORN_CALL_4);
+            case 5 -> player.getLevel().playSound(player, Sound.HORN_CALL_5);
+            case 6 -> player.getLevel().playSound(player, Sound.HORN_CALL_6);
+            case 7 -> player.getLevel().playSound(player, Sound.HORN_CALL_7);
         }
     }
 }

--- a/src/main/java/cn/nukkit/item/ItemMilkBucket.java
+++ b/src/main/java/cn/nukkit/item/ItemMilkBucket.java
@@ -41,7 +41,7 @@ public class ItemMilkBucket extends ItemBucket {
             --this.count;
             player.getInventory().addItem(Item.get(ItemID.BUCKET, 0, 1));
             player.getInventory().setItemInHand(this);
-            player.getLevel().addSound(player, Sound.RANDOM_BURP);
+            player.getLevel().playSound(player, Sound.RANDOM_BURP);
         }
 
         player.getLevel().getVibrationManager().callVibrationEvent(new VibrationEvent(player, player.add(0, player.getEyeHeight()), VibrationType.DRINKING));

--- a/src/main/java/cn/nukkit/item/ItemTrident.java
+++ b/src/main/java/cn/nukkit/item/ItemTrident.java
@@ -97,7 +97,7 @@ public class ItemTrident extends ItemTool {
                 entityShootBowEvent.getProjectile().close();
             } else {
                 entityShootBowEvent.getProjectile().spawnToAll();
-                player.getLevel().addSound(player, Sound.ITEM_TRIDENT_THROW);
+                player.getLevel().playSound(player, Sound.ITEM_TRIDENT_THROW);
                 if (!player.isCreative()) {
                     this.count--;
                     player.getInventory().setItemInHand(this);

--- a/src/main/java/cn/nukkit/level/Explosion.java
+++ b/src/main/java/cn/nukkit/level/Explosion.java
@@ -365,7 +365,7 @@ public class Explosion {
             data.putFloat(prefix + "y", (float) pos.y);
             data.putFloat(prefix + "z", (float) pos.z);
         }
-        this.level.addSound(this.source, Sound.RANDOM_EXPLODE);
+        this.level.playSound(this.source, Sound.RANDOM_EXPLODE);
         this.level.addLevelEvent(this.source, LevelEventPacket.EVENT_PARTICLE_EXPLOSION, Math.round((float) this.size));
         this.level.addLevelEvent(this.source, LevelEventPacket.EVENT_PARTICLE_BLOCK_EXPLOSION, data);
 

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -636,24 +636,87 @@ public class Level implements Metadatable {
         this.blockMetadata = null;
     }
 
+    /**
+     * @deprecated Use {@link #playSound(Vector3, Sound)} instead.
+     */
+    @Deprecated
     public void addSound(Vector3 pos, Sound sound) {
-        this.addSound(pos, sound, 1, 1, (Player[]) null);
+        this.playSound(pos, sound, 1, 1, (Player[]) null);
     }
 
+    /**
+     * @deprecated Use {@link #playSound(Vector3, Sound, float, float)} instead.
+     */
+    @Deprecated
     public void addSound(Vector3 pos, Sound sound, float volume, float pitch) {
-        this.addSound(pos, sound, volume, pitch, (Player[]) null);
+        this.playSound(pos, sound, volume, pitch, (Player[]) null);
     }
 
+    /**
+     * @deprecated Use {@link #playSound(Vector3, Sound, float, float, Collection<Player>)} instead.
+     */
+    @Deprecated
     public void addSound(Vector3 pos, Sound sound, float volume, float pitch, Collection<Player> players) {
-        this.addSound(pos, sound, volume, pitch, players.toArray(Player.EMPTY_ARRAY));
+        this.playSound(pos, sound, volume, pitch, players != null ? players.toArray(Player.EMPTY_ARRAY) : null);
     }
 
+    /**
+     * @deprecated Use {@link #playSound(Vector3, Sound, float, float, Player...)} instead.
+     */
+    @Deprecated
     public void addSound(Vector3 pos, Sound sound, float volume, float pitch, Player... players) {
         Preconditions.checkArgument(volume >= 0 && volume <= 1, "Sound volume must be between 0 and 1");
-        Preconditions.checkArgument(pitch >= 0, "Sound pitch must be higher than 0");
+        Preconditions.checkArgument(pitch >= 0, "Sound pitch must be higher or equal to 0");
 
         PlaySoundPacket packet = new PlaySoundPacket();
         packet.name = sound.getSound();
+        packet.volume = volume;
+        packet.pitch = pitch;
+        packet.x = pos.getFloorX();
+        packet.y = pos.getFloorY();
+        packet.z = pos.getFloorZ();
+
+        if (players == null || players.length == 0) {
+            addChunkPacket(pos.getFloorX() >> 4, pos.getFloorZ() >> 4, packet);
+        } else {
+            Server.broadcastPacket(players, packet);
+        }
+    }
+
+    public void playSound(Vector3 pos, Sound sound) {
+        this.playSound(pos, sound.getSound(), 1, 1, (Player[]) null);
+    }
+
+    public void playSound(Vector3 pos, Sound sound, float volume, float pitch) {
+        this.playSound(pos, sound.getSound(), volume, pitch, (Player[]) null);
+    }
+
+    public void playSound(Vector3 pos, Sound sound, float volume, float pitch, Collection<Player> players) {
+        this.playSound(pos, sound.getSound(), volume, pitch, players != null ? players.toArray(Player.EMPTY_ARRAY) : null);
+    }
+
+    public void playSound(Vector3 pos, Sound sound, float volume, float pitch, Player... players) {
+        this.playSound(pos, sound.getSound(), volume, pitch, players);
+    }
+
+    public void playSound(Vector3 pos, String soundName) {
+        this.playSound(pos, soundName, 1, 1, (Player[]) null);
+    }
+
+    public void playSound(Vector3 pos, String soundName, float volume, float pitch) {
+        this.playSound(pos, soundName, volume, pitch, (Player[]) null);
+    }
+
+    public void playSound(Vector3 pos, String soundName, float volume, float pitch, Collection<Player> players) {
+        this.playSound(pos, soundName, volume, pitch, players != null ? players.toArray(Player.EMPTY_ARRAY) : null);
+    }
+
+    public void playSound(Vector3 pos, String soundName, float volume, float pitch, Player... players) {
+        Preconditions.checkArgument(volume >= 0 && volume <= 1, "Sound volume must be between 0 and 1");
+        Preconditions.checkArgument(pitch >= 0, "Sound pitch must be higher or equal to 0");
+
+        PlaySoundPacket packet = new PlaySoundPacket();
+        packet.name = soundName;
         packet.volume = volume;
         packet.pitch = pitch;
         packet.x = pos.getFloorX();
@@ -2723,7 +2786,7 @@ public class Level implements Metadatable {
         item.useOn(target);
         if (item.isTool() && item.getDamage() >= item.getMaxDurability()) {
             if (player != null) {
-                addSound(player, Sound.RANDOM_BREAK);
+                playSound(player, Sound.RANDOM_BREAK);
             }
             item = Item.AIR;
         }
@@ -2834,7 +2897,7 @@ public class Level implements Metadatable {
                 target.onTouch(vector, item, face, fx, fy, fz, player, ev.getAction());
                 if (ev.getAction() == Action.RIGHT_CLICK_BLOCK && target.canBeActivated() && target.onActivate(item, player, face, fx, fy, fz)) {
                     if (item.isTool() && item.getDamage() >= item.getMaxDurability()) {
-                        addSound(player, Sound.RANDOM_BREAK);
+                        playSound(player, Sound.RANDOM_BREAK);
                         item = Item.AIR;
                     }
                     return item;
@@ -4917,7 +4980,7 @@ public class Level implements Metadatable {
                 }
             }
 
-            this.addSound(target, Sound.FIRE_IGNITE);
+            this.playSound(target, Sound.FIRE_IGNITE);
             return true;
         } else if (sizeZ >= 2 && sizeZ <= maxPortalSize) {
             //start scan from 1 block above base
@@ -5002,7 +5065,7 @@ public class Level implements Metadatable {
                 }
             }
 
-            this.addSound(target, Sound.FIRE_IGNITE);
+            this.playSound(target, Sound.FIRE_IGNITE);
             return true;
         }
 

--- a/src/main/java/cn/nukkit/network/process/processor/InventoryTransactionProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/InventoryTransactionProcessor.java
@@ -159,7 +159,7 @@ public class InventoryTransactionProcessor extends DataPacketProcessor<Inventory
                 if (target.onInteract(player, item, useItemOnEntityData.clickPos) && (player.isSurvival() || player.isAdventure())) {
                     if (item.isTool()) {
                         if (item.useOn(target) && item.getDamage() >= item.getMaxDurability()) {
-                            player.getLevel().addSound(player, Sound.RANDOM_BREAK);
+                            player.getLevel().playSound(player, Sound.RANDOM_BREAK);
                             item = new ItemBlock(Block.get(BlockID.AIR));
                         }
                     } else {
@@ -247,7 +247,7 @@ public class InventoryTransactionProcessor extends DataPacketProcessor<Inventory
                 }
                 if (item.isTool() && (player.isSurvival() || player.isAdventure())) {
                     if (item.useOn(target) && item.getDamage() >= item.getMaxDurability()) {
-                        player.getLevel().addSound(player, Sound.RANDOM_BREAK);
+                        player.getLevel().playSound(player, Sound.RANDOM_BREAK);
                         player.getInventory().setItem(useItemOnEntityData.hotbarSlot, Item.AIR);
                     } else {
                         if (item.isNull() || player.getInventory().getItemInHand().getId() == item.getId()) {

--- a/src/main/java/cn/nukkit/network/process/processor/PlayerActionProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/PlayerActionProcessor.java
@@ -243,7 +243,7 @@ public class PlayerActionProcessor extends DataPacketProcessor<PlayerActionPacke
                     } else {
                         riptideSound = Sound.ITEM_TRIDENT_RIPTIDE_1;
                     }
-                    player.level.addSound(player, riptideSound);
+                    player.level.playSound(player, riptideSound);
                 }
             }
             case PlayerActionPacket.ACTION_STOP_SPIN_ATTACK -> {


### PR DESCRIPTION
This PR deprecates the old `addSound() `methods and introduces `playSound() `to match BDS naming.
It also adds support for passing **string sound IDs** in addition to Sound like BDS does, useful if server owners have their own RP with custom sounds.

No breaking changes.