### PR TITLE
enhancement: Fire ItemFrameUseEvent on creative item removal

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockFrame.java
+++ b/src/main/java/cn/nukkit/block/BlockFrame.java
@@ -121,7 +121,25 @@ public class BlockFrame extends BlockTransparent implements BlockEntityHolder<Bl
         if (player != null && action == PlayerInteractEvent.Action.LEFT_CLICK_BLOCK) {
             BlockEntityItemFrame blockEntity = getOrCreateBlockEntity();
             if (player.isCreative()) {
+                Item before = blockEntity.getItem();
+                if (before.isNull()) return;
+
+                ItemFrameUseEvent event = new ItemFrameUseEvent(player, this, blockEntity, before, ItemFrameUseEvent.Action.REMOVE);
+                this.getLevel().getServer().getPluginManager().callEvent(event);
+                if (event.isCancelled()) {
+                    blockEntity.spawnTo(player);
+                    return;
+                }
+
                 blockEntity.setItem(Item.AIR);
+                blockEntity.setItemRotation(0);
+
+                if (isStoringMap()) {
+                    setStoringMap(false);
+                    this.getLevel().setBlock(this, this, true);
+                }
+
+                this.getLevel().addLevelEvent(this, LevelEventPacket.EVENT_SOUND_ITEMFRAME_ITEM_REMOVE);
             } else {
                 blockEntity.dropItem(player);
             }

--- a/src/main/java/cn/nukkit/event/block/ItemFrameUseEvent.java
+++ b/src/main/java/cn/nukkit/event/block/ItemFrameUseEvent.java
@@ -84,6 +84,7 @@ public class ItemFrameUseEvent extends BlockEvent implements Cancellable {
     public enum Action {
         DROP,
         PUT,
-        ROTATION
+        ROTATION,
+        REMOVE
     }
 }


### PR DESCRIPTION
Adds a new REMOVE action to ItemFrameUseEvent and fires it when a creative player takes an item out of an item frame. Rotation is reset to 0 and the pop sound is played.