### PR TITLE
feat: Custom network interfaces

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -22,6 +22,7 @@ import cn.nukkit.entity.data.property.EntityProperty;
 import cn.nukkit.event.HandlerList;
 import cn.nukkit.event.level.LevelInitEvent;
 import cn.nukkit.event.level.LevelLoadEvent;
+import cn.nukkit.event.network.NetworkRegisterEvent;
 import cn.nukkit.event.player.PlayerLoginEvent;
 import cn.nukkit.event.server.QueryRegenerateEvent;
 import cn.nukkit.event.server.ServerReloadEvent;
@@ -63,6 +64,7 @@ import cn.nukkit.nbt.tag.ShortTag;
 import cn.nukkit.nbt.tag.StringTag;
 import cn.nukkit.nbt.tag.Tag;
 import cn.nukkit.network.Network;
+import cn.nukkit.network.NetworkInterface;
 import cn.nukkit.network.process.NetworkState;
 import cn.nukkit.network.protocol.DataPacket;
 import cn.nukkit.network.protocol.PlayerListPacket;
@@ -207,7 +209,7 @@ public class Server {
     private EntityMetadataStore entityMetadata;
     private PlayerMetadataStore playerMetadata;
     private LevelMetadataStore levelMetadata;
-    private Network network;
+    private NetworkInterface network;
     private int serverAuthoritativeMovementMode = 0;
     private int defaultGamemode = Integer.MAX_VALUE;
     private int autoSaveTicker = 0;
@@ -553,7 +555,6 @@ public class Server {
         loadLevels();
 
         this.queryRegenerateEvent = new QueryRegenerateEvent(this, 5);
-        this.network = new Network(this);
         this.getTickingAreaManager().loadAllTickingArea();
 
         if (this.getDefaultLevel() == null) {
@@ -566,6 +567,15 @@ public class Server {
         this.autoSaveTicks = settings.baseSettings().autosaveDelay();
 
         this.enablePlugins(PluginLoadOrder.POSTWORLD);
+
+        NetworkRegisterEvent networkRegisterEvent = new NetworkRegisterEvent(new Network(this));
+        this.pluginManager.callEvent(networkRegisterEvent);
+
+        NetworkInterface networkInterface = networkRegisterEvent.getNetworkInterface();
+
+        this.getLogger().debug("Registering network interface: " + networkInterface.getClass().getCanonicalName());
+        this.network = networkInterface;
+
         EntityProperty.buildEntityProperty();
         EntityProperty.buildPlayerProperty();
 
@@ -1386,7 +1396,7 @@ public class Server {
         return this.queryRegenerateEvent;
     }
 
-    public Network getNetwork() {
+    public NetworkInterface getNetwork() {
         return network;
     }
 

--- a/src/main/java/cn/nukkit/compression/ZlibChooser.java
+++ b/src/main/java/cn/nukkit/compression/ZlibChooser.java
@@ -55,7 +55,7 @@ public final class ZlibChooser {
             log.warn(lang.tr("nukkit.zlib.affect-performance"));
         }
         provider = providers[providerIndex];
-        log.info("{}: {} ({})", lang.tr("nukkit.zlib.selected"), providerIndex, provider.getClass().getCanonicalName());
+        log.info("{}: {} ({})", lang.tr("nukkit.zlib.selected"), providerIndex, provider.getClass().getSimpleName());
     }
 
     public static ZlibProvider getCurrentProvider() {

--- a/src/main/java/cn/nukkit/event/network/NetworkEvent.java
+++ b/src/main/java/cn/nukkit/event/network/NetworkEvent.java
@@ -1,0 +1,10 @@
+package cn.nukkit.event.network;
+
+import cn.nukkit.event.Event;
+
+/**
+ * @author xRookieFight
+ * @since 20/02/2026
+ */
+public abstract class NetworkEvent extends Event {
+}

--- a/src/main/java/cn/nukkit/event/network/NetworkRegisterEvent.java
+++ b/src/main/java/cn/nukkit/event/network/NetworkRegisterEvent.java
@@ -1,0 +1,26 @@
+package cn.nukkit.event.network;
+
+import cn.nukkit.event.HandlerList;
+import cn.nukkit.network.NetworkInterface;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Triggers before the network class is registered.
+ * @author xRookieFight
+ * @since 20/02/2026
+ */
+@Getter
+@Setter
+public class NetworkRegisterEvent extends NetworkEvent {
+    private static final HandlerList handlers = new HandlerList();
+    public static HandlerList getHandlers() {
+        return handlers;
+    }
+
+    private NetworkInterface networkInterface;
+
+    public NetworkRegisterEvent(NetworkInterface networkInterface) {
+        this.networkInterface = networkInterface;
+    }
+}

--- a/src/main/java/cn/nukkit/network/Network.java
+++ b/src/main/java/cn/nukkit/network/Network.java
@@ -55,7 +55,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * @author MagicDroidX (Nukkit Project)
  */
 @Slf4j
-public class Network {
+public class Network implements NetworkInterface {
     private final Server server;
     private final LinkedList<NetWorkStatisticData> netWorkStatisticDataList = new LinkedList<>();
     private final AtomicReference<List<NetworkIF>> hardWareNetworkInterfaces = new AtomicReference<>(null);

--- a/src/main/java/cn/nukkit/network/NetworkInterface.java
+++ b/src/main/java/cn/nukkit/network/NetworkInterface.java
@@ -1,0 +1,61 @@
+package cn.nukkit.network;
+
+import cn.nukkit.Player;
+import cn.nukkit.Server;
+import cn.nukkit.network.connection.BedrockPong;
+import cn.nukkit.network.connection.BedrockSession;
+import cn.nukkit.network.process.NetworkState;
+import oshi.hardware.NetworkIF;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.List;
+
+/**
+ * Interfaces for network classes
+ *
+ * @see cn.nukkit.event.network.NetworkRegisterEvent
+ * @since 20/02/2026
+ */
+public interface NetworkInterface {
+
+    NetworkState getState();
+
+    void setState(NetworkState state);
+
+    void shutdown();
+
+    double getUpload();
+
+    double getDownload();
+
+    void resetStatistics();
+
+    void process();
+
+    void processInterfaces();
+
+    Server getServer();
+
+    @Nullable
+    List<NetworkIF> getHardWareNetworkInterfaces();
+
+    BedrockSession getSession(InetSocketAddress address);
+
+    void replaceSessionAddress(InetSocketAddress oldAddress, InetSocketAddress newAddress, BedrockSession newSession);
+
+    void onSessionDisconnect(InetSocketAddress address);
+
+    int getNetworkLatency(Player player);
+
+    void blockAddress(InetAddress address);
+
+    void blockAddress(InetAddress address, int timeout);
+
+    void unblockAddress(InetAddress address);
+
+    boolean isAddressBlocked(InetSocketAddress address);
+
+    BedrockPong getPong();
+}

--- a/src/main/java/cn/nukkit/network/connection/BedrockPong.java
+++ b/src/main/java/cn/nukkit/network/connection/BedrockPong.java
@@ -1,6 +1,6 @@
 package cn.nukkit.network.connection;
 
-import cn.nukkit.network.Network;
+import cn.nukkit.network.NetworkInterface;
 import cn.nukkit.network.process.NetworkState;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -61,8 +61,7 @@ public class BedrockPong {
      *
      * @param network the network instance to check state
      */
-    public void update(Network network) {
-        // Defensive checks
+    public void update(NetworkInterface network) {
         if (network == null) {
             return;
         }
@@ -72,7 +71,7 @@ public class BedrockPong {
         if (network.getState() == NetworkState.STARTING || network.getState() == NetworkState.STOPPING) {
             return;
         }
-        // Update advertisement
+
         channel.config().setAdvertisement(this.toByteBuf());
     }
 }


### PR DESCRIPTION
## Changes
### API Changes
- Added a new event `NetworkRegisterEvent`. You can change the network interface and make your custom interfaces with `setNetworkInterface()`. Please note that your custom interface should implement `NetworkInterface`

### Misc Changes
- Removed logging full class name in `ZLibChooser`. Now it logs the simple name of class.