### PR TITLE
fix: Entity looking direction when placed by spawn eggs

### DIFF
--- a/src/main/java/cn/nukkit/item/ItemCustomEntitySpawnEgg.java
+++ b/src/main/java/cn/nukkit/item/ItemCustomEntitySpawnEgg.java
@@ -91,8 +91,10 @@ public class ItemCustomEntitySpawnEgg extends Item implements SpawnEggPickable {
         if (chunk == null) return false;
 
         double spawnY = (target.getBoundingBox() == null) ? block.getY() : target.getBoundingBox().getMaxY() + 0.0001d;
-        float yaw = ThreadLocalRandom.current().nextFloat() * 360f;
-        Location loc = new Location(block.getX() + 0.5, spawnY, block.getZ() + 0.5, yaw, 0f, level);
+        double spawnX = block.getX() + 0.5;
+        double spawnZ = block.getZ() + 0.5;
+        float yaw = getYawFacingPlayer(spawnX, spawnZ, player);
+        Location loc = new Location(spawnX, spawnY, spawnZ, yaw, 0f, level);
         CompoundTag nbt = Entity.getDefaultNBT(loc);
 
         if (this.hasCustomName()) {
@@ -148,6 +150,17 @@ public class ItemCustomEntitySpawnEgg extends Item implements SpawnEggPickable {
 
 
     // ---------- helpers ----------
+    private float getYawFacingPlayer(double spawnX, double spawnZ, @Nullable Player player) {
+        if (player == null) {
+            return ThreadLocalRandom.current().nextFloat() * 360f;
+        }
+
+        double dx = player.getX() - spawnX;
+        double dz = player.getZ() - spawnZ;
+
+        return (float) Math.toDegrees(Math.atan2(-dx, dz));
+    }
+
     private void selfHealIdentifierFromNamedTag() {
         CompoundTag tag = this.getNamedTag();
         if (tag == null) return;

--- a/src/main/java/cn/nukkit/item/ItemCustomEntitySpawnEgg.java
+++ b/src/main/java/cn/nukkit/item/ItemCustomEntitySpawnEgg.java
@@ -87,14 +87,20 @@ public class ItemCustomEntitySpawnEgg extends Item implements SpawnEggPickable {
             return false;
         }
 
-        IChunk chunk = level.getChunk((int) block.getX() >> 4, (int) block.getZ() >> 4);
+        double spawnY = (target.getBoundingBox() == null) ? block.getY() : target.getBoundingBox().getMaxY() + 0.0001d;
+        double spawnX = target.getX() + fx;
+        double spawnZ = target.getZ() + fz;
+        Location loc = new Location(spawnX, spawnY, spawnZ, 0f, 0f, level);
+
+        if (player != null) {
+            loc.setYawFacing(player);
+        } else {
+            loc.setYaw(ThreadLocalRandom.current().nextFloat() * 360f);
+        }
+
+        IChunk chunk = level.getChunk((int) Math.floor(loc.getX()) >> 4, (int) Math.floor(loc.getZ()) >> 4);
         if (chunk == null) return false;
 
-        double spawnY = (target.getBoundingBox() == null) ? block.getY() : target.getBoundingBox().getMaxY() + 0.0001d;
-        double spawnX = block.getX() + 0.5;
-        double spawnZ = block.getZ() + 0.5;
-        float yaw = getYawFacingPlayer(spawnX, spawnZ, player);
-        Location loc = new Location(spawnX, spawnY, spawnZ, yaw, 0f, level);
         CompoundTag nbt = Entity.getDefaultNBT(loc);
 
         if (this.hasCustomName()) {
@@ -150,17 +156,6 @@ public class ItemCustomEntitySpawnEgg extends Item implements SpawnEggPickable {
 
 
     // ---------- helpers ----------
-    private float getYawFacingPlayer(double spawnX, double spawnZ, @Nullable Player player) {
-        if (player == null) {
-            return ThreadLocalRandom.current().nextFloat() * 360f;
-        }
-
-        double dx = player.getX() - spawnX;
-        double dz = player.getZ() - spawnZ;
-
-        return (float) Math.toDegrees(Math.atan2(-dx, dz));
-    }
-
     private void selfHealIdentifierFromNamedTag() {
         CompoundTag tag = this.getNamedTag();
         if (tag == null) return;

--- a/src/main/java/cn/nukkit/item/ItemSpawnEgg.java
+++ b/src/main/java/cn/nukkit/item/ItemSpawnEgg.java
@@ -71,8 +71,10 @@ public class ItemSpawnEgg extends Item implements SpawnEggPickable {
         if (chunk == null) return false;
 
         double spawnY = (target.getBoundingBox() == null) ? block.getY() : target.getBoundingBox().getMaxY() + 0.0001d;
-        float yaw = java.util.concurrent.ThreadLocalRandom.current().nextFloat() * 360f;
-        Location loc = new Location(block.getX() + 0.5, spawnY, block.getZ() + 0.5, yaw, 0f, level);
+        double spawnX = block.getX() + 0.5;
+        double spawnZ = block.getZ() + 0.5;
+        float yaw = getYawFacingPlayer(spawnX, spawnZ, player);
+        Location loc = new Location(spawnX, spawnY, spawnZ, yaw, 0f, level);
 
         CompoundTag nbt = Entity.getDefaultNBT(loc);
         if (this.hasCustomName()) {
@@ -128,5 +130,12 @@ public class ItemSpawnEgg extends Item implements SpawnEggPickable {
     @Override
     public void setEntityNBT(CompoundTag entityNBT) {
         this.entityNBT = entityNBT;
+    }
+
+    private float getYawFacingPlayer(double spawnX, double spawnZ, Player player) {
+        double dx = player.getX() - spawnX;
+        double dz = player.getZ() - spawnZ;
+
+        return (float) Math.toDegrees(Math.atan2(-dx, dz));
     }
 }

--- a/src/main/java/cn/nukkit/item/ItemSpawnEgg.java
+++ b/src/main/java/cn/nukkit/item/ItemSpawnEgg.java
@@ -67,14 +67,13 @@ public class ItemSpawnEgg extends Item implements SpawnEggPickable {
     public boolean onActivate(Level level, Player player, Block block, Block target, BlockFace face, double fx, double fy, double fz) {
         if (player.isAdventure()) return false;
 
-        IChunk chunk = level.getChunk((int) block.getX() >> 4, (int) block.getZ() >> 4);
-        if (chunk == null) return false;
-
         double spawnY = (target.getBoundingBox() == null) ? block.getY() : target.getBoundingBox().getMaxY() + 0.0001d;
-        double spawnX = block.getX() + 0.5;
-        double spawnZ = block.getZ() + 0.5;
-        float yaw = getYawFacingPlayer(spawnX, spawnZ, player);
-        Location loc = new Location(spawnX, spawnY, spawnZ, yaw, 0f, level);
+        double spawnX = target.getX() + fx;
+        double spawnZ = target.getZ() + fz;
+        Location loc = new Location(spawnX, spawnY, spawnZ, 0f, 0f, level).setYawFacing(player);
+
+        IChunk chunk = level.getChunk((int) Math.floor(loc.getX()) >> 4, (int) Math.floor(loc.getZ()) >> 4);
+        if (chunk == null) return false;
 
         CompoundTag nbt = Entity.getDefaultNBT(loc);
         if (this.hasCustomName()) {
@@ -130,12 +129,5 @@ public class ItemSpawnEgg extends Item implements SpawnEggPickable {
     @Override
     public void setEntityNBT(CompoundTag entityNBT) {
         this.entityNBT = entityNBT;
-    }
-
-    private float getYawFacingPlayer(double spawnX, double spawnZ, Player player) {
-        double dx = player.getX() - spawnX;
-        double dz = player.getZ() - spawnZ;
-
-        return (float) Math.toDegrees(Math.atan2(-dx, dz));
     }
 }

--- a/src/main/java/cn/nukkit/level/Location.java
+++ b/src/main/java/cn/nukkit/level/Location.java
@@ -108,6 +108,27 @@ public class Location extends Position {
         return this;
     }
 
+    public static double calculateYawFacing(double fromX, double fromZ, double toX, double toZ) {
+        double dx = toX - fromX;
+        double dz = toZ - fromZ;
+
+        return Math.toDegrees(Math.atan2(-dx, dz));
+    }
+
+    public static double calculateYawFacing(Vector3 from, Vector3 to) {
+        return calculateYawFacing(from.getX(), from.getZ(), to.getX(), to.getZ());
+    }
+
+    public Location setYawFacing(double x, double z) {
+        this.yaw = calculateYawFacing(this.x, this.z, x, z);
+        this.headYaw = this.yaw;
+        return this;
+    }
+
+    public Location setYawFacing(Vector3 target) {
+        return this.setYawFacing(target.getX(), target.getZ());
+    }
+
     @Override
     public Location setX(double x) {
         super.setX(x);


### PR DESCRIPTION
Fix entity looking direction when placed by spawn eggs
On BDS the placed entity is always looking the player who placed it, helps to set NPCs to the correct looking direction.