### PR TITLE
fix: Player movement speed when effects slowness/speed are used

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -4929,18 +4929,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
 
         if (isSprinting() != value) {
             super.setSprinting(value);
-
-            float base = DEFAULT_SPEED;
-            int speedLvl = 0;
-            if (this.hasEffect(EffectType.SPEED)) {
-                speedLvl = this.getEffect(EffectType.SPEED).getLevel();
-            }
-            float effectMul = 1.0f + 0.2f * speedLvl;
-            float sprintMul = value ? 1.3f : 1.0f;
-
-            float finalSpeed = base * effectMul * sprintMul;
-
-            this.setMovementSpeed(finalSpeed, true);
+            this.recalcMovementSpeedFromEffects();
         }
     }
 

--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -864,6 +864,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
             effects.remove(type);
 
             this.recalculateEffectColor();
+            if (this instanceof EntityLiving) ((EntityLiving) this).recalcMovementSpeedFromEffects();
         }
     }
 
@@ -917,6 +918,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
         effects.put(effect.getType(), effect);
 
         this.recalculateEffectColor();
+        if (this instanceof EntityLiving) ((EntityLiving) this).recalcMovementSpeedFromEffects();
     }
 
     public void recalculateBoundingBox() {

--- a/src/main/java/cn/nukkit/entity/EntityLiving.java
+++ b/src/main/java/cn/nukkit/entity/EntityLiving.java
@@ -10,6 +10,7 @@ import cn.nukkit.entity.custom.CustomEntityDefinition.Meta;
 import cn.nukkit.entity.data.EntityDataMap;
 import cn.nukkit.entity.data.EntityDataTypes;
 import cn.nukkit.entity.data.EntityFlag;
+import cn.nukkit.entity.effect.Effect;
 import cn.nukkit.entity.effect.EffectType;
 import cn.nukkit.entity.projectile.EntityProjectile;
 import cn.nukkit.entity.weather.EntityWeather;
@@ -590,5 +591,36 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
 
     public int getAttackTimeBefore() {
         return attackTimeBefore;
+    }
+
+    public void recalcMovementSpeedFromEffects() {
+        float base = this.getDefaultSpeed() * this.getSpeedMultiplier();
+        float mul = 1.0f;
+
+        Effect speed = this.getEffect(EffectType.SPEED);
+        int speedLvl = (speed != null) ? (Math.max(0, speed.getAmplifier()) + 1) : 0;
+
+        Effect slow = this.getEffect(EffectType.SLOWNESS);
+        int slowLvl = (slow != null) ? (Math.max(0, slow.getAmplifier()) + 1) : 0;
+
+        if (slowLvl >= 7) {
+            mul = 0.0f;
+        } else {
+            if (speedLvl > 0) {
+                mul *= (1.0f + 0.20f * speedLvl);
+            }
+            if (slowLvl > 0) {
+                mul *= Math.max(0.0f, 1.0f - 0.15f * slowLvl);
+            }
+        }
+
+        if (this instanceof Player p && p.isSprinting()) mul *= 1.3f;
+        float newSpeed = base * mul;
+
+        if (this instanceof Player) {
+            ((Player) this).setMovementSpeed(newSpeed, true);
+        } else {
+            this.setMovementSpeed(newSpeed);
+        }
     }
 }


### PR DESCRIPTION
This PR fixes an issue where the **Slowness** effect caused an incorrect zoom (FOV) behavior when it ended — making the player appear to run faster, as if affected by the **Speed** effect.

Additionally, movement speed was not being recalculated while Slowness was active, causing entities to keep moving at normal speed.

The new logic now mirrors **BDS behavior**, where **Speed** and **Slowness** effects stack multiplicatively.
Both modifiers are applied to the entity’s base movement speed, producing the correct combined result (including full immobilization at high Slowness levels).