### PR TITLE
Enforce Rak Protocol Version 11

### DIFF
--- a/src/main/java/cn/nukkit/network/Network.java
+++ b/src/main/java/cn/nukkit/network/Network.java
@@ -112,6 +112,8 @@ public class Network implements NetworkInterface {
         this.channel = (RakServerChannel) new ServerBootstrap()
                 .channelFactory(RakChannelFactory.server(oclass))
                 .option(RakChannelOption.RAK_ADVERTISEMENT, getAdvertisement())
+                .option(RakChannelOption.RAK_PROTOCOL_VERSION, 11)
+                .option(RakChannelOption.RAK_SUPPORTED_PROTOCOLS, new int[] {11})
                 .option(RakChannelOption.RAK_PACKET_LIMIT, server.getSettings().networkSettings().packetLimit())
                 .option(RakChannelOption.RAK_SERVER_COOKIE_MODE, RakServerCookieMode.ACTIVE)
                 .group(eventloopgroup)

--- a/src/main/java/cn/nukkit/network/connection/BedrockPeer.java
+++ b/src/main/java/cn/nukkit/network/connection/BedrockPeer.java
@@ -167,7 +167,7 @@ public class BedrockPeer extends ChannelInboundHandlerAdapter {
 
     public void setCompression(PacketCompressionAlgorithm algorithm) {
         Objects.requireNonNull(algorithm, "algorithm");
-        this.setCompression(BedrockChannelInitializer.getCompression(algorithm, this.getRakVersion(), false));
+        this.setCompression(BedrockChannelInitializer.getCompression(algorithm, false));
     }
 
     public void setCompression(CompressionStrategy strategy) {
@@ -242,10 +242,6 @@ public class BedrockPeer extends ChannelInboundHandlerAdapter {
 
     public Channel getChannel() {
         return this.channel;
-    }
-
-    public int getRakVersion() {
-        return this.channel.config().getOption(RakChannelOption.RAK_PROTOCOL_VERSION);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/network/connection/netty/initializer/BedrockChannelInitializer.java
+++ b/src/main/java/cn/nukkit/network/connection/netty/initializer/BedrockChannelInitializer.java
@@ -35,7 +35,7 @@ public abstract class BedrockChannelInitializer<T extends BedrockSession> extend
     private static final CompressionStrategy NOOP_STRATEGY = new SimpleCompressionStrategy(new NoopCompression());
 
     @Override
-    protected final void initChannel(Channel channel) throws Exception {
+    protected final void initChannel(Channel channel) {
         // Decode
         // RAKNET_FRAME_CODEC -> CompressionCodec -> BATCH_DECODER ->  BedrockPacketCodec -> BedrockPeer
         // Encode
@@ -56,20 +56,13 @@ public abstract class BedrockChannelInitializer<T extends BedrockSession> extend
     protected void preInitChannel(Channel channel) {
         channel.pipeline().addLast(FrameIdCodec.NAME, RAKNET_FRAME_CODEC);
 
-        int rakVersion = channel.config().getOption(RakChannelOption.RAK_PROTOCOL_VERSION);
-
-        CompressionStrategy compression = getCompression(PacketCompressionAlgorithm.ZLIB, rakVersion, true);
+        CompressionStrategy compression = getCompression(PacketCompressionAlgorithm.ZLIB, true);
         // At this point all connections use not prefixed compression
         channel.pipeline().addLast(CompressionCodec.NAME, new CompressionCodec(compression, false));
     }
 
-    public static CompressionStrategy getCompression(CompressionAlgorithm algorithm, int rakVersion, boolean initial) {
-        return switch (rakVersion) {
-            case 7, 8, 9 -> ZLIB_STRATEGY;
-            case 10 -> ZLIB_RAW_STRATEGY;
-            case 11 -> initial ? NOOP_STRATEGY : getCompression(algorithm);
-            default -> throw new UnsupportedOperationException("Unsupported RakNet protocol version: " + rakVersion);
-        };
+    public static CompressionStrategy getCompression(CompressionAlgorithm algorithm,boolean initial) {
+        return initial ? NOOP_STRATEGY : getCompression(algorithm);
     }
 
     private static CompressionStrategy getCompression(CompressionAlgorithm algorithm) {
@@ -82,27 +75,11 @@ public abstract class BedrockChannelInitializer<T extends BedrockSession> extend
         };
     }
 
-    protected void postInitChannel(Channel channel) throws Exception {
+    protected void postInitChannel(Channel channel) {
     }
 
-    protected void initPacketCodec(Channel channel) throws Exception {
-        int rakVersion = channel.config().getOption(RakChannelOption.RAK_PROTOCOL_VERSION);
-
-        switch (rakVersion) {
-            case 11:
-            case 10:
-            case 9: // Merged & Varint-ified
-                channel.pipeline().addLast(BedrockPacketCodec.NAME, new BedrockPacketCodec_v3());
-                break;
-            case 8: // Split-screen support
-                channel.pipeline().addLast(BedrockPacketCodec.NAME, new BedrockPacketCodec_v2());
-                break;
-            case 7: // Single byte packet ID
-                channel.pipeline().addLast(BedrockPacketCodec.NAME, new BedrockPacketCodec_v1());
-                break;
-            default:
-                throw new UnsupportedOperationException("Unsupported RakNet protocol version: " + rakVersion);
-        }
+    protected void initPacketCodec(Channel channel) {
+        channel.pipeline().addLast(BedrockPacketCodec.NAME, new BedrockPacketCodec_v3());
     }
 
     protected BedrockPeer createPeer(Channel channel) {


### PR DESCRIPTION
Rak Protocol Version 11 is in use since at least 1.19.30 (according to cloudburst protocol)
Other protocol versions are not in use anymore.