### PR TITLE
enhancement: Added more context to Inventory Change Events

### DIFF
--- a/src/main/java/cn/nukkit/event/entity/EntityInventoryChangeEvent.java
+++ b/src/main/java/cn/nukkit/event/entity/EntityInventoryChangeEvent.java
@@ -4,6 +4,7 @@ import cn.nukkit.entity.Entity;
 import cn.nukkit.event.Cancellable;
 import cn.nukkit.event.HandlerList;
 import cn.nukkit.item.Item;
+import cn.nukkit.network.protocol.types.itemstack.ContainerSlotType;
 
 /**
  * @author MagicDroidX (Nukkit Project)
@@ -18,12 +19,30 @@ public class EntityInventoryChangeEvent extends EntityEvent implements Cancellab
     private final Item oldItem;
     private Item newItem;
     private final int slot;
+    private final ContainerSlotType slotType;
+    private final int heldHotbarIndex;
 
+    /**
+     * @deprecated Use {@link #EntityInventoryChangeEvent(Entity, Item, Item, int, ContainerSlotType, int)}
+     * so listeners know the slot type and currently selected hotbar index.
+     */
+    @Deprecated
     public EntityInventoryChangeEvent(Entity entity, Item oldItem, Item newItem, int slot) {
         this.entity = entity;
         this.oldItem = oldItem;
         this.newItem = newItem;
         this.slot = slot;
+        this.slotType = ContainerSlotType.INVENTORY;
+        this.heldHotbarIndex = -1;
+    }
+
+    public EntityInventoryChangeEvent(Entity entity, Item oldItem, Item newItem, int slot, ContainerSlotType slotType, int heldHotbarIndex) {
+        this.entity = entity;
+        this.oldItem = oldItem;
+        this.newItem = newItem;
+        this.slot = slot;
+        this.slotType = slotType;
+        this.heldHotbarIndex = heldHotbarIndex;
     }
 
     public int getSlot() {
@@ -40,5 +59,20 @@ public class EntityInventoryChangeEvent extends EntityEvent implements Cancellab
 
     public Item getOldItem() {
         return oldItem;
+    }
+
+    public ContainerSlotType getSlotType() {
+        return slotType;
+    }
+
+    public int getHeldHotbarIndex() {
+        return heldHotbarIndex;
+    }
+
+    /**
+     * @return true if this change targets the currently selected hotbar slot
+     */
+    public boolean isSelectedHotbar() {
+        return this.slotType == ContainerSlotType.HOTBAR && this.slot == this.heldHotbarIndex && this.heldHotbarIndex >= 0;
     }
 }

