### PR TITLE
feat: Silent Container Interaction

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockChest.java
+++ b/src/main/java/cn/nukkit/block/BlockChest.java
@@ -6,6 +6,7 @@ import cn.nukkit.block.property.CommonPropertyMap;
 import cn.nukkit.block.property.enums.MinecraftCardinalDirection;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.blockentity.BlockEntityChest;
+import cn.nukkit.entity.data.EntityFlag;
 import cn.nukkit.inventory.ContainerInventory;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBlock;
@@ -217,8 +218,8 @@ public class BlockChest extends BlockTransparent implements Faceable, BlockEntit
         Item itemInHand = player.getInventory().getItemInHand();
         if (player.isSneaking() && !(itemInHand.isTool() || itemInHand.isNull())) return false;
 
-        // Check itself if can be opened
-        if (!this.hasFreeSpaceAbove()) {
+        // Check if the chest can be opened - bypass for SILENT
+        if (!player.getDataFlag(EntityFlag.SILENT) && !this.hasFreeSpaceAbove()) {
             return false;
         }
 

--- a/src/main/java/cn/nukkit/inventory/BarrelInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BarrelInventory.java
@@ -34,7 +34,7 @@ public class BarrelInventory extends ContainerInventory implements BlockEntityIn
     public void onOpen(Player who) {
         super.onOpen(who);
 
-        if (this.getViewers().size() == 1) {
+        if (this.getVisibleViewersCount() == 1) {
             BlockEntityBarrel barrel = this.getHolder();
             Level level = barrel.getLevel();
             if (level != null) {
@@ -52,9 +52,7 @@ public class BarrelInventory extends ContainerInventory implements BlockEntityIn
 
     @Override
     public void onClose(Player who) {
-        super.onClose(who);
-
-        if (this.getViewers().isEmpty()) {
+        if (this.getVisibleViewersCount() == 1) {
             BlockEntityBarrel barrel = this.getHolder();
             Level level = barrel.getLevel();
             if (level != null) {
@@ -68,6 +66,8 @@ public class BarrelInventory extends ContainerInventory implements BlockEntityIn
                 }
             }
         }
+
+        super.onClose(who);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/inventory/BaseInventory.java
+++ b/src/main/java/cn/nukkit/inventory/BaseInventory.java
@@ -4,6 +4,7 @@ import cn.nukkit.Player;
 import cn.nukkit.Server;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.entity.Entity;
+import cn.nukkit.entity.data.EntityFlag;
 import cn.nukkit.event.entity.EntityInventoryChangeEvent;
 import cn.nukkit.event.inventory.InventoryCloseEvent;
 import cn.nukkit.event.inventory.InventoryOpenEvent;
@@ -424,6 +425,12 @@ public abstract class BaseInventory implements Inventory {
     @Override
     public Set<Player> getViewers() {
         return viewers;
+    }
+
+    public long getVisibleViewersCount() {
+        return this.getViewers().stream()
+                .filter(v -> !v.getDataFlag(EntityFlag.SILENT))
+                .count();
     }
 
     @Override

--- a/src/main/java/cn/nukkit/inventory/ChestInventory.java
+++ b/src/main/java/cn/nukkit/inventory/ChestInventory.java
@@ -4,6 +4,7 @@ import cn.nukkit.Player;
 import cn.nukkit.block.BlockTrappedChest;
 import cn.nukkit.blockentity.BlockEntityChest;
 import cn.nukkit.blockentity.BlockEntityNameable;
+import cn.nukkit.entity.data.EntityFlag;
 import cn.nukkit.event.redstone.RedstoneUpdateEvent;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.Sound;
@@ -54,7 +55,11 @@ public class ChestInventory extends ContainerInventory implements BlockEntityInv
     public void onOpen(Player who) {
         super.onOpen(who);
 
-        if (this.getViewers().size() == 1) {
+        if (who.getDataFlag(EntityFlag.SILENT)) {
+            return;
+        }
+
+        if (this.getVisibleViewersCount() == 1) {
             BlockEventPacket pk = new BlockEventPacket();
             pk.x = (int) this.getHolder().getX();
             pk.y = (int) this.getHolder().getY();
@@ -82,7 +87,7 @@ public class ChestInventory extends ContainerInventory implements BlockEntityInv
 
     @Override
     public void onClose(Player who) {
-        if (this.getViewers().size() == 1) {
+        if (this.getVisibleViewersCount() == 1) {
             BlockEventPacket pk = new BlockEventPacket();
             pk.x = (int) this.getHolder().getX();
             pk.y = (int) this.getHolder().getY();

--- a/src/main/java/cn/nukkit/inventory/DoubleChestInventory.java
+++ b/src/main/java/cn/nukkit/inventory/DoubleChestInventory.java
@@ -123,7 +123,7 @@ public class DoubleChestInventory extends ContainerInventory {
         this.left.viewers.add(who);
         this.right.viewers.add(who);
 
-        if (this.getViewers().size() == 1) {
+        if (this.getVisibleViewersCount() == 1) {
             BlockEventPacket pk1 = new BlockEventPacket();
             pk1.x = (int) this.left.getHolder().getX();
             pk1.y = (int) this.left.getHolder().getY();
@@ -153,7 +153,7 @@ public class DoubleChestInventory extends ContainerInventory {
 
     @Override
     public void onClose(Player who) {
-        if (this.getViewers().size() == 1) {
+        if (this.getVisibleViewersCount() == 1) {
             BlockEventPacket pk1 = new BlockEventPacket();
             pk1.x = (int) this.right.getHolder().getX();
             pk1.y = (int) this.right.getHolder().getY();

--- a/src/main/java/cn/nukkit/inventory/ShulkerBoxInventory.java
+++ b/src/main/java/cn/nukkit/inventory/ShulkerBoxInventory.java
@@ -36,7 +36,7 @@ public class ShulkerBoxInventory extends ContainerInventory {
     public void onOpen(Player who) {
         super.onOpen(who);
 
-        if (this.getViewers().size() == 1) {
+        if (this.getVisibleViewersCount() == 1) {
             BlockEventPacket pk = new BlockEventPacket();
             pk.x = (int) this.getHolder().getX();
             pk.y = (int) this.getHolder().getY();
@@ -54,7 +54,7 @@ public class ShulkerBoxInventory extends ContainerInventory {
 
     @Override
     public void onClose(Player who) {
-        if (this.getViewers().size() == 1) {
+        if (this.getVisibleViewersCount() == 1) {
             BlockEventPacket pk = new BlockEventPacket();
             pk.x = (int) this.getHolder().getX();
             pk.y = (int) this.getHolder().getY();

--- a/src/main/java/cn/nukkit/network/process/processor/InventoryTransactionProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/InventoryTransactionProcessor.java
@@ -3,7 +3,6 @@ package cn.nukkit.network.process.processor;
 import cn.nukkit.AdventureSettings;
 import cn.nukkit.Player;
 import cn.nukkit.PlayerHandle;
-import cn.nukkit.Server;
 import cn.nukkit.block.Block;
 import cn.nukkit.block.BlockID;
 import cn.nukkit.blockentity.BlockEntity;
@@ -16,6 +15,7 @@ import cn.nukkit.event.entity.EntityDamageByEntityEvent;
 import cn.nukkit.event.entity.EntityDamageEvent;
 import cn.nukkit.event.player.*;
 import cn.nukkit.inventory.HumanInventory;
+import cn.nukkit.inventory.InventoryHolder;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemBlock;
 import cn.nukkit.item.ItemMace;
@@ -51,10 +51,6 @@ public class InventoryTransactionProcessor extends DataPacketProcessor<Inventory
     @Override
     public void handle(@NotNull PlayerHandle playerHandle, @NotNull InventoryTransactionPacket pk) {
         Player player = playerHandle.player;
-        if (player.isSpectator()) {
-            player.sendAllInventories();
-            return;
-        }
         if (pk.transactionType == InventoryTransactionPacket.TYPE_USE_ITEM) {
             handleUseItem(playerHandle, pk);
         } else if (pk.transactionType == InventoryTransactionPacket.TYPE_USE_ITEM_ON_ENTITY) {
@@ -79,9 +75,7 @@ public class InventoryTransactionProcessor extends DataPacketProcessor<Inventory
                             player.getInventory().sendContents(player);
                         }
                     }
-                    case InventoryTransactionPacket.RELEASE_ITEM_ACTION_CONSUME -> {
-                        log.debug("Unexpected release item action consume from {}", player.getName());
-                    }
+                    case InventoryTransactionPacket.RELEASE_ITEM_ACTION_CONSUME -> log.debug("Unexpected release item action consume from {}", player.getName());
                 }
             } finally {
                 player.removeLastUseTick(releaseItemData.itemInHand.getId());
@@ -150,7 +144,7 @@ public class InventoryTransactionProcessor extends DataPacketProcessor<Inventory
         switch (type) {
             case InventoryTransactionPacket.USE_ITEM_ON_ENTITY_ACTION_INTERACT -> {
                 PlayerInteractEntityEvent playerInteractEntityEvent = new PlayerInteractEntityEvent(player, target, item, useItemOnEntityData.clickPos);
-                if (player.isSpectator()) playerInteractEntityEvent.setCancelled();
+                if (player.isSpectator() || (player.getDataFlag(EntityFlag.SILENT) && !(target instanceof InventoryHolder))) playerInteractEntityEvent.setCancelled();
                 playerHandle.setInteract();
                 player.getServer().getPluginManager().callEvent(playerInteractEntityEvent);
                 if (playerInteractEntityEvent.isCancelled()) {


### PR DESCRIPTION
Allows players with `EntityFlag.SILENT` set to `true` to open and interact with containers without triggering animations or sounds for other players.

### Affected Containers
- Chests (including double chests)
- Shulker Boxes
- Barrels
- Entity inventories

### Behavior
- Players with the `SILENT` data flag can open and fully interact with container contents as normal
- Other players nearby will not see the open animation or hear the opening/closing sounds

### Changes
- Modified the viewer count check to filter out silent-flagged players before determining whether to send container open/close animations and sounds to nearby players