### PR TITLE
fix: Entity data flags

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -745,7 +745,25 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
     }
 
     public void setSneaking(boolean value) {
-        this.setDataFlag(EntityFlag.SNEAKING, value);
+        boolean changed = this.getEntityDataMap().existFlag(EntityFlag.SNEAKING) ^ value;
+
+        if (changed) {
+            this.getEntityDataMap().setFlag(EntityFlag.SNEAKING, value);
+        }
+
+        recalculateBoundingBox(false);
+        float newHeight = this.getEntityDataMap().getOrDefault(EntityDataTypes.HEIGHT, getCurrentHeight());
+
+        if (changed) {
+            EntityDataMap delta = new EntityDataMap();
+            delta.put(EntityDataTypes.FLAGS, this.getEntityDataMap().getFlags());
+            delta.putType(EntityDataTypes.HEIGHT, newHeight);
+            sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), delta);
+        } else {
+            EntityDataMap delta = new EntityDataMap();
+            delta.putType(EntityDataTypes.HEIGHT, newHeight);
+            sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), delta);
+        }
     }
 
     public boolean isSwimming() {
@@ -3184,17 +3202,40 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
     public void setDataFlag(EntityFlag entityFlag, boolean value, boolean send) {
         if (this.getEntityDataMap().existFlag(entityFlag) ^ value) {
             this.getEntityDataMap().setFlag(entityFlag, value);
-            if(send) {
+
+            if (send) {
                 EntityDataMap entityDataMap = new EntityDataMap();
-                entityDataMap.put(EntityDataTypes.FLAGS, this.getEntityDataMap().getFlags());
+
+                if (entityFlag.getValue() >= 64) {
+                    entityDataMap.put(EntityDataTypes.FLAGS_2, this.getEntityDataMap().getFlags2());
+                } else {
+                    entityDataMap.put(EntityDataTypes.FLAGS, this.getEntityDataMap().getFlags());
+                }
+
                 sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), entityDataMap);
             }
         }
     }
 
     public void setDataFlags(EnumSet<EntityFlag> entityFlags) {
-        this.getEntityDataMap().put(FLAGS, entityFlags);
-        sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), entityDataMap);
+        // split the incoming set into FLAGS and FLAGS_2 in the backing map
+        this.getEntityDataMap().putFlags(entityFlags);
+
+        // send both lanes (only if non-empty)
+        EnumSet<EntityFlag> f0 = this.getEntityDataMap().getFlags();
+        EnumSet<EntityFlag> f1 = this.getEntityDataMap().getFlags2();
+
+        if (f0 != null && !f0.isEmpty()) {
+            EntityDataMap d0 = new EntityDataMap();
+            d0.put(EntityDataTypes.FLAGS, f0);
+            sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), d0);
+        }
+
+        if (f1 != null && !f1.isEmpty()) {
+            EntityDataMap d1 = new EntityDataMap();
+            d1.put(EntityDataTypes.FLAGS_2, f1);
+            sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), d1);
+        }
     }
 
     public void setDataFlagExtend(EntityFlag entityFlag) {
@@ -3206,14 +3247,19 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
     }
 
     public void setDataFlagExtend(EntityFlag entityFlag, boolean value, boolean send) {
+        if (entityFlag.getValue() < 64) {
+            this.setDataFlag(entityFlag, value, send);
+            return;
+        }
+
         if (this.getEntityDataMap().existFlag(entityFlag) ^ value) {
-            EnumSet<EntityFlag> entityFlags = this.getEntityDataMap().getOrDefault(EntityDataTypes.FLAGS_2, EnumSet.noneOf(EntityFlag.class));
+            EnumSet<EntityFlag> entityFlags = this.getEntityDataMap().getOrCreateFlags2();
             if (value) {
                 entityFlags.add(entityFlag);
             } else {
                 entityFlags.remove(entityFlag);
             }
-            this.getEntityDataMap().put(EntityDataTypes.FLAGS_2, entityFlags);
+
             if(send) {
                 EntityDataMap entityDataMap = new EntityDataMap();
                 entityDataMap.put(EntityDataTypes.FLAGS_2, entityFlags);
@@ -3228,7 +3274,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
     }
 
     public boolean getDataFlag(EntityFlag id) {
-        return this.getEntityDataMap().getOrCreateFlags().contains(id);
+        return this.getEntityDataMap().existFlag(id);
     }
 
     public void setPlayerFlag(PlayerFlag entityFlag) {

--- a/src/main/java/cn/nukkit/entity/EntityLiving.java
+++ b/src/main/java/cn/nukkit/entity/EntityLiving.java
@@ -7,6 +7,8 @@ import cn.nukkit.block.BlockCactus;
 import cn.nukkit.block.BlockMagma;
 import cn.nukkit.entity.custom.CustomEntityComponents;
 import cn.nukkit.entity.custom.CustomEntityDefinition.Meta;
+import cn.nukkit.entity.data.EntityDataMap;
+import cn.nukkit.entity.data.EntityDataTypes;
 import cn.nukkit.entity.data.EntityFlag;
 import cn.nukkit.entity.effect.Effect;
 import cn.nukkit.entity.effect.EffectType;
@@ -39,6 +41,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -643,8 +646,29 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
     }
 
     public void setBlocking(boolean value) {
-        this.setDataFlagExtend(EntityFlag.BLOCKING, value, false);
-        this.setDataFlagExtend(EntityFlag.TRANSITION_BLOCKING, value, true);
+        EnumSet<EntityFlag> ext = this.getEntityDataMap().getOrCreateFlags2();
+
+        boolean changed;
+        if (value) {
+            changed = ext.add(EntityFlag.BLOCKING);
+        } else {
+            changed = ext.remove(EntityFlag.BLOCKING);
+        }
+
+        if (!changed) return;
+
+        this.getEntityDataMap().put(EntityDataTypes.FLAGS_2, ext);
+
+        EnumSet<EntityFlag> wire = EnumSet.copyOf(ext);
+        if (value) {
+            wire.add(EntityFlag.TRANSITION_BLOCKING);
+        } else {
+            wire.remove(EntityFlag.TRANSITION_BLOCKING);
+        }
+
+        EntityDataMap delta = new EntityDataMap();
+        delta.put(EntityDataTypes.FLAGS_2, wire);
+        sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), delta);
     }
 
     @Override


### PR DESCRIPTION
fix: This reintroduces the fix of #2081 reverted due to WDPE bugs on #2118

The fix was done to separate storage for FLAGS and FLAGS_2 in EntityDataMap, route high-bit flags (≥64) to FLAGS_2.
That would address some weird bugs like horses flying and others that was not yet identified that is directly related to flags updates.