--- a/src/main/java/cn/nukkit/inventory/BaseInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BaseInventory.java
@@ -133,7 +133,20 @@ public abstract class BaseInventory implements Inventory {
         item = item.clone();
         InventoryHolder holder = this.getHolder();
         if (holder instanceof Entity entity) {
-            EntityInventoryChangeEvent ev = new EntityInventoryChangeEvent(entity, this.getItem(index), item, index);
+            int held = -1;
+            ContainerSlotType type = ContainerSlotType.INVENTORY;
+
+
+            if (holder instanceof Player p) {
+                if (p.getOffhandInventory() == this) {
+                    type = ContainerSlotType.OFFHAND;
+                } else if (this instanceof HumanInventory) {
+                    held = ((HumanInventory) this).getHeldItemIndex();
+                    try { type = this.getSlotType(index); } catch (Throwable ignored) {}
+                }
+            }
+
+            EntityInventoryChangeEvent ev = new EntityInventoryChangeEvent(entity, this.getItem(index), item, index, type, held);
             Server.getInstance().getPluginManager().callEvent(ev);
             if (ev.isCancelled()) {
                 this.sendSlot(index, this.getViewers());
@@ -368,7 +381,19 @@ public abstract class BaseInventory implements Inventory {
             Item old = this.slots.get(index);
             InventoryHolder holder = this.getHolder();
             if (holder instanceof Entity) {
-                EntityInventoryChangeEvent ev = new EntityInventoryChangeEvent((Entity) holder, old, item, index);
+                int held = -1;
+                ContainerSlotType type = ContainerSlotType.INVENTORY;
+
+                if (holder instanceof Player p) {
+                    if (p.getOffhandInventory() == this) {
+                        type = ContainerSlotType.OFFHAND;
+                    } else if (this instanceof HumanInventory) {
+                        held = ((HumanInventory) this).getHeldItemIndex();
+                        try { type = this.getSlotType(index); } catch (Throwable ignored) {}
+                    }
+                }
+
+                EntityInventoryChangeEvent ev = new EntityInventoryChangeEvent( (Entity) holder, old, item, index, type, held);
                 Server.getInstance().getPluginManager().callEvent(ev);
                 if (ev.isCancelled()) {
                     this.sendSlot(index, this.getViewers());

--- a/src/main/java/cn/nukkit/inventory/HumanInventory.java
+++ b/src/main/java/cn/nukkit/inventory/HumanInventory.java
@@ -383,7 +383,13 @@ public class HumanInventory extends BaseInventory {
             }
             item = ev.getNewItem();
         } else {
-            EntityInventoryChangeEvent ev = new EntityInventoryChangeEvent( this.getHolder().getEntity(), this.getItem(index), item, index, this.getSlotType(index), this.getHeldItemIndex());
+            EntityInventoryChangeEvent ev = new EntityInventoryChangeEvent(
+                this.getHolder().getEntity(),
+                this.getItem(index),
+                item,
+                index,
+                this.getSlotType(index),
+                this.getHeldItemIndex());
             Server.getInstance().getPluginManager().callEvent(ev);
             if (ev.isCancelled()) {
                 this.sendSlot(index, this.getViewers());

--- a/src/main/java/cn/nukkit/inventory/HumanInventory.java
+++ b/src/main/java/cn/nukkit/inventory/HumanInventory.java
@@ -383,7 +383,7 @@ public class HumanInventory extends BaseInventory {
             }
             item = ev.getNewItem();
         } else {
-            EntityInventoryChangeEvent ev = new EntityInventoryChangeEvent(this.getHolder().getEntity(), this.getItem(index), item, index);
+            EntityInventoryChangeEvent ev = new EntityInventoryChangeEvent( this.getHolder().getEntity(), this.getItem(index), item, index, this.getSlotType(index), this.getHeldItemIndex());
             Server.getInstance().getPluginManager().callEvent(ev);
             if (ev.isCancelled()) {
                 this.sendSlot(index, this.getViewers());
@@ -411,7 +411,7 @@ public class HumanInventory extends BaseInventory {
                 }
                 item = ev.getNewItem();
             } else if (index < ARMORS_INDEX) {
-                EntityInventoryChangeEvent ev = new EntityInventoryChangeEvent(this.getHolder().getEntity(), old, item, index);
+                EntityInventoryChangeEvent ev = new EntityInventoryChangeEvent(this.getHolder().getEntity(), old, item, index, this.getSlotType(index), this.getHeldItemIndex());
                 Server.getInstance().getPluginManager().callEvent(ev);
                 if (ev.isCancelled()) {
                     this.sendSlot(index, this.getViewers());


### PR DESCRIPTION
Inventory events now give more context, plugins need to distinguish:
1. real offhand changes vs cursor “parking” in hotbar slot 0,
2. selected hotbar item changes vs edits to other hotbar cells,
3. and avoid stale mainhand reads.


**New getters**
- ContainerSlotType getSlotType() — HOTBAR, INVENTORY, OFFHAND, etc.
- int getHeldHotbarIndex() — the player’s currently selected hotbar index, or -1 for non-player containers.
- boolean isSelectedHotbar() — convenience: getSlotType()==HOTBAR && getSlot()==getHeldHotbarIndex().

**New constructor (overload)**
- EntityInventoryChangeEvent(Entity entity, Item oldItem, Item newItem, int slot, ContainerSlotType slotType, int heldHotbarIndex)
- The existing 4-arg ctor remains for source/binary compatibility.


Ex usage:
```
@EventHandler
public void onInv(EntityInventoryChangeEvent e) {
    if (!(e.getEntity() instanceof Player p)) return;

    if (e.getSlotType() == ContainerSlotType.OFFHAND) {
        // real offhand change (not cursor parking)
        handleOffhand(p, e.getOldItem(), e.getNewItem());
        return;
    }
    if (e.getSlotType() == ContainerSlotType.HOTBAR && e.isSelectedHotbar()) {
        // selected mainhand content changed without selector move
        updateMainhand(p, e.getHeldHotbarIndex());
    }
}
```