### PR TITLE
Fixed that exclusive enchantments was not compatible with custom items.

### DIFF
--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -2406,9 +2406,48 @@ public abstract class Item implements Cloneable, ItemID {
     }
 
     /**
-     * Define if the item can break the shield
+     * Define if the item is a Shield
      */
-    public boolean canBreakShield() {
+    public boolean isShield() {
+        CustomItemDefinition def = getCustomDefinition();
+        if (def != null) return def.isShield();
+        if (this instanceof ItemShield) return true;
+        return false;
+    }
+    /**
+     * Define if the item is a Bow
+     */
+    public boolean isBow() {
+        CustomItemDefinition def = getCustomDefinition();
+        if (def != null) return def.isBow();
+        if (this instanceof ItemBow) return true;
+        return false;
+    }
+    /**
+     * Define if the item is a Crossbow
+     */
+    public boolean isCrossbow() {
+        CustomItemDefinition def = getCustomDefinition();
+        if (def != null) return def.isCrossbow();
+        if (this instanceof ItemCrossbow) return true;
+        return false;
+    }
+    /**
+     * Define if the item is a Trident
+     */
+    public boolean isTrident() {
+        CustomItemDefinition def = getCustomDefinition();
+        if (def != null) return def.isTrident();
+        if (this instanceof ItemTrident) return true;
+        return false;
+    }
+    /**
+     * Define if the item is a Mace
+     */
+    public boolean isMace() {
+        CustomItemDefinition def = getCustomDefinition();
+        if (def != null) return def.isMace();
+        if (this instanceof ItemMace) return true;
         return false;
     }
 
@@ -2418,6 +2457,13 @@ public abstract class Item implements Cloneable, ItemID {
     public boolean isShears() {
         CustomItemDefinition def = getCustomDefinition();
         if (def != null) return def.isShears();
+        return false;
+    }
+
+    /**
+     * Define if the item can break the shield
+     */
+    public boolean canBreakShield() {
         return false;
     }
 

--- a/src/main/java/cn/nukkit/item/customitem/CustomItemDefinition.java
+++ b/src/main/java/cn/nukkit/item/customitem/CustomItemDefinition.java
@@ -499,7 +499,7 @@ public record CustomItemDefinition(String identifier, CompoundTag nbt) implement
          * builder.enchantable("pickaxe", 20);
          * </pre>
          * @param slot {@link ItemEnchantSlot} slot ID of the enchantable item
-         * @param value int value, must be >= 0
+         * @param value int value, can be 0 if you enchant over API, must be >= 1 if you use Anvil
          */
         public SimpleBuilder enchantable(ItemEnchantSlot slot, int value) {
             if (value < 0) value = 0;
@@ -516,7 +516,7 @@ public record CustomItemDefinition(String identifier, CompoundTag nbt) implement
          * builder.enchantable("pickaxe", 20);
          * </pre>
          * @param slot string slot ID of the enchantable item
-         * @param value int value, must be >= 0
+         * @param value int value, can be 0 if you enchant over API, must be >= 1 if you use Anvil
          */
         public SimpleBuilder enchantable(String slot, int value) {
             if (slot == null || slot.isBlank()) return this;
@@ -1801,6 +1801,7 @@ public record CustomItemDefinition(String identifier, CompoundTag nbt) implement
         return ItemEnchantSlot.fromId(slot);
     }
     public boolean isSword()     { return getEnchantSlot() == ItemEnchantSlot.SWORD; }
+    public boolean isMace()      { return getEnchantSlot() == ItemEnchantSlot.MACE; }
     public boolean isShield()    { return getEnchantSlot() == ItemEnchantSlot.SHIELD; }
     public boolean isPickaxe()   { return getEnchantSlot() == ItemEnchantSlot.PICKAXE; }
     public boolean isShovel()    { return getEnchantSlot() == ItemEnchantSlot.SHOVEL; }

--- a/src/main/java/cn/nukkit/item/enchantment/EnchantmentType.java
+++ b/src/main/java/cn/nukkit/item/enchantment/EnchantmentType.java
@@ -4,12 +4,10 @@ import cn.nukkit.block.BlockCarvedPumpkin;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemArmor;
 import cn.nukkit.item.ItemBook;
-import cn.nukkit.item.ItemBow;
-import cn.nukkit.item.ItemCrossbow;
 import cn.nukkit.item.ItemFishingRod;
 import cn.nukkit.item.ItemHead;
-import cn.nukkit.item.ItemMace;
-import cn.nukkit.item.ItemTrident;
+import cn.nukkit.item.customitem.CustomItem;
+
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -41,7 +39,7 @@ public enum EnchantmentType {
             return true;
         }
 
-        if (item instanceof ItemArmor) {
+        if (item instanceof ItemArmor || (item instanceof CustomItem && item.isArmor())) {
             if (this == WEARABLE || this == ARMOR && item.isArmor()) {
                 return true;
             }
@@ -56,14 +54,14 @@ public enum EnchantmentType {
         }
 
         return switch (this) {
-            case SWORD -> item.isSword() && !(item instanceof ItemTrident);
+            case SWORD -> item.isSword() && !item.isTrident();
             case DIGGER -> item.isPickaxe() || item.isShovel() || item.isAxe() || item.isHoe();
-            case BOW -> item instanceof ItemBow;
+            case BOW -> item.isBow();
             case FISHING_ROD -> item instanceof ItemFishingRod;
             case WEARABLE -> item instanceof ItemHead || item.getBlock() instanceof BlockCarvedPumpkin;
-            case TRIDENT -> item instanceof ItemTrident;
-            case CROSSBOW -> item instanceof ItemCrossbow;
-            case MACE -> item instanceof ItemMace;
+            case TRIDENT -> item.isTrident();
+            case CROSSBOW -> item.isCrossbow();
+            case MACE -> item.isMace();
             default -> false;
         };
     }

--- a/src/main/java/cn/nukkit/item/utils/ItemEnchantSlot.java
+++ b/src/main/java/cn/nukkit/item/utils/ItemEnchantSlot.java
@@ -6,6 +6,7 @@ public enum ItemEnchantSlot {
     NONE("none"),
     ALL("all"),
     SWORD("sword"),
+    MACE("all"), // Temporary untill Mojang opens what slot is used for mace
     SPEAR("spear"),
     BOW("bow"),
     CROSSBOW("crossbow"),


### PR DESCRIPTION
This fix is to address exclusive enchantments for instance "Fire Protection" that can be only added to armors that was not compatible with custom items.

Also added enchantable slot type MACE, temporary supporting "all" type of enchantments for custom items while we don't know what exactly slot the client accepts for type mace.