### PR TITLE
Fix Ominous Bottle amplifier & drinking visuals/sounds

### DIFF
--- a/src/main/java/cn/nukkit/blockentity/BlockEntityVault.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityVault.java
@@ -620,9 +620,8 @@ public class BlockEntityVault extends BlockEntitySpawnable {
         }
 
         private static Item ominousBottle(int amplifier) {
-            Item item = item(ItemID.OMINOUS_BOTTLE, 0, 1);
+            Item item = item(ItemID.OMINOUS_BOTTLE, amplifier, 1);
             item.setNamedTag(new CompoundTag().putInt("OminousBottleAmplifier", amplifier));
-            item.setLore("Amplifier: " + (amplifier + 1));
             return item;
         }
 

--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -2031,6 +2031,15 @@ public abstract class Item implements Cloneable, ItemID {
     /////////////////////////////
     // Item Food/Edible Methods
     /////////////////////////////
+    /**
+     * Whether the item can be consumed, and therefore has a consumption animation (e.g. eating food, drinking potions/milk)
+     *
+     * @return true if the item can be consumed, otherwise {@link #isEdible()}
+     */
+    public boolean isConsumable() {
+        return this.isEdible();
+    }
+
     public boolean isEdible() {
         CustomItemDefinition def = getCustomDefinition();
         if (def != null) {

--- a/src/main/java/cn/nukkit/item/ItemHoneyBottle.java
+++ b/src/main/java/cn/nukkit/item/ItemHoneyBottle.java
@@ -43,7 +43,9 @@ public class ItemHoneyBottle extends ItemFood {
 
     @Override
     public boolean onEaten(Player player) {
-        player.getInventory().addItem(new ItemGlassBottle());
+        if (player.isAdventure() || player.isSurvival()) {
+            player.getInventory().addItem(new ItemGlassBottle());
+        }
         player.removeEffect(EffectType.POISON);
 
         return super.onEaten(player);

--- a/src/main/java/cn/nukkit/item/ItemMilkBucket.java
+++ b/src/main/java/cn/nukkit/item/ItemMilkBucket.java
@@ -43,8 +43,8 @@ public class ItemMilkBucket extends ItemBucket {
 
         if (player.isAdventure() || player.isSurvival()) {
             --this.count;
-            player.getInventory().addItem(Item.get(ItemID.BUCKET, 0, 1));
             player.getInventory().setItemInMainHand(this);
+            player.getInventory().addItem(Item.get(ItemID.BUCKET, 0, 1));
         }
 
         player.getLevel().getVibrationManager().callVibrationEvent(new VibrationEvent(player, player.add(0, player.getEyeHeight()), VibrationType.DRINKING));

--- a/src/main/java/cn/nukkit/item/ItemMilkBucket.java
+++ b/src/main/java/cn/nukkit/item/ItemMilkBucket.java
@@ -19,6 +19,11 @@ public class ItemMilkBucket extends ItemBucket {
     }
 
     @Override
+    public boolean isConsumable() {
+        return true;
+    }
+
+    @Override
     public int getUsingTicks() {
         return 31;
     }

--- a/src/main/java/cn/nukkit/item/ItemMilkBucket.java
+++ b/src/main/java/cn/nukkit/item/ItemMilkBucket.java
@@ -3,7 +3,6 @@ package cn.nukkit.item;
 import cn.nukkit.Player;
 import cn.nukkit.Server;
 import cn.nukkit.event.player.PlayerItemConsumeEvent;
-import cn.nukkit.level.Sound;
 import cn.nukkit.level.vibration.VibrationEvent;
 import cn.nukkit.level.vibration.VibrationType;
 import cn.nukkit.math.Vector3;
@@ -40,13 +39,12 @@ public class ItemMilkBucket extends ItemBucket {
 
         player.removeAllEffects();
 
-        player.completeUsingItem(this.getRuntimeId(), CompletedUsingItemPacket.ACTION_EAT);
+        player.completeUsingItem(this.getRuntimeId(), CompletedUsingItemPacket.ACTION_CONSUME);
 
         if (player.isAdventure() || player.isSurvival()) {
             --this.count;
             player.getInventory().addItem(Item.get(ItemID.BUCKET, 0, 1));
             player.getInventory().setItemInMainHand(this);
-            player.getLevel().addSound(player, Sound.RANDOM_BURP);
         }
 
         player.getLevel().getVibrationManager().callVibrationEvent(new VibrationEvent(player, player.add(0, player.getEyeHeight()), VibrationType.DRINKING));

--- a/src/main/java/cn/nukkit/item/ItemOminousBottle.java
+++ b/src/main/java/cn/nukkit/item/ItemOminousBottle.java
@@ -33,6 +33,11 @@ public class ItemOminousBottle extends Item {
     }
 
     @Override
+    public boolean isConsumable() {
+        return true;
+    }
+
+    @Override
     public int getUsingTicks() {
         return 31;
     }

--- a/src/main/java/cn/nukkit/item/ItemOminousBottle.java
+++ b/src/main/java/cn/nukkit/item/ItemOminousBottle.java
@@ -16,7 +16,15 @@ public class ItemOminousBottle extends Item {
     private static final int BAD_OMEN_DURATION = 100 * 60 * 20;
 
     public ItemOminousBottle() {
-        super(OMINOUS_BOTTLE);
+        this(0, 1);
+    }
+
+    public ItemOminousBottle(Integer meta) {
+        this(meta, 1);
+    }
+
+    public ItemOminousBottle(Integer meta, int count) {
+        super(OMINOUS_BOTTLE, meta, count);
     }
 
     @Override
@@ -42,16 +50,18 @@ public class ItemOminousBottle extends Item {
             return false;
         }
 
-        int amplifier = Math.max(0, Math.min(4, this.getNamedTag() != null
-                ? this.getNamedTag().getInt(TAG_OMINOUS_BOTTLE_AMPLIFIER, 0)
-                : 0));
+        int amplifier = this.getDamage();
+        if (this.hasCompoundTag() && this.getNamedTag().contains(TAG_OMINOUS_BOTTLE_AMPLIFIER)) {
+            amplifier = this.getNamedTag().getInt(TAG_OMINOUS_BOTTLE_AMPLIFIER);
+        }
+        amplifier = Math.clamp(amplifier, 0, 4);
 
         player.addEffect(Effect.get(EffectType.BAD_OMEN)
                 .setAmplifier(amplifier)
                 .setDuration(BAD_OMEN_DURATION)
                 .setVisible(true));
 
-        player.completeUsingItem(this.getRuntimeId(), CompletedUsingItemPacket.ACTION_EAT);
+        player.completeUsingItem(this.getRuntimeId(), CompletedUsingItemPacket.ACTION_CONSUME);
         player.getLevel().addLevelSoundEvent(player, LevelSoundEvent.OMINOUS_BOTTLE_END_USE);
         player.getLevel().addLevelSoundEvent(player, LevelSoundEvent.APPLY_EFFECT_BAD_OMEN);
         player.getLevel().getVibrationManager().callVibrationEvent(new VibrationEvent(

--- a/src/main/java/cn/nukkit/item/ItemPotion.java
+++ b/src/main/java/cn/nukkit/item/ItemPotion.java
@@ -81,6 +81,11 @@ public class ItemPotion extends Item {
     }
 
     @Override
+    public boolean isConsumable() {
+        return true;
+    }
+
+    @Override
     public boolean onClickAir(Player player, Vector3 directionVector) {
         return true;
     }

--- a/src/main/java/cn/nukkit/item/ItemPotion.java
+++ b/src/main/java/cn/nukkit/item/ItemPotion.java
@@ -7,6 +7,8 @@ import cn.nukkit.event.player.PlayerItemConsumeEvent;
 import cn.nukkit.level.vibration.VibrationEvent;
 import cn.nukkit.level.vibration.VibrationType;
 import cn.nukkit.math.Vector3;
+import cn.nukkit.network.protocol.CompletedUsingItemPacket;
+import cn.nukkit.network.protocol.types.LevelSoundEvent;
 
 import javax.annotation.Nullable;
 
@@ -98,6 +100,9 @@ public class ItemPotion extends Item {
         if (consumeEvent.isCancelled()) {
             return false;
         }
+
+        player.completeUsingItem(this.getRuntimeId(), CompletedUsingItemPacket.ACTION_CONSUME);
+
         PotionType potion = PotionType.get(this.getDamage());
 
         player.level.getVibrationManager().callVibrationEvent(new VibrationEvent(player, player.getLocation(), VibrationType.DRINKING));
@@ -106,6 +111,7 @@ public class ItemPotion extends Item {
             --this.count;
             player.getInventory().setItemInMainHand(this);
             player.getInventory().addItem(new ItemGlassBottle());
+            player.level.addLevelSoundEvent(player, LevelSoundEvent.BOTTLE_EMPTY);
         }
 
         if (potion != null) {

--- a/src/main/java/cn/nukkit/network/process/processor/EntityEventProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/EntityEventProcessor.java
@@ -4,10 +4,6 @@ import cn.nukkit.Player;
 import cn.nukkit.PlayerHandle;
 import cn.nukkit.Server;
 import cn.nukkit.item.Item;
-import cn.nukkit.item.ItemFood;
-import cn.nukkit.item.ItemMilkBucket;
-import cn.nukkit.item.ItemOminousBottle;
-import cn.nukkit.item.ItemPotion;
 import cn.nukkit.network.process.DataPacketProcessor;
 import cn.nukkit.network.protocol.EntityEventPacket;
 import cn.nukkit.network.protocol.ProtocolInfo;
@@ -28,8 +24,7 @@ public class EntityEventProcessor extends DataPacketProcessor<EntityEventPacket>
             }
 
             Item hand = player.getInventory().getItemInMainHand();
-            if (!(hand instanceof ItemFood) && !(hand instanceof ItemPotion)
-                    && !(hand instanceof ItemMilkBucket) && !(hand instanceof ItemOminousBottle)) {
+            if (!hand.isConsumable()) {
                 return;
             }
 

--- a/src/main/java/cn/nukkit/network/process/processor/EntityEventProcessor.java
+++ b/src/main/java/cn/nukkit/network/process/processor/EntityEventProcessor.java
@@ -5,6 +5,9 @@ import cn.nukkit.PlayerHandle;
 import cn.nukkit.Server;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemFood;
+import cn.nukkit.item.ItemMilkBucket;
+import cn.nukkit.item.ItemOminousBottle;
+import cn.nukkit.item.ItemPotion;
 import cn.nukkit.network.process.DataPacketProcessor;
 import cn.nukkit.network.protocol.EntityEventPacket;
 import cn.nukkit.network.protocol.ProtocolInfo;
@@ -19,23 +22,30 @@ public class EntityEventProcessor extends DataPacketProcessor<EntityEventPacket>
             return;
         }
 
-        if (pk.event == EntityEventPacket.EATING_ITEM) {
-            if (pk.data == 0 || pk.eid != player.getId()) {
+        if (pk.event == EntityEventPacket.EATING_ITEM || pk.event == EntityEventPacket.DRINK_MILK) {
+            if (pk.eid != player.getId()) {
                 return;
             }
 
             Item hand = player.getInventory().getItemInMainHand();
-            if(!(hand instanceof ItemFood)) {
+            if (!(hand instanceof ItemFood) && !(hand instanceof ItemPotion)
+                    && !(hand instanceof ItemMilkBucket) && !(hand instanceof ItemOminousBottle)) {
+                return;
+            }
+
+            if (pk.event == EntityEventPacket.EATING_ITEM && pk.data == 0) {
                 return;
             }
 
             int predictedData = (hand.getRuntimeId() << 16) | hand.getDamage();
-            if(pk.data != predictedData) {
+            if (pk.event == EntityEventPacket.EATING_ITEM && pk.data != predictedData) {
                 return;
             }
 
             pk.eid = player.getId();
-            pk.data = predictedData;
+            if (pk.event == EntityEventPacket.EATING_ITEM) {
+                pk.data = predictedData;
+            }
 
             player.dataPacket(pk);
             Server.broadcastPacket(player.getViewers().values(), pk);


### PR DESCRIPTION
### Fix Ominous Bottle
* Set the Ominous Bottle item meta to the amplifier value when created and remove the lore (debug leftover?).
* Add ItemOminousBottle constructors that accept meta and count, and change amplifier resolution to prefer the item damage (falling back to the named tag) and clamp it between 0 and 4.
* Change the completed-using action from ACTION_EAT to ACTION_CONSUME to reflect consumption semantics.

### Fix drinking visuals/sounds
* ItemMilkBucket: use ACTION_CONSUME when completing use, remove burp sound, keep DRINKING vibration event.
* ItemPotion: import CompletedUsingItemPacket and LevelSoundEvent; call ACTION_CONSUME and play BOTTLE_EMPTY sound when consumed.
* EntityEventProcessor: accept DRINK_MILK events, treat ItemPotion/ItemMilkBucket/ItemOminousBottle as valid consumables, and adjust packet validation so data checks and pk.data assignment only apply to EATING_ITEM. This avoids incorrectly rejecting drink events and synchronizes client/server consumption behavior.

### Other changes
* Only add an ItemGlassBottle to the player's inventory when they are in Adventure or Survival mode (to match vanilla behavior).