### PR TITLE
Mace Smash Effect Improvements

### DIFF
--- a/src/main/java/cn/nukkit/item/ItemMace.java
+++ b/src/main/java/cn/nukkit/item/ItemMace.java
@@ -1,12 +1,11 @@
 package cn.nukkit.item;
 
-import cn.nukkit.block.Block;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.Sound;
-import cn.nukkit.level.particle.DestroyBlockParticle;
 import cn.nukkit.math.NukkitMath;
 import cn.nukkit.math.Vector3;
+import cn.nukkit.network.protocol.LevelEventPacket;
 
 public class ItemMace extends ItemTool {
     public ItemMace() {
@@ -31,34 +30,20 @@ public class ItemMace extends ItemTool {
         }
 
         entity.resetFallDistance();
+        return damage;
+    }
 
+    public void onPostAttack(Entity victim, float damage) {
         if (damage >= 7) {
-            Level entityLevel = entity.getLevel();
-            Vector3 pos = entity.getPosition();
+            Level level = victim.getLevel();
+            Vector3 pos = victim.getPosition();
 
-            int x = pos.getFloorX();
-            int y = pos.getFloorY() - 1;
-            int z = pos.getFloorZ();
-
-            Block underBlock = entityLevel.getBlock(x, y, z);
-            while (underBlock.isAir()) {
-                y--;
-                underBlock = entityLevel.getBlock(x, y, z);
-            }
-
-            for (int ox = -1; ox <= 1; ox++) {
-                for (int oz = -1; oz <= 1; oz++) {
-                    Vector3 particlePos = pos.add(0.5 + ox, 0.1, 0.5 + oz);
-                    entityLevel.addParticle(new DestroyBlockParticle(particlePos, underBlock));
-                }
-            }
-
+            level.addLevelEvent(LevelEventPacket.EVENT_PARTICLE_SMASH_ATTACK_GROUND_DUST, 0, pos);
             if (damage >= 16) {
-                entityLevel.addSound(pos, Sound.MACE_HEAVY_SMASH_GROUND);
+                level.addSound(pos, Sound.MACE_HEAVY_SMASH_GROUND);
             } else {
-                entityLevel.addSound(pos, Sound.MACE_SMASH_GROUND);
+                level.addSound(pos, Sound.MACE_SMASH_GROUND);
             }
         }
-        return damage;
     }
 }

--- a/src/main/java/cn/nukkit/network/process/processor/InventoryTransactionProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/InventoryTransactionProcessor.java
@@ -18,6 +18,7 @@ import cn.nukkit.event.player.*;
 import cn.nukkit.inventory.HumanInventory;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBlock;
+import cn.nukkit.item.ItemMace;
 import cn.nukkit.item.ItemSpear;
 import cn.nukkit.item.enchantment.Enchantment;
 import cn.nukkit.level.GameRule;
@@ -248,6 +249,9 @@ public class InventoryTransactionProcessor extends DataPacketProcessor<Inventory
                     if (target instanceof EntityLiving living) {
                         living.postAttack(player);
                     }
+                }
+                if (item instanceof ItemMace mace) {
+                    mace.onPostAttack(target, itemDamage);
                 }
                 if (item.isTool() && (player.isSurvival() || player.isAdventure())) {
                     if (item.useOn(target) && item.getDamage() >= item.getMaxDurability()) {


### PR DESCRIPTION
While checking out PNX, I noticed the particles used for mace smash attacks were implemented incorrectly.

# Changes
- Use the correct LevelEventPacket rather than DestroyBlockParticle.
- Introduce `ItemMace.onPostAttack` to use the victims position for the smash effect.

# Test Showcase
https://streamable.com/9yqjcv



