### PR TITLE
Allow /list command by default

### DIFF
--- a/src/main/java/cn/nukkit/permission/DefaultPermissions.java
+++ b/src/main/java/cn/nukkit/permission/DefaultPermissions.java
@@ -94,7 +94,7 @@ public abstract class DefaultPermissions {
         registerPermission(new Permission(ROOT + ".command.teleport", "Allows the user to teleport players", Permission.DEFAULT_OP), commands);
         registerPermission(new Permission(ROOT + ".command.kick", "Allows the user to kick players", Permission.DEFAULT_OP), commands);
         registerPermission(new Permission(ROOT + ".command.stop", "Allows the user to stop the server", Permission.DEFAULT_OP), commands);
-        registerPermission(new Permission(ROOT + ".command.list", "Allows the user to list all online players", Permission.DEFAULT_OP), commands);
+        registerPermission(new Permission(ROOT + ".command.list", "Allows the user to list all online players", Permission.DEFAULT_TRUE), commands);
         registerPermission(new Permission(ROOT + ".command.help", "Allows the user to view the help menu", Permission.DEFAULT_TRUE), commands);
         registerPermission(new Permission(ROOT + ".command.plugins", "Allows the user to view the list of plugins", Permission.DEFAULT_OP), commands);
         registerPermission(new Permission(ROOT + ".command.reload", "Allows the user to reload the server settings", Permission.DEFAULT_OP), commands);


### PR DESCRIPTION
To match vanilla behavior, change default permission for "nukkit.command.list" from Permission.DEFAULT_OP to Permission.DEFAULT_TRUE so non-op users can list online players by default

If the goal here is to match vanilla as much as possible, we should also consider setting "nukkit.textcolor" to Permission.DEFAULT_TRUE and "nukkit.command.kill.self" to Permission.DEFAULT_OP. I personally don't care about those, so that's for others to decide.