### PR TITLE
fix: encode CameraInstructionPacket ease type as string

### DIFF
--- a/src/main/java/cn/nukkit/network/protocol/CameraInstructionPacket.java
+++ b/src/main/java/cn/nukkit/network/protocol/CameraInstructionPacket.java
@@ -67,7 +67,7 @@ public class CameraInstructionPacket extends DataPacket {
         byteBuf.writeNotNull(fovInstruction, target -> {
             byteBuf.writeFloatLE(target.getFov());
             byteBuf.writeFloatLE(target.getEaseTime());
-            byteBuf.writeByte(target.getEaseType().ordinal());
+            byteBuf.writeString(target.getEaseType().getSerializeName());
             byteBuf.writeBoolean(target.isClear());
         });
 
@@ -90,7 +90,7 @@ public class CameraInstructionPacket extends DataPacket {
     }
 
     protected void writeEase(HandleByteBuf byteBuf, Ease ease) {
-        byteBuf.writeByte((byte) ease.easeType().ordinal());
+        byteBuf.writeString(ease.easeType().getType());
         byteBuf.writeFloatLE(ease.time());
     }
 


### PR DESCRIPTION

## Bug

`CameraInstructionPacket` writes the ease type as a `byte` (enum ordinal) for both:
- `writeEase` (used by `SetInstruction`) at line 93
- `fovInstruction` encoder at line 70

Bedrock 1.21+ wire format expects a **string** (e.g. `"in_quad"`, `"out_quad"`, `"linear"`).

Mismatch → client fails to parse the packet → disconnects with `disconnect.closed` (reason `UNKNOWN`) on the next tick.

## Fix

Both write sites now serialize the ease type as a string via the existing `getSerializeName()` / `getType()` accessors on `CameraEase` / `EaseType`.

## Reference

PocketMine bedrock-protocol. `CameraFovInstruction::write` writes `easeType` via `CommonTypes::putString` (string), confirming the wire format.
- https://github.com/pmmp/BedrockProtocol/blob/master/src/types/camera/CameraFovInstruction.php
- https://github.com/pmmp/BedrockProtocol/blob/master/src/types/camera/CameraSetInstructionEaseType.php

CloudburstMC Protocol (de-facto Bedrock wire spec, used by Geyser):
- https://github.com/CloudburstMC/Protocol/blob/3.0/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/camera/CameraSetInstruction.java
- https://github.com/CloudburstMC/Protocol/blob/3.0/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/camera/CameraEase.java

## Repro

Send any `CameraInstructionPacket` with a non-default ease type → connected client disconnects within 1 tick.

## Verified

Patched build deployed against vanilla Bedrock 1.21.x client : pulse FOV updates apply, no disconnect.