### PR TITLE
fix/Custom Name and Persistence

### DIFF
--- a/src/main/java/cn/nukkit/entity/EntityCreature.java
+++ b/src/main/java/cn/nukkit/entity/EntityCreature.java
@@ -38,6 +38,8 @@ public abstract class EntityCreature extends EntityLiving implements EntityNamea
         if (item.hasCustomName()) {
             this.setNameTag(item.getCustomName());
             this.setNameTagVisible(true);
+            this.despawnable = false;
+            this.setPersistent(true);
 
             if (!player.isCreative()) {
                 player.getInventory().removeItem(item);


### PR DESCRIPTION
This PR fixes two issues:

1) Entities with custom name set by label was not being persistent, this was happening because of the route of applyNameTag() was never reaching the onInteract() default on Entity class.
2) Entity NAME data map was overwriting custom names on initEntity()