### PR TITLE
enhancement: Custom Items refactor (centralized builder, fewer overrides) (WIP)

### DIFF
--- a/src/main/java/cn/nukkit/item/ItemFood.java
+++ b/src/main/java/cn/nukkit/item/ItemFood.java
@@ -29,18 +29,26 @@ public abstract class ItemFood extends Item {
         super(id, meta, count, name);
     }
 
+    @Override
+    public boolean isEdible() {
+        return true;
+    }
+
     public int getFoodRestore() {
         return 0;
     }
 
+    @Override
     public float getSaturationRestore() {
         return 0;
     }
 
+    @Override
     public boolean isRequiresHunger() {
         return true;
     }
 
+    @Override
     public int getEatingTicks() {
         return 31;
     }

--- a/src/main/java/cn/nukkit/item/enchantment/utils/ItemEnchantSlot.java
+++ b/src/main/java/cn/nukkit/item/enchantment/utils/ItemEnchantSlot.java
@@ -1,0 +1,54 @@
+package cn.nukkit.item.enchantment.utils;
+
+public enum ItemEnchantSlot {
+    NONE("none"),
+    ALL("all"),
+    SWORD("sword"),
+    SPEAR("spear"),
+    BOW("bow"),
+    CROSSBOW("crossbow"),
+    G_ARMOR("g_armor"),
+    ARMOR_HEAD("armor_head"),
+    COSMETIC_HEAD("cosmetic_head"),
+    ARMOR_TORSO("armor_torso"),
+    ARMOR_LEGS("armor_legs"),
+    ARMOR_FEET("armor_feet"),
+    ELYTRA("elytra"),
+    SHIELD("shield"),
+    G_TOOL("g_tool"),
+    G_DIGGING("g_digging"),
+    PICKAXE("pickaxe"),
+    SHOVEL("shovel"),
+    AXE("axe"),
+    HOE("hoe"),
+    SHEARS("shears"),
+    FLINTSTEEL("flintsteel"),
+    FISHING_ROD("fishing_rod"),
+    CARROT_STICK("carrot_stick"),
+
+    HEAD("armor_head"),
+    CHESTPLATE("armor_torso"),
+    LEGGINGS("armor_legs"),
+    BOOTS("armor_feet"),
+    TRIDENT("spear"),
+    FLINT_AND_STEEL("flintsteel"),
+    CARROT_ON_A_STICK("carrot_stick");
+
+    private final String id;
+
+    ItemEnchantSlot(String id) {
+        this.id = id;
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public static ItemEnchantSlot fromId(String id) {
+        if (id == null) return null;
+        for (ItemEnchantSlot s : values()) {
+            if (s.id.equals(id)) return s;
+        }
+        return null;
+    }
+}

--- a/src/main/java/cn/nukkit/registry/ItemRegistry.java
+++ b/src/main/java/cn/nukkit/registry/ItemRegistry.java
@@ -13,9 +13,12 @@ import lombok.extern.slf4j.Slf4j;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
 import me.sunlan.fastreflection.FastConstructor;
 import me.sunlan.fastreflection.FastMemberLoader;
+
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnmodifiableView;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -744,12 +747,16 @@ public final class ItemRegistry implements ItemID, IRegistry<String, Item, Class
         }
     }
 
+    @UnmodifiableView
+    public static Collection<CustomItemDefinition> getCustomItemDefinitionList() {
+        return Collections.unmodifiableCollection(CUSTOM_ITEM_DEFINITIONS.values());
+    }
 
-    private void register0(String key, Class<? extends Item> value) {
-        try {
-            register(key, value);
-        } catch (RegisterException e) {
-            throw new RuntimeException(e);
-        }
+    public static @Nullable CustomItemDefinition getCustomItemDefinitionByIdStatic(String id) {
+        return CUSTOM_ITEM_DEFINITIONS.get(id);
+    }
+
+    public static cn.nukkit.item.customitem.CustomItemDefinition getCustomItemDefinition(String identifier) {
+        return CUSTOM_ITEM_DEFINITIONS.get(identifier);
     }
 }


### PR DESCRIPTION
### Summary
Refactors how **custom items** are defined and registered, mirroring the approach used for custom blocks.

- Centralizes client-facing definition into **CustomItemDefinition.SimpleBuilder**
- Minimizes server-side overrides; core derives behavior from the definition where possible
- Deprecates helper builders: **toolBuilder**, **armorBuilder**, **edibleBuilder**
- Adds guard rails: SimpleBuilder validates and rejects conflicting/incompatible components

### Motivation
Reduce maintenance overhead and confusion from multiple builders; make the builder the standard path and reserve overrides for advanced cases.

### Key Changes
- `SimpleBuilder` now covers:
  - gameplay: `enchantable(...)`
  - usage: `useAnimation("eat"|"drink"|...)`, `useModifiers(movement, seconds)` with legacy `use_animation` auto-mapping (0/1/2) and `use_duration` ticks auto-derived
  - food: `food(canAlwaysEat, nutrition, saturation[, usingConvertsTo])`

- Core `Item` reads definition for common behavior:
  - `isFood()` → presence of `minecraft:food`

- `ItemRegistry` gains static lookups analogous to `BlockRegistry`:
  - `getCustomItemDefinitionByIdStatic(String)`
  - `getCustomItemDefinitionList()`

- `EdibleBuilder` kept as a **deprecated** shim that delegates to the new API

### Breaking/Behavior Notes
- Existing custom items compiled against deprecated builders continue to work, but will show deprecation warnings.
- Vanilla item classes (`ItemFood`, `ItemArmor`, etc.) may have light changes where core now derives behavior from definitions when present.
- `minecraft:food` serialization is limited to currently-accepted fields (e.g., `can_always_eat`, `nutrition`, `saturation_modifier`, `using_converts_to`).

### Migration
- Prefer `CustomItemDefinition.simpleBuilder(this)` and set components via builder methods.
- Replace usage of `edibleBuilder/toolBuilder/armorBuilder` with `simpleBuilder`.
- For advanced logic, override `Item` methods as before; the builder should cover most cases.
