### PR TITLE
fix: Flags split FLAGS/FLAGS_2 and match BDS sneaking/blocking (incl. HEIGHT) recalculation

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -672,7 +672,30 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
     }
 
     public void setSneaking(boolean value) {
-        this.setDataFlag(EntityFlag.SNEAKING, value);
+        EnumSet<EntityFlag> primary = this.getEntityDataMap().getOrCreateFlags();
+        boolean flagsChanged = false;
+
+        if (value ? primary.add(EntityFlag.SNEAKING) : primary.remove(EntityFlag.SNEAKING)) {
+            flagsChanged = true;
+        }
+
+        if (primary.remove(EntityFlag.CAN_SHOW_NAME)) {
+            flagsChanged = true;
+        }
+
+        recalculateBoundingBox(false);
+        float newHeight = this.getEntityDataMap().getOrDefault(EntityDataTypes.HEIGHT, getCurrentHeight());
+
+        if (flagsChanged) {
+            EntityDataMap delta = new EntityDataMap();
+            delta.put(EntityDataTypes.FLAGS, primary);
+            delta.putType(EntityDataTypes.HEIGHT, newHeight);
+            sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), delta);
+        } else {
+            EntityDataMap delta = new EntityDataMap();
+            delta.putType(EntityDataTypes.HEIGHT, newHeight);
+            sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), delta);
+        }
     }
 
     public boolean isSwimming() {
@@ -2960,41 +2983,57 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
     }
 
     public void setDataFlag(EntityFlag entityFlag, boolean value) {
-        if (this.getEntityDataMap().existFlag(entityFlag) ^ value) {
+        if (entityFlag.getValue() >= 64) {
+            this.setDataFlagExtend(entityFlag, value);
+            return;
+        }
+
+        if ((this.getEntityDataMap().existFlag(entityFlag)) ^ value) {
             this.getEntityDataMap().setFlag(entityFlag, value);
-            EntityDataMap entityDataMap = new EntityDataMap();
-            entityDataMap.put(EntityDataTypes.FLAGS, this.getEntityDataMap().getFlags());
-            sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), entityDataMap);
+
+            EntityDataMap delta = new EntityDataMap();
+            delta.put(EntityDataTypes.FLAGS, this.getEntityDataMap().getFlags());
+            sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), delta);
         }
     }
 
     public void setDataFlags(EnumSet<EntityFlag> entityFlags) {
-        this.getEntityDataMap().put(FLAGS, entityFlags);
-        sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), entityDataMap);
+        this.getEntityDataMap().put(EntityDataTypes.FLAGS, entityFlags);
+
+        EntityDataMap delta = new EntityDataMap();
+        delta.put(EntityDataTypes.FLAGS, entityFlags);
+        sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), delta);
     }
 
     public void setDataFlagExtend(EntityFlag entityFlag) {
-        this.setDataFlag(entityFlag, true);
+        this.setDataFlagExtend(entityFlag, true);
     }
 
     public void setDataFlagExtend(EntityFlag entityFlag, boolean value) {
-        if (this.getEntityDataMap().existFlag(entityFlag) ^ value) {
-            EnumSet<EntityFlag> entityFlags = this.getEntityDataMap().getOrDefault(EntityDataTypes.FLAGS_2, EnumSet.noneOf(EntityFlag.class));
+        EnumSet<EntityFlag> entityFlags = this.getEntityDataMap()
+                .getOrDefault(EntityDataTypes.FLAGS_2, EnumSet.noneOf(EntityFlag.class));
+
+        boolean currently = entityFlags.contains(entityFlag);
+        if (currently ^ value) {
             if (value) {
                 entityFlags.add(entityFlag);
             } else {
                 entityFlags.remove(entityFlag);
             }
             this.getEntityDataMap().put(EntityDataTypes.FLAGS_2, entityFlags);
-            EntityDataMap entityDataMap = new EntityDataMap();
-            entityDataMap.put(EntityDataTypes.FLAGS_2, entityFlags);
-            sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), entityDataMap);
+
+            EntityDataMap delta = new EntityDataMap();
+            delta.put(EntityDataTypes.FLAGS_2, entityFlags);
+            sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), delta);
         }
     }
 
     public void setDataFlagsExtend(EnumSet<EntityFlag> entityFlags) {
-        this.getEntityDataMap().put(FLAGS_2, entityFlags);
-        sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), entityDataMap);
+        this.getEntityDataMap().put(EntityDataTypes.FLAGS_2, entityFlags);
+
+        EntityDataMap delta = new EntityDataMap();
+        delta.put(EntityDataTypes.FLAGS_2, entityFlags);
+        sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), delta);
     }
 
     public boolean getDataFlag(EntityFlag id) {

--- a/src/main/java/cn/nukkit/entity/EntityLiving.java
+++ b/src/main/java/cn/nukkit/entity/EntityLiving.java
@@ -5,6 +5,8 @@ import cn.nukkit.Server;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockCactus;
 import cn.nukkit.block.BlockMagma;
+import cn.nukkit.entity.data.EntityDataMap;
+import cn.nukkit.entity.data.EntityDataTypes;
 import cn.nukkit.entity.data.EntityFlag;
 import cn.nukkit.entity.effect.EffectType;
 import cn.nukkit.entity.projectile.EntityProjectile;
@@ -30,8 +32,8 @@ import cn.nukkit.utils.TickCachedBlockIterator;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
 
 public abstract class EntityLiving extends Entity implements EntityDamageable {
     public final static float DEFAULT_SPEED = 0.1f;
@@ -474,7 +476,20 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
     }
 
     public void setBlocking(boolean value) {
-        this.setDataFlagExtend(EntityFlag.BLOCKING, value);
+        EnumSet<EntityFlag> ext = this.getEntityDataMap().getOrCreateFlags2();
+        if (value) {
+            ext.add(EntityFlag.BLOCKING);
+        } else {
+            ext.remove(EntityFlag.BLOCKING);
+        }
+        this.getEntityDataMap().put(EntityDataTypes.FLAGS_2, ext);
+
+        EnumSet<EntityFlag> wire = EnumSet.copyOf(ext);
+        wire.add(EntityFlag.TRANSITION_BLOCKING);
+
+        EntityDataMap delta = new EntityDataMap();
+        delta.put(EntityDataTypes.FLAGS_2, wire);
+        sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), delta);
     }
 
     public boolean isPersistent() {

--- a/src/main/java/cn/nukkit/network/process/processor/PlayerAuthInputProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/PlayerAuthInputProcessor.java
@@ -97,6 +97,7 @@ public class PlayerAuthInputProcessor extends DataPacketProcessor<PlayerAuthInpu
                 player.sendData(player);
             } else {
                 player.setSneaking(true);
+                player.setBlocking(true);
             }
         }
         if (pk.inputData.contains(AuthInputAction.STOP_SNEAKING)) {
@@ -106,6 +107,7 @@ public class PlayerAuthInputProcessor extends DataPacketProcessor<PlayerAuthInpu
                 player.sendData(player);
             } else {
                 player.setSneaking(false);
+                player.setBlocking(false);
             }
         }
         if (player.getAdventureSettings().get(AdventureSettings.Type.FLYING)) {


### PR DESCRIPTION
- Separate storage for FLAGS and FLAGS_2 in EntityDataMap, route high-bit flags (≥64) to FLAGS_2.
- Implement setBlocking: with BLOCKING on/off + one-shot TRANSITION_BLOCKING (as BDS does).
- Improved setSneaking: toggling SNEAKING, removing CAN_SHOW_NAME when sneaking, and updating HEIGHT (via recalculateBoundingBox (BDS parity)

**Enables Molang tests (query.is_blocking) to behave correctly.**