### PR TITLE
fix: Enforce strict per-pack RP delivery to protect low-end clients

### DIFF
--- a/src/main/java/cn/nukkit/network/connection/BedrockSession.java
+++ b/src/main/java/cn/nukkit/network/connection/BedrockSession.java
@@ -809,4 +809,9 @@ public class BedrockSession {
         }
         throw new IllegalStateException("BedrockPacketCodec not found in channel pipeline");
     }
+
+    public void nudgePacer() {
+        if (!this.pacingEnabled) return;
+        this.scheduler.tryPump(this.peer, this.subClientId, this);
+    }
 }

--- a/src/main/java/cn/nukkit/network/process/handler/ResourcePackHandler.java
+++ b/src/main/java/cn/nukkit/network/process/handler/ResourcePackHandler.java
@@ -13,15 +13,43 @@ import cn.nukkit.resourcepacks.ResourcePack;
 import cn.nukkit.utils.version.Version;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.UUID;
+import java.util.ArrayDeque;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.UUID;
 
 @Slf4j
 public class ResourcePackHandler extends BedrockSessionPacketHandler {
 
-    private final Queue<ResourcePackChunkRequestPacket> chunkRequestQueue = new ConcurrentLinkedQueue<>();
-    private boolean sendingChunks = false;
+    private static final class PackMeta {
+        final UUID packId;
+        final ResourcePack pack;
+        final int maxChunkSize;
+        final int chunkCount;
+        final BitSet want = new BitSet();
+        final BitSet sent = new BitSet();
+        int nextToSend = 0;
+
+        PackMeta(UUID id, ResourcePack p, int maxChunkSize, int chunkCount) {
+            this.packId = id;
+            this.pack = p;
+            this.maxChunkSize = maxChunkSize;
+            this.chunkCount = chunkCount;
+        }
+
+        boolean finished() {
+            return nextToSend >= chunkCount;
+        }
+    }
+
+    private final Map<UUID, PackMeta> packs = new HashMap<>();
+    private final ArrayDeque<UUID> packOrder = new ArrayDeque<>();
+    private UUID activePack = null;
+    private final Queue<ResourcePackChunkRequestPacket> chunkRequestQueue = new ArrayDeque<>();
+    private volatile boolean draining = false;
 
     public ResourcePackHandler(BedrockSession session) {
         super(session);
@@ -50,12 +78,16 @@ public class ResourcePackHandler extends BedrockSessionPacketHandler {
                         this.session.close("disconnectionScreen.resourcePack");
                         return;
                     }
+                    int maxChunkSize = server.getResourcePackManager().getMaxChunkSize();
+                    int chunkCount = (int) Math.ceil(resourcePack.getPackSize() / (double) maxChunkSize);
+
+                    packs.put(resourcePack.getPackId(), new PackMeta(resourcePack.getPackId(), resourcePack, maxChunkSize, chunkCount));
 
                     ResourcePackDataInfoPacket dataInfoPacket = new ResourcePackDataInfoPacket();
                     dataInfoPacket.packId = resourcePack.getPackId();
                     dataInfoPacket.setPackVersion(new Version(resourcePack.getPackVersion()));
-                    dataInfoPacket.maxChunkSize = server.getResourcePackManager().getMaxChunkSize();
-                    dataInfoPacket.chunkCount = (int) Math.ceil(resourcePack.getPackSize() / (double) dataInfoPacket.maxChunkSize);
+                    dataInfoPacket.maxChunkSize = maxChunkSize;
+                    dataInfoPacket.chunkCount = chunkCount;
                     dataInfoPacket.compressedPackSize = resourcePack.getPackSize();
                     dataInfoPacket.sha256 = resourcePack.getSha256();
                     session.sendPacket(dataInfoPacket);
@@ -83,35 +115,94 @@ public class ResourcePackHandler extends BedrockSessionPacketHandler {
     @Override
     public void handle(ResourcePackChunkRequestPacket pk) {
         chunkRequestQueue.add(pk);
-        if (!sendingChunks) {
-            sendingChunks = true;
-            processNextChunk();
+
+        PackMeta meta = packs.get(pk.getPackId());
+        if (meta == null) {
+            var mgr = session.getServer().getResourcePackManager();
+            ResourcePack p = mgr.getPackById(pk.getPackId());
+            if (p == null) {
+                this.session.close("disconnectionScreen.resourcePack");
+                return;
+            }
+            int maxChunkSize = mgr.getMaxChunkSize();
+            int chunkCount = (int) Math.ceil(p.getPackSize() / (double) maxChunkSize);
+            meta = new PackMeta(p.getPackId(), p, maxChunkSize, chunkCount);
+            packs.put(meta.packId, meta);
+        }
+
+        if (activePack == null) {
+            activePack = meta.packId;
+            packOrder.addLast(meta.packId);
+        } else if (!Objects.equals(activePack, meta.packId) && !packOrder.contains(meta.packId)) {
+            packOrder.addLast(meta.packId);
+        }
+
+        if (pk.chunkIndex >= 0 && pk.chunkIndex < meta.chunkCount) {
+            meta.want.set(pk.chunkIndex);
+        }
+
+        drainActiveStrict();
+    }
+
+    private void drainActiveStrict() {
+        if (draining) return;
+        draining = true;
+        try {
+            while (activePack != null) {
+                PackMeta m = packs.get(activePack);
+                if (m == null) {
+                    nextPack();
+                    continue;
+                }
+
+                // Send strictly in order, but ONLY when the client has requested that chunk
+                boolean progressed = false;
+                while (m.nextToSend < m.chunkCount && m.want.get(m.nextToSend) && !m.sent.get(m.nextToSend)) {
+                    ResourcePackChunkDataPacket dataPacket = new ResourcePackChunkDataPacket();
+                    dataPacket.setPackId(m.packId);
+                    dataPacket.setPackVersion(new Version(m.pack.getPackVersion()));
+                    dataPacket.chunkIndex = m.nextToSend;
+                    dataPacket.progress = (long) m.maxChunkSize * m.nextToSend;
+                    dataPacket.data = m.pack.getPackChunk(m.maxChunkSize * m.nextToSend, m.maxChunkSize);
+                    if (dataPacket.data == null) {
+                        log.warn("RP chunk out of range or null data: pack={} chunk={}", m.packId, m.nextToSend);
+                        this.session.close("disconnectionScreen.resourcePack");
+                        return;
+                    }
+
+                    // Enqueue to the baseline paced RP FIFO; pacer handles rate limiting
+                    session.sendPacket(dataPacket);
+
+                    m.sent.set(m.nextToSend);
+                    m.nextToSend++;
+                    progressed = true;
+                }
+
+                if (m.finished()) {
+                    nextPack();
+                    // Loop back and start draining the next pack (if any)
+                    continue;
+                }
+
+                if (!progressed) {
+                    break;
+                }
+            }
+
+            session.nudgePacer();
+        } finally {
+            draining = false;
         }
     }
 
-    private void processNextChunk() {
-        ResourcePackChunkRequestPacket req;
-        while ((req = chunkRequestQueue.poll()) != null) {
-            var mgr = session.getServer().getResourcePackManager();
-            ResourcePack resourcePack = mgr.getPackById(req.getPackId());
-            if (resourcePack == null) {
-                this.session.close("disconnectionScreen.resourcePack");
-                sendingChunks = false;
-                return;
-            }
-
-            int maxChunkSize = mgr.getMaxChunkSize();
-
-            ResourcePackChunkDataPacket dataPacket = new ResourcePackChunkDataPacket();
-            dataPacket.setPackId(resourcePack.getPackId());
-            dataPacket.setPackVersion(new Version(resourcePack.getPackVersion()));
-            dataPacket.chunkIndex = req.chunkIndex;
-            dataPacket.data = resourcePack.getPackChunk(maxChunkSize * req.chunkIndex, maxChunkSize);
-            dataPacket.progress = maxChunkSize * (long) req.chunkIndex;
-
-            session.sendPacket(dataPacket);
+    private void nextPack() {
+        if (activePack == null) return;
+        UUID current = packOrder.peekFirst();
+        if (Objects.equals(current, activePack)) {
+            packOrder.pollFirst();
+        } else {
+            packOrder.remove(activePack);
         }
-
-        sendingChunks = false;
+        activePack = packOrder.peekFirst();
     }
 }


### PR DESCRIPTION
* Switch RP transfer to **strict per-pack, in-order** delivery: finish all chunks of the first requested pack before starting the next.
* Park requests for other packs until the active pack completes; only send a chunk when the client has requested that exact index.
* Keep non-RP traffic flowing via the paced lanes to avoid starvation.

This prevents low-memory Android/older devices from stalling by avoiding cross-pack interleaving and reducing memory pressure during RP assembly.
