### PR TITLE
fix: Avoid EntityItems with display only set to get damage from others  & commands

### DIFF
--- a/src/main/java/cn/nukkit/command/defaults/DamageCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/DamageCommand.java
@@ -44,6 +44,7 @@ public class DamageCommand extends VanillaCommand {
     public int execute(CommandSender sender, String commandLabel, Map.Entry<String, ParamList> result, CommandLogger log) {
         var list = result.getValue();
         List<Entity> entities = list.getResult(0);
+        entities.removeIf(e -> (e instanceof EntityItem item) && item.isDisplayOnly());
         if (entities.isEmpty()) {
             log.addNoTargetMatch().output();
             return 0;

--- a/src/main/java/cn/nukkit/entity/item/EntityItem.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityItem.java
@@ -134,6 +134,8 @@ public class EntityItem extends Entity {
 
     @Override
     public boolean attack(EntityDamageEvent source) {
+        if (this.isDisplayOnly()) return false;
+
         if (item != null && item.isLavaResistant() && (
                 source.getCause() == DamageCause.LAVA ||
                         source.getCause() == DamageCause.FIRE ||
@@ -285,6 +287,7 @@ public class EntityItem extends Entity {
 
     @Override
     public void setOnFire(int seconds) {
+        if (this.isDisplayOnly()) return;
         if (item != null && item.isLavaResistant()) {
             return;
         }


### PR DESCRIPTION
fix: Avoid EntityItems with display only set to get damage from others  & commands