### PR TITLE
fix: Natural Regeneration check not matching

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -2704,7 +2704,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
 
             this.entityBaseTick(tickDiff);
 
-            if (this.getServer().getDifficulty() == 0 && this.level.getGameRules().getBoolean(GameRule.NATURAL_REGENERATION)) {
+            if (this.getServer().getDifficulty() == 0 || this.level.getGameRules().getBoolean(GameRule.NATURAL_REGENERATION)) {
                 if (this.getHealth() < this.getMaxHealth() && this.ticksLived % 20 == 0) {
                     this.heal(1);
                 }


### PR DESCRIPTION
Small fix the check, natural regeneration must happens when the server is on peaceful mode or have the natural regeneration set to true (which is default).
Natural regeneration can be disabled in server settings `/gamulre naturalregeneration false`