### PR TITLE
enhancement: Custom Entity Refactor - Phase 1 (!! BREAKING API !!)

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockMobSpawner.java
+++ b/src/main/java/cn/nukkit/block/BlockMobSpawner.java
@@ -4,10 +4,13 @@ import cn.nukkit.Player;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.blockentity.BlockEntityMobSpawner;
 import cn.nukkit.item.Item;
+import cn.nukkit.item.ItemCustomEntitySpawnEgg;
 import cn.nukkit.item.ItemSpawnEgg;
 import cn.nukkit.item.ItemTool;
 import cn.nukkit.math.BlockFace;
 import cn.nukkit.nbt.tag.CompoundTag;
+import cn.nukkit.registry.Registries;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -105,10 +108,23 @@ public class BlockMobSpawner extends BlockSolid {
 
     @Override
     public boolean onActivate(@NotNull Item item, @Nullable Player player, BlockFace blockFace, float fx, float fy, float fz) {
-        if(!(item instanceof ItemSpawnEgg egg)) return false;
-        if(player == null) return false;
-        if (player.isAdventure()) return false;
-        if(setType(egg.getEntityNetworkId())) {
+        if (player == null || player.isAdventure()) return false;
+        int networkId = -1;
+
+        if (item instanceof ItemSpawnEgg egg) {
+            networkId = egg.getEntityNetworkId();
+        } else if (item instanceof ItemCustomEntitySpawnEgg) {
+            String eggId = item.getId();
+            String entityId = ItemCustomEntitySpawnEgg.entityIdFromEggId(eggId);
+            if (entityId != null) {
+                int rid = Registries.ENTITY.getEntityNetworkId(entityId);
+                if (rid != 0) networkId = rid;
+            }
+        }
+
+        if (networkId <= 0) return false;
+
+        if (setType(networkId)) {
             if (!player.isCreative()) {
                 player.getInventory().decreaseCount(player.getInventory().getHeldItemIndex());
             }

--- a/src/main/java/cn/nukkit/command/defaults/SummonCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/SummonCommand.java
@@ -9,6 +9,7 @@ import cn.nukkit.command.tree.ParamList;
 import cn.nukkit.command.utils.CommandLogger;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.level.Position;
+import cn.nukkit.registry.EntityRegistry;
 import cn.nukkit.registry.Registries;
 
 import java.util.ArrayList;
@@ -44,6 +45,7 @@ public class SummonCommand extends VanillaCommand {
             return 0;
         }
         Integer entityId = Type.ENTITY_TYPE2ID.get(entityType);
+
         Position pos = sender.getPosition();
         if (list.hasResult(1)) {
             pos = list.getResult(1);
@@ -52,6 +54,7 @@ public class SummonCommand extends VanillaCommand {
             log.addError("commands.summon.outOfWorld").output();
             return 0;
         }
+
         String nameTag = null;
         if (list.hasResult(2)) {
             nameTag = list.getResult(2);
@@ -60,18 +63,34 @@ public class SummonCommand extends VanillaCommand {
         if (list.hasResult(3)) {
             nameTagAlwaysVisible = list.getResult(3);
         }
+
+        // ---- block non-summonable entities BEFORE creating the instance ----
+        EntityRegistry.EntityDefinition def;
+        if (entityId != null) {
+            String fullId = Registries.ENTITY.getEntityIdentifier(entityId);
+            def = Registries.ENTITY.getEntityDefinition(fullId);
+        } else {
+            def = Registries.ENTITY.getEntityDefinition(entityType);
+        }
+        if (def == null || !def.summonable()) {
+            log.addError("commands.summon.failed").output();
+            return 0;
+        }
+        // -------------------------------------------------------------------
+
         Entity entity;
         if (entityId != null) {
-            //原版生物
+            // Vanilla Entities
             entity = Entity.createEntity(entityId, pos);
         } else {
-            //自定义生物
+            // Custom Entities
             entity = Entity.createEntity(entityType, pos);
         }
         if (entity == null) {
             log.addError("commands.summon.failed").output();
             return 0;
         }
+
         if (nameTag != null) {
             entity.setNameTag(nameTag);
             entity.setNameTagAlwaysVisible(nameTagAlwaysVisible);
@@ -84,7 +103,7 @@ public class SummonCommand extends VanillaCommand {
     protected String completionPrefix(String type) {
         var completed = type.contains(":") ? type : "minecraft:" + type;
         if (!Type.ENTITY_TYPE2ID.containsKey(type) && !Type.ENTITY_TYPE2ID.containsKey(completed)) {
-            //是自定义生物，不需要补全
+            // It is a custom creature and does not need to be completed
             return type;
         }
         return completed;

--- a/src/main/java/cn/nukkit/command/defaults/SummonCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/SummonCommand.java
@@ -15,6 +15,7 @@ import cn.nukkit.registry.Registries;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 
 public class SummonCommand extends VanillaCommand {
@@ -65,10 +66,7 @@ public class SummonCommand extends VanillaCommand {
         }
 
         // ---- block non-summonable entities BEFORE creating the instance ----
-        String fullId = (entityId != null)
-                ? Registries.ENTITY.getEntityIdentifier(entityId)
-                : entityType;
-        if (fullId == null) fullId = entityType;
+        String fullId = Optional.ofNullable(entityId).map(Registries.ENTITY::getEntityIdentifier).orElse(entityType);
         EntityRegistry.EntityDefinition def = Registries.ENTITY.getEntityDefinition(fullId);
 
         if (def == null || !def.summonable()) {

--- a/src/main/java/cn/nukkit/command/defaults/SummonCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/SummonCommand.java
@@ -65,13 +65,12 @@ public class SummonCommand extends VanillaCommand {
         }
 
         // ---- block non-summonable entities BEFORE creating the instance ----
-        EntityRegistry.EntityDefinition def;
-        if (entityId != null) {
-            String fullId = Registries.ENTITY.getEntityIdentifier(entityId);
-            def = Registries.ENTITY.getEntityDefinition(fullId);
-        } else {
-            def = Registries.ENTITY.getEntityDefinition(entityType);
-        }
+        String fullId = (entityId != null)
+                ? Registries.ENTITY.getEntityIdentifier(entityId)
+                : entityType;
+        if (fullId == null) fullId = entityType;
+        EntityRegistry.EntityDefinition def = Registries.ENTITY.getEntityDefinition(fullId);
+
         if (def == null || !def.summonable()) {
             log.addError("commands.summon.failed").output();
             return 0;

--- a/src/main/java/cn/nukkit/command/tree/node/EntitiesNode.java
+++ b/src/main/java/cn/nukkit/command/tree/node/EntitiesNode.java
@@ -10,13 +10,12 @@ import com.google.common.collect.Lists;
 import java.util.List;
 
 /**
- * 解析为{@code List<Entity>}值
- * <p>
- * 所有命令参数类型为{@link cn.nukkit.command.data.CommandParamType#TARGET TARGET}如果没有手动指定{@link IParamNode},则会默认使用这个解析
+ * Parsed as {@code List<Entity>} value <p>
+ * All command parameter types are {@link cn.nukkit.command.data.CommandParamType#TARGET TARGET} If not manually specified {@link IParamNode}, This analysis will be used by default
  */
 public class EntitiesNode extends TargetNode<Entity> {
 
-    //todo 支持uuid 或者 xuid
+    // TODO: Support UUID or xuid
     @Override
     public void fill(String arg) {
         List<Entity> entities;

--- a/src/main/java/cn/nukkit/command/tree/node/ItemNode.java
+++ b/src/main/java/cn/nukkit/command/tree/node/ItemNode.java
@@ -5,12 +5,12 @@ import cn.nukkit.block.customblock.CustomBlock;
 import cn.nukkit.command.utils.CommandUtils;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBlock;
+import cn.nukkit.item.ItemCustomEntitySpawnEgg;
 import cn.nukkit.item.customitem.CustomItem;
 
 /**
- * 解析对应参数为{@link Item}值
- * <p>
- * 所有命令枚举{@link cn.nukkit.command.data.CommandEnum#ENUM_ITEM ENUM_ITEM}如果没有手动指定{@link IParamNode},则会默认使用这个解析
+ * The corresponding parameters for analysis are {@link Item} value <p>
+ * All command enumeration {@link cn.nukkit.command.data.CommandEnum#ENUM_ITEM ENUM_ITEM} If not manually specified {@link IParamNode}, This analysis will be used by default
  */
 public class ItemNode extends ParamNode<Item> {
     @Override
@@ -40,6 +40,12 @@ public class ItemNode extends ParamNode<Item> {
             }
         }
 
-        this.value = item;
+        if (item instanceof ItemCustomEntitySpawnEgg egg) {
+             // Resolve custom entity spawn egg
+            egg.resolveSpawnEgg(arg);
+            this.value = egg;
+        } else {
+            this.value = item;
+        }
     }
 }

--- a/src/main/java/cn/nukkit/command/tree/node/ItemNode.java
+++ b/src/main/java/cn/nukkit/command/tree/node/ItemNode.java
@@ -5,7 +5,6 @@ import cn.nukkit.block.customblock.CustomBlock;
 import cn.nukkit.command.utils.CommandUtils;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBlock;
-import cn.nukkit.item.ItemCustomEntitySpawnEgg;
 import cn.nukkit.item.customitem.CustomItem;
 
 /**
@@ -40,12 +39,6 @@ public class ItemNode extends ParamNode<Item> {
             }
         }
 
-        if (item instanceof ItemCustomEntitySpawnEgg egg) {
-             // Resolve custom entity spawn egg
-            egg.resolveSpawnEgg(arg);
-            this.value = egg;
-        } else {
-            this.value = item;
-        }
+        this.value = item;
     }
 }

--- a/src/main/java/cn/nukkit/entity/custom/CustomEntity.java
+++ b/src/main/java/cn/nukkit/entity/custom/CustomEntity.java
@@ -2,5 +2,8 @@ package cn.nukkit.entity.custom;
 
 
 public interface CustomEntity {
-
+    /**
+     * This method sets the definition of custom Entity
+     */
+    CustomEntityDefinition getDefinition();
 }

--- a/src/main/java/cn/nukkit/entity/custom/CustomEntityDefinition.java
+++ b/src/main/java/cn/nukkit/entity/custom/CustomEntityDefinition.java
@@ -1,0 +1,60 @@
+package cn.nukkit.entity.custom;
+
+import org.jetbrains.annotations.NotNull;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * CustomEntityDefinition defines custom entities from behavior packs.
+ *
+ * Use {@link CustomEntityDefinition.SimpleBuilder} to declare all
+ * properties and behaviors. The builder centralizes supported fields and
+ * handles server side overrides automatically. <p>
+ *
+ * Override {@link Entity Entity} methods can be used for advanced or
+ * specialized logic not covered by the builder.
+ */
+@Slf4j
+public record CustomEntityDefinition(String id, String eid, boolean hasSpawnegg, boolean isSummonable) {
+
+    public CustomEntityDefinition {
+        if (id == null || id.isBlank()) throw new IllegalArgumentException("id is blank");
+        if (eid == null) eid = "";
+    }
+
+    public static SimpleBuilder simpleBuilder(@NotNull String id) {
+        return new SimpleBuilder(id);
+    }
+
+    public static final class SimpleBuilder {
+        private final String id;
+        private String eid = "";
+        private boolean hasSpawnegg = true;
+        private boolean isSummonable  = true;
+
+        public SimpleBuilder(@NotNull String id) {
+            if (id == null || id.isBlank()) throw new IllegalArgumentException("id is blank");
+            this.id = id;
+        }
+
+        public SimpleBuilder eid(String entityIdentifier) {
+            if (entityIdentifier == null) entityIdentifier = "";
+            this.eid = entityIdentifier;
+            return this;
+        }
+
+        public SimpleBuilder hasSpawnEgg(boolean value) {
+            this.hasSpawnegg = value;
+            return this;
+        }
+
+        public SimpleBuilder isSummonable(boolean value) {
+            this.isSummonable = value;
+            return this;
+        }
+
+        public CustomEntityDefinition build() {
+            return new CustomEntityDefinition(this.id, this.eid, this.hasSpawnegg, this.isSummonable);
+        }
+    }
+}

--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -206,8 +206,6 @@ public abstract class Item implements Cloneable, ItemID {
                 item.setCompoundTag(tags);
             }
         } else {
-            item = item.clone();
-
             if (item instanceof ItemCustomEntitySpawnEgg egg) {
                 egg.resolveSpawnEgg(id);
             }

--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -195,6 +195,11 @@ public abstract class Item implements Cloneable, ItemID {
     public static Item get(String id, int meta, int count, byte[] tags, boolean autoAssignStackNetworkId) {
         id = id.contains(":") ? id : "minecraft:" + id;
         Item item = Registries.ITEM.get(id, meta, count, tags);
+
+        if (item instanceof ItemCustomEntitySpawnEgg egg) {
+            egg.resolveSpawnEgg(id);
+        }
+
         if (item == null) {
             BlockState itemBlockState = getItemBlockState(id, meta);
             if (itemBlockState == null || itemBlockState == BlockAir.STATE) {
@@ -205,14 +210,8 @@ public abstract class Item implements Cloneable, ItemID {
             if (tags != null) {
                 item.setCompoundTag(tags);
             }
-        } else {
-            if (item instanceof ItemCustomEntitySpawnEgg egg) {
-                egg.resolveSpawnEgg(id);
-            }
-
-            if (autoAssignStackNetworkId) {
-                item.autoAssignStackNetworkId();
-            }
+        } else if (autoAssignStackNetworkId) {
+            item.autoAssignStackNetworkId();
         }
         return item;
     }

--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -205,8 +205,18 @@ public abstract class Item implements Cloneable, ItemID {
             if (tags != null) {
                 item.setCompoundTag(tags);
             }
-        } else if (autoAssignStackNetworkId) {
-            item.autoAssignStackNetworkId();
+        } else {
+            // IMPORTANT: don’t mutate a registry template instance
+            item = item.clone();
+
+            // Bind spawn-egg to the requested id (sets Item.id + seeds pnx_extra_data)
+            if (item instanceof ItemCustomEntitySpawnEgg egg) {
+                egg.resolveSpawnEgg(id);
+            }
+
+            if (autoAssignStackNetworkId) {
+                item.autoAssignStackNetworkId();
+            }
         }
         return item;
     }
@@ -1406,12 +1416,13 @@ public abstract class Item implements Cloneable, ItemID {
 
     public final int getRuntimeId() {
         if (this.isNull()) return getAirRuntimeId();
+
         int i = Registries.ITEM_RUNTIMEID.getInt(this.getId());
         if (i == Integer.MAX_VALUE) {
             i = Registries.ITEM_RUNTIMEID.getInt(this.getBlockId());
         }
         if (i == Integer.MAX_VALUE) {
-            log.warn("Can't find runtimeId for item {}, will return unknown itemblock!", getId());
+            log.warn("Can't find runtimeId for item {}, will return unknown itemblock!", this.getId());
             return getUnknownRuntimeId();// Can't find runtimeId
         }
         return i;

--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -206,10 +206,8 @@ public abstract class Item implements Cloneable, ItemID {
                 item.setCompoundTag(tags);
             }
         } else {
-            // IMPORTANT: don’t mutate a registry template instance
             item = item.clone();
 
-            // Bind spawn-egg to the requested id (sets Item.id + seeds pnx_extra_data)
             if (item instanceof ItemCustomEntitySpawnEgg egg) {
                 egg.resolveSpawnEgg(id);
             }

--- a/src/main/java/cn/nukkit/item/ItemCustomEntitySpawnEgg.java
+++ b/src/main/java/cn/nukkit/item/ItemCustomEntitySpawnEgg.java
@@ -1,0 +1,226 @@
+package cn.nukkit.item;
+
+import cn.nukkit.Player;
+import cn.nukkit.block.Block;
+import cn.nukkit.entity.Entity;
+import cn.nukkit.event.entity.CreatureSpawnEvent;
+import cn.nukkit.event.entity.CreatureSpawnEvent.SpawnReason;
+import cn.nukkit.item.customitem.CustomItemDefinition;
+import cn.nukkit.level.Level;
+import cn.nukkit.level.format.IChunk;
+import cn.nukkit.level.vibration.VibrationEvent;
+import cn.nukkit.level.vibration.VibrationType;
+import cn.nukkit.math.BlockFace;
+import cn.nukkit.nbt.tag.CompoundTag;
+import cn.nukkit.nbt.tag.DoubleTag;
+import cn.nukkit.nbt.tag.FloatTag;
+import cn.nukkit.nbt.tag.ListTag;
+import cn.nukkit.registry.Registries;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.Field;
+import java.util.Random;
+
+public class ItemCustomEntitySpawnEgg extends Item {
+    private static final String SUFFIX = "_spawn_egg";
+    private static final String PLACEHOLDER_ID = "pnx:auto_spawn_egg";
+
+    private static final String ROOT_PNX_EXTRA  = "pnx_extra_data";
+    private static final String COMP_CUSTOM_EGG = "custom_entity_spawn_egg";
+    private static final String KEY_EGG_ID      = "egg_identifier";
+    private static final String KEY_ENTITY_ID   = "entity_identifier";
+
+    public ItemCustomEntitySpawnEgg() {
+        super(PLACEHOLDER_ID, 0, 1);
+        selfHealIdentifierFromNamedTag();
+    }
+
+    /** Build a full client definition for a spawn egg id */
+    public static CustomItemDefinition buildEggDefinition(String eggId) {
+        final String entityId = entityIdFromEggId(eggId);
+
+        CompoundTag nbt = buildEggDefinitionNbtStatic(eggId, entityId);
+        return new CustomItemDefinition(eggId, nbt);
+    }
+
+    /** Build definition from this instance’s resolved id. */
+    public CustomItemDefinition buildDefinition() {
+        String eggId = getEggId();
+        if (eggId == null || eggId.isEmpty()) eggId = PLACEHOLDER_ID;
+
+        final String entityId = entityIdFromEggId(eggId);
+
+        CompoundTag nbt = buildEggDefinitionNbtStatic(eggId, entityId);
+        return new CustomItemDefinition(eggId, nbt);
+    }
+
+    /** Static NBT builder. */
+    private static CompoundTag buildEggDefinitionNbtStatic(String eggId, @Nullable String entityId) {
+        CompoundTag root = new CompoundTag();
+        CompoundTag pnxExtra = new CompoundTag();
+        CompoundTag eggComp  = new CompoundTag();
+        eggComp.putString(KEY_EGG_ID, eggId);
+        if (entityId != null && !entityId.isEmpty()) {
+            eggComp.putString(KEY_ENTITY_ID, entityId);
+        }
+        pnxExtra.putCompound(COMP_CUSTOM_EGG, eggComp);
+        root.putCompound(ROOT_PNX_EXTRA, pnxExtra);
+
+        return root;
+    }
+
+    @Override
+    public boolean canBeActivated() {
+        return true;
+    }
+
+    @Override
+    public boolean onActivate(Level level, Player player, Block block, Block target, BlockFace face, double fx, double fy, double fz) {
+        if (player != null && player.isAdventure()) return false;
+
+        selfHealIdentifierFromNamedTag();
+
+        String entityId = entityIdFromEggId(this.getId());
+        if (entityId == null || entityId.isEmpty()) {
+            if (player != null) player.sendMessage("§cInvalid spawn egg.");
+            return false;
+        }
+
+        IChunk chunk = level.getChunk((int) block.getX() >> 4, (int) block.getZ() >> 4);
+        if (chunk == null) return false;
+
+        CompoundTag nbt = new CompoundTag()
+            .putList("Pos", new ListTag<DoubleTag>()
+                .add(new DoubleTag(block.getX() + 0.5))
+                .add(new DoubleTag(target.getBoundingBox() == null ? block.getY() : target.getBoundingBox().getMaxY() + 0.0001f))
+                .add(new DoubleTag(block.getZ() + 0.5)))
+            .putList("Motion", new ListTag<DoubleTag>()
+                .add(new DoubleTag(0))
+                .add(new DoubleTag(0))
+                .add(new DoubleTag(0)))
+            .putList("Rotation", new ListTag<FloatTag>()
+                .add(new FloatTag(new Random().nextFloat() * 360))
+                .add(new FloatTag(0)));
+
+        if (this.hasCustomName()) {
+            nbt.putString("CustomName", this.getCustomName());
+        }
+
+        int networkId = Registries.ENTITY.getEntityNetworkId(entityId);
+        var ev = new CreatureSpawnEvent(networkId, block, nbt, SpawnReason.SPAWN_EGG);
+        level.getServer().getPluginManager().callEvent(ev);
+        if (ev.isCancelled()) return false;
+
+        Entity entity = Registries.ENTITY.provideEntity(entityId, chunk, nbt);
+        if (entity == null) {
+            if (player != null) player.sendMessage("§cCould not create entity: §e" + entityId);
+            return false;
+        }
+
+        if (player != null && player.isSurvival()) {
+            player.getInventory().decreaseCount(player.getInventory().getHeldItemIndex());
+        }
+
+        entity.spawnToAll();
+
+        if (player != null) {
+            level.getVibrationManager().callVibrationEvent(new VibrationEvent(player, entity.clone(), VibrationType.ENTITY_PLACE));
+        }
+
+        return true;
+    }
+
+    @Override
+    public Item setNamedTag(CompoundTag tag) {
+        Item out = super.setNamedTag(tag);
+        selfHealIdentifierFromNamedTag();
+        return out;
+    }
+
+    @Override
+    public Item clone() {
+        Item c = super.clone();
+        if (c instanceof ItemCustomEntitySpawnEgg egg) {
+            egg.selfHealIdentifierFromNamedTag();
+        }
+        return c;
+    }
+
+
+    // ---------- helpers ----------
+    private void selfHealIdentifierFromNamedTag() {
+        CompoundTag tag = this.getNamedTag();
+        if (tag == null) return;
+        CompoundTag pnxExtra = tag.getCompound(ROOT_PNX_EXTRA);
+        if (pnxExtra == null) return;
+        CompoundTag customEgg = pnxExtra.getCompound(COMP_CUSTOM_EGG);
+        if (customEgg == null) return;
+        String eggId = customEgg.getString(KEY_EGG_ID);
+        if (eggId != null && !eggId.isEmpty() && !eggId.equals(super.getId())) {
+            setItemIdReflect(this, eggId);
+        }
+    }
+
+    private static void setItemIdReflect(Item item, String id) {
+        try {
+            Field f = Item.class.getDeclaredField("id");
+            f.setAccessible(true);
+            f.set(item, id);
+        } catch (Throwable ignored) { }
+    }
+
+    public static @Nullable String entityIdFromEggId(String eggId) {
+        if (eggId == null) return null;
+        int colon = eggId.indexOf(':');
+        if (colon < 0) return null;
+
+        String ns = eggId.substring(0, colon);
+        String path = eggId.substring(colon + 1);
+        if (!path.endsWith(SUFFIX)) return null;
+
+        String entityPath = path.substring(0, path.length() - SUFFIX.length());
+        if (entityPath.isEmpty()) return null;
+
+        return ns + ":" + entityPath;
+    }
+
+    /** Returns the real item id for this egg (e.g. "namespace:custom_zombie_spawn_egg"), or null if unavailable. */
+    public String getEggId() {
+        String raw = getRawItemIdNoHook();
+        return (raw != null && !raw.isEmpty() && !raw.equals(PLACEHOLDER_ID) && entityIdFromEggId(raw) != null) ? raw : null;
+    }
+
+    private String getRawItemIdNoHook() {
+        try {
+            Field f = Item.class.getDeclaredField("id");
+            f.setAccessible(true);
+            Object v = f.get(this);
+            return v instanceof String ? (String) v : null;
+        } catch (Throwable ignore) {
+            return null;
+        }
+    }
+
+    /** Bind the resolved item id to this egg and seed PNX extra data. */
+    public void resolveSpawnEgg(String resolvedId) {
+        setItemIdReflect(this, resolvedId);
+
+        CompoundTag root = this.getOrCreateNamedTag();
+        CompoundTag pnx  = root.getCompound(ROOT_PNX_EXTRA);
+        if (pnx == null) {
+            pnx = new CompoundTag();
+            root.putCompound(ROOT_PNX_EXTRA, pnx);
+        }
+        CompoundTag ce = pnx.getCompound(COMP_CUSTOM_EGG);
+        if (ce == null) {
+            ce = new CompoundTag();
+            pnx.putCompound(COMP_CUSTOM_EGG, ce);
+        }
+        ce.putString(KEY_EGG_ID, resolvedId);
+
+        String ent = entityIdFromEggId(resolvedId);
+        if (ent != null) {
+            ce.putString(KEY_ENTITY_ID, ent);
+        }
+    }
+}

--- a/src/main/java/cn/nukkit/item/customitem/CustomItemDefinition.java
+++ b/src/main/java/cn/nukkit/item/customitem/CustomItemDefinition.java
@@ -1688,6 +1688,18 @@ public record CustomItemDefinition(String identifier, CompoundTag nbt) implement
 
 
     // Helpers
+    /** Used for spawn eggs registration only */
+    public static int ensureRuntimeIdAllocated(String idStr) {
+        if (!INTERNAL_ALLOCATION_ID_MAP.containsKey(idStr)) {
+            int id;
+            do {
+                id = nextRuntimeId.getAndIncrement();
+            } while (INTERNAL_ALLOCATION_ID_MAP.containsValue(id));
+            INTERNAL_ALLOCATION_ID_MAP.put(idStr, id);
+        }
+        return INTERNAL_ALLOCATION_ID_MAP.getInt(idStr);
+    }
+
     @Nullable
     public BlockPlacerData getBlockPlacerData() {
         CompoundTag components = nbt.getCompound("components");

--- a/src/main/java/cn/nukkit/registry/CreativeItemRegistry.java
+++ b/src/main/java/cn/nukkit/registry/CreativeItemRegistry.java
@@ -4,6 +4,7 @@ import cn.nukkit.block.BlockState;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemID;
 import cn.nukkit.item.customitem.data.CreativeCategory;
+import cn.nukkit.item.customitem.data.CreativeGroup;
 import cn.nukkit.nbt.NBTIO;
 import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.network.protocol.types.inventory.creative.CreativeItemCategory;
@@ -371,6 +372,21 @@ public class CreativeItemRegistry implements ItemID, IRegistry<Integer, Item, It
             }
         }
         return CreativeItemRegistry.LAST_ITEMS_INDEX;
+    }
+
+    public int resolveGroupIndexForSpawnEgg(String identifier) {
+        CreativeCategory category = CreativeCategory.NATURE;
+        String groupName = CreativeGroup.MOB_EGGS.getGroupName();
+        Map<String, Integer> groupMap = CATEGORY_GROUP_INDEX_MAP.getOrDefault(category, Map.of());
+        Integer idx = groupMap.get(groupName);
+
+        CreativeItemRegistry.ITEM_GROUP_MAP.put(identifier, groupName);
+
+        if (idx != null) {
+            return idx;
+        }
+
+        return getLastGroupIndexFrom(category.name());
     }
 
     public static int getLastGroupIndexFrom(String categoryName) {


### PR DESCRIPTION
This refactor makes custom entity creation much simpler, mirroring the approach used for **Custom Items** and **Blocks**, by introducing a `simpleBuilder` API for `CustomEntityDefinition`. It reduces boilerplate, standardizes registration, and automatically wires up spawn eggs.

* **`simpleBuilder` for entities.** Define identifier, spawn-egg presence, and summonability with a small, fluent builder.
* **One-line registration** (same pattern as items/blocks):

  ```java
  Registries.ENTITY.registerCustomEntity(plugin, MyCustomMob.class);
  ```
* **Automatic spawn-egg creation.** If `hasSpawnEgg(true)` is set, a matching egg is created and placed in the **Mob Eggs** creative group. Eggs behave like vanilla ones.
* **No client components on eggs.** Like BDS, spawn eggs are plain items. If you want a nicer egg name, localize it via lang files, the client ignores item components for eggs. (Server-side metadata is carried via `pnx_extra_data` only.)

## Usage example

```java
public class MyCustomMob extends EntityIntelligent implements CustomEntity {
    public static final String IDENTIFIER = "namespace:mycustom_mob";

    @Override public String getOriginalName() { return "My Custom Mob"; }
    @Override public @NotNull String getIdentifier() { return IDENTIFIER; }

    public MyCustomMob(IChunk chunk, CompoundTag nbt) { super(chunk, nbt); }

    // Static definition used by the registry
    public static CustomEntityDefinition definition() {
        return CustomEntityDefinition.simpleBuilder(IDENTIFIER)
            .eid(IDENTIFIER)
            .hasSpawnEgg(true)
            .isSummonable(false)
            .build();
    }

    // Instance override remains for runtime compatibility
    @Override public CustomEntityDefinition getDefinition() { return definition(); }
}
```

## Breaking changes
This refactor **breaks existing custom entities** that don’t expose a `CustomEntityDefinition` via the new pattern.

### Migration guide
1. Add a **static** definition source to each entity class (supported options, in order of preference):
   * `public static CustomEntityDefinition definition()`
   * `public static CustomEntityDefinition getDefinition()`
2. Add a instance  of `getDefinition()` if you rely on it at runtime; the registry prefers a static definition for registration.
3. Register with:
   ```java
   Registries.ENTITY.registerCustomEntity(plugin, MyCustomMob.class);
   ```


## Notes
Next phases will introduce more nested builder methods to allow simple customization of the custom entities.

