### PR TITLE
Spawn baby chickens when egg collides with block

### DIFF
--- a/src/main/java/cn/nukkit/entity/projectile/EntityEgg.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntityEgg.java
@@ -2,11 +2,14 @@ package cn.nukkit.entity.projectile;
 
 import cn.nukkit.entity.ClimateVariant;
 import cn.nukkit.entity.Entity;
+import cn.nukkit.entity.data.EntityFlag;
 import cn.nukkit.entity.data.property.EntityProperty;
 import cn.nukkit.entity.data.property.EnumEntityProperty;
 import cn.nukkit.item.ItemEgg;
+import cn.nukkit.level.Position;
 import cn.nukkit.level.format.IChunk;
 import cn.nukkit.level.particle.ItemBreakParticle;
+import cn.nukkit.math.Vector3;
 import cn.nukkit.nbt.tag.CompoundTag;
 import org.jetbrains.annotations.NotNull;
 
@@ -99,5 +102,36 @@ public class EntityEgg extends EntityProjectile implements ClimateVariant {
     @Override
     public String getOriginalName() {
         return "Egg";
+    }
+
+    @Override
+    protected void onCollideWithBlock(Position position, Vector3 motion) {
+        super.onCollideWithBlock(position, motion);
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        int chicks = 0;
+        if (random.nextInt(8) == 0) {
+            chicks = 1;
+            if (random.nextInt(32) == 0) {
+                chicks = 4;
+            }
+        }
+        if (chicks > 0) {
+            for (int i = 0; i < chicks; i++) {
+                CompoundTag nbt = Entity.getDefaultNBT(
+                        this.add(0, 0.5, 0),
+                        null,
+                        0,
+                        0
+                );
+                String variant = this.getVariant().getName();
+                nbt.putString("variant", variant);
+                Entity entity = Entity.createEntity(Entity.CHICKEN, this.level.getChunk((int)this.x >> 4, (int)this.z >> 4), nbt);
+                if (entity != null) {
+                    entity.setDataFlag(EntityFlag.BABY, true);
+                    entity.setScale(0.5f);
+                    entity.spawnToAll();
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Implements logic in EntityEgg to randomly spawn 1 or 4 baby chickens upon collision with a block, mimicking vanilla egg behavior. Sets the spawned chickens as babies and applies appropriate scale and variant.