### PR TITLE
fix: BlockFrame support validation for wall blocks

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockFrame.java
+++ b/src/main/java/cn/nukkit/block/BlockFrame.java
@@ -106,7 +106,7 @@ public class BlockFrame extends BlockTransparent implements BlockEntityHolder<Bl
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_NORMAL) {
             Block support = this.getSideAtLayer(0, getFacing().getOpposite());
-            if (!support.isSolid() && !support.getId().equals(COBBLESTONE_WALL)) {
+            if (!support.isSolid() && !(support instanceof BlockWallBase)) {
                 // [ITEM_DEBUG] Log when item frame breaks due to missing support
                 BlockEntityItemFrame be = getBlockEntity();
                 if (be != null) {


### PR DESCRIPTION
Fixes item frames being removed when placed on some wall variants.

Placement already allowed BlockWallBase blocks, but the update validation only accepted solid blocks or cobblestone walls. This caused frames placed on walls like mossy stone brick walls to detach immediately, and could also trigger a ClassCastException while handling InventoryTransactionPacket.