### PR TITLE
improved terra performance by alot

### DIFF
--- a/src/main/java/cn/nukkit/level/generator/Generator.java
+++ b/src/main/java/cn/nukkit/level/generator/Generator.java
@@ -73,24 +73,32 @@ public abstract class Generator implements BlockID {
         return context.getChunk();
     }
 
+    protected String getEndName(IChunk chunk) {
+        return end.name();
+    }
+
+    protected GenerateStage getStart(ChunkGenerateContext context) {
+        return start;
+    }
+
     public final void asyncGenerate(IChunk chunk) {
-        asyncGenerate(chunk, end.name(), (c) -> {
+        asyncGenerate(chunk, getEndName(chunk), (c) -> {
         });
     }
 
     public final void asyncGenerate(IChunk chunk, Consumer<ChunkGenerateContext> callback) {
-        asyncGenerate(chunk, end.name(), callback);
+        asyncGenerate(chunk, getEndName(chunk), callback);
     }
 
     public final void asyncGenerate(IChunk chunk, String to, Consumer<ChunkGenerateContext> callback) {
         Preconditions.checkNotNull(to);
         final ChunkGenerateContext context = new ChunkGenerateContext(this, level, chunk);
         chunk.setChunkState(ChunkState.STARTED);
-        asyncGenerate0(context, start, to, () -> callback.accept(context));
+        asyncGenerate0(context, getStart(context), to, () -> callback.accept(context));
     }
 
 
-    private void asyncGenerate0(final ChunkGenerateContext context, final GenerateStage start, String to, final Runnable callback) {
+    protected final void asyncGenerate0(final ChunkGenerateContext context, final GenerateStage start, String to, final Runnable callback) {
         if (start == null || to == null) {
             callback.run();
             return;

--- a/src/main/java/cn/nukkit/level/generator/PopulatedGenerator.java
+++ b/src/main/java/cn/nukkit/level/generator/PopulatedGenerator.java
@@ -1,0 +1,47 @@
+package cn.nukkit.level.generator;
+
+import cn.nukkit.level.DimensionData;
+import cn.nukkit.level.format.ChunkState;
+import cn.nukkit.level.format.IChunk;
+
+import java.util.Map;
+
+public abstract class PopulatedGenerator extends Generator {
+
+    private GenerateStage startPopulateStage;
+
+    public PopulatedGenerator(DimensionData dimensionData, Map<String, Object> options) {
+        super(dimensionData, options);
+    }
+
+    public abstract String getLastTerrainStage();
+
+    @Override
+    protected String getEndName(IChunk chunk) {
+        return chunk.getChunkState().ordinal() >= ChunkState.GENERATED.ordinal() ||
+                level.getChunkLoaders(chunk.getX(), chunk.getZ()).length != 0 ? end.name() : getLastTerrainStage();
+    }
+
+    @Override
+    protected GenerateStage getStart(ChunkGenerateContext context) {
+        ChunkState state = context.getChunk().getChunkState();
+        if(state.ordinal() >= ChunkState.GENERATED.ordinal()) {
+            return getStartPopulateStage();
+        }
+        return super.getStart(context);
+    }
+
+    protected GenerateStage getStartPopulateStage() {
+        if(startPopulateStage == null) {
+            GenerateStage stage = start;
+            while((stage = stage.getNextStage()) != null && !stage.name().equals(getLastTerrainStage()));
+            startPopulateStage = stage;
+        }
+        return startPopulateStage;
+    }
+
+    protected void asyncPopulate(IChunk chunk) {
+        final ChunkGenerateContext context = new ChunkGenerateContext(this, level, chunk);
+        asyncGenerate0(context, getStartPopulateStage(), end.name(), () -> {});
+    }
+}

--- a/src/main/java/cn/nukkit/level/generator/terra/delegate/PNXServerWorld.java
+++ b/src/main/java/cn/nukkit/level/generator/terra/delegate/PNXServerWorld.java
@@ -1,8 +1,12 @@
 package cn.nukkit.level.generator.terra.delegate;
 
+import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockID;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.Position;
+import cn.nukkit.level.format.ChunkState;
+import cn.nukkit.level.format.IChunk;
+import cn.nukkit.level.generator.object.BlockManager;
 import cn.nukkit.level.generator.terra.PNXAdapter;
 import cn.nukkit.level.generator.terra.TerraGenerator;
 import cn.nukkit.math.BlockVector3;
@@ -18,42 +22,75 @@ import com.dfsek.terra.api.world.chunk.generation.ChunkGenerator;
 
 import java.util.Objects;
 
-public record PNXServerWorld(TerraGenerator generatorWrapper, Level level) implements ServerWorld {
+public class PNXServerWorld implements ServerWorld {
+
+    private final TerraGenerator generatorWrapper;
+    private final BlockManager level;
+
+    public PNXServerWorld(TerraGenerator generatorWrapper, Level level) {
+        this.generatorWrapper = generatorWrapper;
+        this.level = new BlockManager(level);
+    }
+
+    public TerraGenerator generatorWrapper() {
+        return generatorWrapper;
+    }
+
+    public Level level() {
+        return level.getLevel();
+    }
+
+    public void apply(IChunk chunk) {
+        for(Block b : level.getBlocks()) {
+            if(b.getChunk() != chunk) {
+                level.getChunk(b.getChunkX(), b.getChunkZ());
+            }
+        }
+        level.applySubChunkUpdate();
+    }
 
     @Override
-    public void setBlockState(int i, int i1, int i2, BlockState blockState, boolean b) {
+    public void setBlockState(int x, int y, int z, BlockState blockState, boolean b) {
         var innerBlockState = ((PNXBlockStateDelegate) blockState).innerBlockState();
+
         if (Objects.equals(innerBlockState.getIdentifier(), BlockID.KELP)) {
-            level.setBlockStateAt(i, i1, i2, innerBlockState);
-            level.setBlockStateAt(i, i1, i2, 1, PNXProtoChunk.water);
+            level.setBlockStateAt(x, y, z, innerBlockState);
+            level.setBlockStateAt(x, y, z, 1, PNXProtoChunk.water);
+            return;
+        }
+
+        var ob = level.getBlockAt(x, y, z);
+        if (Objects.equals(ob.getId(), BlockID.WATERLILY)
+                || Objects.equals(ob.getId(), BlockID.WATER)
+                || Objects.equals(ob.getId(), BlockID.FLOWING_WATER)) {
+
+            level.setBlockStateAt(x, y, z, innerBlockState);
+            level.setBlockStateAt(x, y, z, 1, PNXProtoChunk.water);
         } else {
-            var ob = level.getBlockStateAt(i, i1, i2);
-            if (Objects.equals(ob.getIdentifier(), BlockID.WATERLILY) ||
-                    Objects.equals(ob.getIdentifier(), BlockID.WATER) ||
-                    Objects.equals(ob.getIdentifier(), BlockID.FLOWING_WATER)) {
-                level.setBlockStateAt(i, i1, i2, innerBlockState);
-                level.setBlockStateAt(i, i1, i2, 1, PNXProtoChunk.water);
-            } else {
-                level.setBlockStateAt(i, i1, i2, innerBlockState);
-            }
+            level.setBlockStateAt(x, y, z, innerBlockState);
         }
     }
 
     @Override
-    public Entity spawnEntity(double v, double v1, double v2, EntityType entityType) {
+    public Entity spawnEntity(double x, double y, double z, EntityType entityType) {
         String identifier = (String) entityType.getHandle();
-        cn.nukkit.entity.Entity nukkitEntity = cn.nukkit.entity.Entity.createEntity(identifier, new Position(v, v1, v2, level));
+        cn.nukkit.entity.Entity nukkitEntity =
+                cn.nukkit.entity.Entity.createEntity(
+                        identifier,
+                        new Position(x, y, z, level.getLevel())
+                );
         return new PNXEntity(nukkitEntity, this);
     }
 
     @Override
-    public BlockState getBlockState(int i, int i1, int i2) {
-        return PNXAdapter.adapt(level.getBlockStateAt(i, i1, i2));
+    public BlockState getBlockState(int x, int y, int z) {
+        return PNXAdapter.adapt(level.getBlockAt(x, y, z).getBlockState());
     }
 
     @Override
-    public BlockEntity getBlockEntity(int i, int i1, int i2) {
-        cn.nukkit.blockentity.BlockEntity blockEntity = level.getBlockEntity(new BlockVector3(i, i1, i2));
+    public BlockEntity getBlockEntity(int x, int y, int z) {
+        cn.nukkit.blockentity.BlockEntity blockEntity =
+                level.getLevel().getBlockEntity(new BlockVector3(x, y, z));
         return null;
     }
 
@@ -89,11 +126,11 @@ public record PNXServerWorld(TerraGenerator generatorWrapper, Level level) imple
 
     @Override
     public Level getHandle() {
-        return level;
+        return level.getLevel();
     }
 
     @Override
-    public Chunk getChunkAt(int i, int i1) {
-        return new PNXChunkDelegate(this, level.getChunk(i, i1));
+    public Chunk getChunkAt(int x, int z) {
+        return new PNXChunkDelegate(this, level.getChunk(x, z));
     }
 }


### PR DESCRIPTION
Trees and other populators often span multiple chunks. Instead of generating entire chunks—which in turn may trigger the generation of additional chunks—we can now generate only the terrain. For example, when generating a tree, only the terrain of the overlapping chunks is generated. Those chunks will be populated only once they are actually loaded by a player.

This will be applied to the default generator at some point too.