### PR TITLE
Update Gradle publish command with no-cache option

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,7 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Build PNX & Publish to repo
-        run: ./gradlew publish
+        run: ./gradlew publish --no-configuration-cache
         env:            
           PNX_REPO_USERNAME: ${{ secrets.PNX_REPO_USERNAME }}
           PNX_REPO_PASSWORD: ${{ secrets.PNX_REPO_PASSWORD }}


### PR DESCRIPTION
Added --no-configuration-cache option to Gradle publish command.