### PR TITLE
fix: TimeUnit constant casing in Gradle build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,8 +70,8 @@ dependencies {
 
 configurations.all {
     resolutionStrategy {
-        cacheDynamicVersionsFor(10, "minutes")
-        cacheChangingModulesFor(10, "minutes")
+        cacheDynamicVersionsFor(10, TimeUnit.MINUTES)
+        cacheChangingModulesFor(10, TimeUnit.MINUTES)
         preferProjectModules()
     }
 }


### PR DESCRIPTION
In locales like Turkish, case conversion breaks "minutes" and results
in an invalid TimeUnit reference.

Using TimeUnit.MINUTES avoids locale-specific casing issues.
<img width="863" height="105" alt="image" src="https://github.com/user-attachments/assets/76c25f58-fc75-4a1a-85df-6ca5018af739" />
