### PR TITLE
Feat/molang variable map support on add particles method

### DIFF
--- a/src/main/java/cn/nukkit/command/defaults/ParticleCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/ParticleCommand.java
@@ -46,7 +46,7 @@ public class ParticleCommand extends VanillaCommand {
             return 0;
         }
         for (int i = 0; i < count; i++) {
-            position.level.addParticleEffect(position.asVector3f(), name, -1, position.level.getDimension(), (Player[]) null);
+            position.level.addParticleEffect(position, name);
         }
         log.addSuccess("commands.particle.success", name, String.valueOf(count));
         return 1;

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -84,6 +84,7 @@ import cn.nukkit.utils.BlockUpdateEntry;
 import cn.nukkit.utils.GameLoop;
 import cn.nukkit.utils.Hash;
 import cn.nukkit.utils.LevelException;
+import cn.nukkit.utils.MolangVariableMap;
 import cn.nukkit.utils.TextFormat;
 import cn.nukkit.utils.Utils;
 import cn.nukkit.utils.collection.nb.Int2ObjectNonBlockingMap;
@@ -792,32 +793,58 @@ public class Level implements Metadatable {
         }
     }
 
-    public void addParticleEffect(Vector3 pos, ParticleEffect particleEffect) {
-        this.addParticleEffect(pos, particleEffect, -1, this.getDimension(), (Player[]) null);
+    public void addParticleEffect(Vector3 pos, ParticleEffect effect) {
+        this.addParticleEffect(pos, effect, -1L);
     }
 
-    public void addParticleEffect(Vector3 pos, ParticleEffect particleEffect, long uniqueEntityId) {
-        this.addParticleEffect(pos, particleEffect, uniqueEntityId, this.getDimension(), (Player[]) null);
+    public void addParticleEffect(Vector3 pos, ParticleEffect effect, long uniqueEntityId) {
+        this.addParticleEffect(pos, effect, uniqueEntityId, (MolangVariableMap) null);
     }
 
-    public void addParticleEffect(Vector3 pos, ParticleEffect particleEffect, long uniqueEntityId, int dimensionId) {
-        this.addParticleEffect(pos, particleEffect, uniqueEntityId, dimensionId, (Player[]) null);
+    public void addParticleEffect(Vector3 pos, ParticleEffect effect, long uniqueEntityId, MolangVariableMap molangVariables) {
+        this.addParticleEffect(pos, effect, uniqueEntityId, molangVariables, (Player[]) null);
     }
 
-    public void addParticleEffect(Vector3 pos, ParticleEffect particleEffect, long uniqueEntityId, int dimensionId, Collection<Player> players) {
-        this.addParticleEffect(pos, particleEffect, uniqueEntityId, dimensionId, players.toArray(Player.EMPTY_ARRAY));
+    public void addParticleEffect(Vector3 pos, ParticleEffect effect, long uniqueEntityId, MolangVariableMap molangVariables, Collection<Player> players) {
+        this.addParticleEffect(pos.asVector3f(), effect.getIdentifier(), uniqueEntityId, molangVariables, players != null ? players.toArray(Player.EMPTY_ARRAY) : null);
     }
 
-    public void addParticleEffect(Vector3 pos, ParticleEffect particleEffect, long uniqueEntityId, int dimensionId, Player... players) {
-        this.addParticleEffect(pos.asVector3f(), particleEffect.getIdentifier(), uniqueEntityId, dimensionId, players);
+    public void addParticleEffect(Vector3 pos, ParticleEffect effect, long uniqueEntityId, MolangVariableMap molangVariables, Player... players) {
+        this.addParticleEffect(pos.asVector3f(), effect.getIdentifier(), uniqueEntityId, molangVariables, players);
     }
 
-    public void addParticleEffect(Vector3f pos, String identifier, long uniqueEntityId, int dimensionId, Player... players) {
+    public void addParticleEffect(Vector3 pos, String effectName) {
+        this.addParticleEffect(pos, effectName, -1L);
+    }
+
+    public void addParticleEffect(Vector3 pos, String effectName, long uniqueEntityId) {
+        this.addParticleEffect(pos, effectName, uniqueEntityId, (MolangVariableMap) null);
+    }
+
+    public void addParticleEffect(Vector3 pos, String effectName, long uniqueEntityId, MolangVariableMap molangVariables) {
+        this.addParticleEffect(pos, effectName, uniqueEntityId, molangVariables, (Player[]) null);
+    }
+
+    public void addParticleEffect(Vector3 pos, String effectName, long uniqueEntityId, MolangVariableMap molangVariables, Collection<Player> players) {
+        this.addParticleEffect(pos.asVector3f(), effectName, uniqueEntityId, molangVariables, players != null ? players.toArray(Player.EMPTY_ARRAY) : null);
+    }
+
+    public void addParticleEffect(Vector3 pos, String effectName, long uniqueEntityId, MolangVariableMap molangVariables, Player... players) {
+        this.addParticleEffect(pos.asVector3f(), effectName, uniqueEntityId, molangVariables, players);
+    }
+
+    public void addParticleEffect(Vector3f pos, String identifier, long uniqueEntityId, MolangVariableMap molangVariables, Player... players) {
         SpawnParticleEffectPacket pk = new SpawnParticleEffectPacket();
         pk.identifier = identifier;
         pk.uniqueEntityId = uniqueEntityId;
-        pk.dimensionId = dimensionId;
+        pk.dimensionId = this.getDimension();
         pk.position = pos;
+
+        if (molangVariables == null) {
+            pk.molangVariablesJson = Optional.empty();
+        } else {
+            pk.molangVariablesJson = Optional.of(molangVariables.isEmpty() ? "[]" : molangVariables.toJson());
+        }
 
         if (players == null || players.length == 0) {
             addChunkPacket(pos.getFloorX() >> 4, pos.getFloorZ() >> 4, pk);

--- a/src/main/java/cn/nukkit/utils/MolangVariableMap.java
+++ b/src/main/java/cn/nukkit/utils/MolangVariableMap.java
@@ -1,0 +1,146 @@
+package cn.nukkit.utils;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * MoLang variable map compatible with Bedrock's SpawnParticleEffectPacket payload.
+ * Produces a JSON array of entries like:
+ * [
+ *   {"name":"direction_x","type":"float","value":0.25},
+ *   {"name":"direction_y","type":"float","value":-5.0}
+ * ]
+ */
+public final class MolangVariableMap {
+
+    private static final class Entry {
+        final String name;
+        final String type;
+        final Object value;
+
+        Entry(String name, String type, Object value) {
+            this.name = name;
+            this.type = type;
+            this.value = value;
+        }
+    }
+
+    private final LinkedHashMap<String, Entry> vars = new LinkedHashMap<>();
+
+    public MolangVariableMap() {
+    }
+
+    public MolangVariableMap(Map<String, Float> initialFloats) {
+        if (initialFloats != null) {
+            for (Map.Entry<String, Float> e : initialFloats.entrySet()) {
+                if (e.getKey() != null && e.getValue() != null) {
+                    setFloat(e.getKey(), e.getValue());
+                }
+            }
+        }
+    }
+
+    public MolangVariableMap setFloat(String name, float value) {
+        put(name, "float", Float.valueOf(value));
+        return this;
+    }
+
+    public MolangVariableMap setInt(String name, int value) {
+        put(name, "int", Integer.valueOf(value));
+        return this;
+    }
+
+    public MolangVariableMap setBool(String name, boolean value) {
+        put(name, "bool", Boolean.valueOf(value));
+        return this;
+    }
+
+    public MolangVariableMap setString(String name, String value) {
+        Objects.requireNonNull(value, "value");
+        put(name, "string", value);
+        return this;
+    }
+
+    public boolean remove(String name) {
+        return vars.remove(name) != null;
+    }
+
+    public MolangVariableMap clear() {
+        vars.clear();
+        return this;
+    }
+
+    public boolean isEmpty() {
+        return vars.isEmpty();
+    }
+
+    public int size() {
+        return vars.size();
+    }
+
+    public String toJson() {
+        if (vars.isEmpty()) return "[]";
+        StringBuilder sb = new StringBuilder(vars.size() * 32).append('[');
+        boolean first = true;
+        for (Entry e : vars.values()) {
+            if (!first) sb.append(',');
+            first = false;
+            sb.append('{')
+              .append("\"name\":\"").append(escape(e.name)).append("\",")
+              .append("\"type\":\"").append(e.type).append("\",")
+              .append("\"value\":");
+            switch (e.type) {
+                case "float":
+                case "int":
+                    sb.append(e.value.toString());
+                    break;
+                case "bool":
+                    sb.append(((Boolean) e.value).booleanValue() ? "true" : "false");
+                    break;
+                case "string":
+                    sb.append('"').append(escape((String) e.value)).append('"');
+                    break;
+                default:
+                    sb.append('"').append(escape(String.valueOf(e.value))).append('"');
+            }
+            sb.append('}');
+        }
+        return sb.append(']').toString();
+    }
+
+    private void put(String name, String type, Object value) {
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(type, "type");
+        Objects.requireNonNull(value, "value");
+        vars.put(name, new Entry(name, type, value));
+    }
+
+    private static String escape(String s) {
+        StringBuilder out = new StringBuilder(s.length() + 8);
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"':
+                case '\\':
+                    out.append('\\').append(c);
+                    break;
+                case '\b': out.append("\\b"); break;
+                case '\f': out.append("\\f"); break;
+                case '\n': out.append("\\n"); break;
+                case '\r': out.append("\\r"); break;
+                case '\t': out.append("\\t"); break;
+                default:
+                    if (c < 0x20) {
+                        String hex = Integer.toHexString(c);
+                        out.append("\\u");
+                        for (int k = hex.length(); k < 4; k++) out.append('0');
+                        out.append(hex);
+                    } else {
+                        out.append(c);
+                    }
+            }
+        }
+        return out.toString();
+    }
+}


### PR DESCRIPTION
Adds MoLang support to particle spawning and lets you use either ParticleEffect enums or string identifiers.
Introduces a simple MolangVariableMap that serializes to the exact BDS JSON format
Level now auto-resolves the dimensionId.

### **Potential breakage: method overloads were adjusted (dimension removed from callers, new MoLang parameter), so plugins calling the old variants may need minor updates.**