### PR TITLE
fix: resolve concurrent world loading issues (NPE and Lock conflict)

### DIFF
--- a/src/main/java/cn/nukkit/level/format/leveldb/LevelDBChunkSerializer.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/LevelDBChunkSerializer.java
@@ -437,6 +437,13 @@ public class LevelDBChunkSerializer {
         if (extraData == null) return;
         long chunkKey = ((long) builder.getChunkX() & 0xffffffffL) << 32 | ((long) builder.getChunkZ() & 0xffffffffL);
 
+        LevelDBProvider provider = null;
+        if (builder.getLevelProvider() instanceof LevelDBProvider p) {
+            provider = p;
+        }
+
+        if (provider == null) return;
+
         // --- Scheduled Ticks ---
         if (extraData.contains("pendingScheduledTicks")) {
             ListTag<CompoundTag> scheduledTicks = extraData.getList("pendingScheduledTicks", CompoundTag.class);
@@ -454,7 +461,7 @@ public class LevelDBChunkSerializer {
                 scheduledList.add(info);
             }
             if (!scheduledList.isEmpty()) {
-                LevelDBProvider.getScheduledTicksMap().put(chunkKey, scheduledList);
+                provider.getScheduledTicksMap().put(chunkKey, scheduledList);
             }
         }
 
@@ -471,7 +478,7 @@ public class LevelDBChunkSerializer {
                 normalList.add(info);
             }
             if (!normalList.isEmpty()) {
-                LevelDBProvider.getNormalTicksMap().put(chunkKey, normalList);
+                provider.getNormalTicksMap().put(chunkKey, normalList);
             }
         }
     }

--- a/src/main/java/cn/nukkit/level/format/leveldb/LevelDBProvider.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/LevelDBProvider.java
@@ -208,7 +208,7 @@ public class LevelDBProvider implements LevelProvider {
         List<LevelDBChunkSerializer.NormalTickInfo> normalList = this.normalTicksMap.remove(chunkKey);
 
         restoreScheduledTicks(level, chunk, scheduledList);
-        restoreNormalTicks(level, chunk, normalList);
+        restoreNormalTicks(level, normalList);
     }
 
     private static void restoreScheduledTicks(Level level, IChunk chunk, List<LevelDBChunkSerializer.ScheduledTickInfo> scheduledList) {
@@ -228,7 +228,7 @@ public class LevelDBProvider implements LevelProvider {
         }
     }
 
-    private static void restoreNormalTicks(Level level, IChunk chunk, List<LevelDBChunkSerializer.NormalTickInfo> normalList) {
+    private static void restoreNormalTicks(Level level, List<LevelDBChunkSerializer.NormalTickInfo> normalList) {
         if (normalList == null || normalList.isEmpty()) return;
 
         int batchSize = 32;

--- a/src/main/java/cn/nukkit/level/format/leveldb/LevelDBProvider.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/LevelDBProvider.java
@@ -5,8 +5,6 @@ import cn.nukkit.api.UsedByReflection;
 import cn.nukkit.block.Block;
 import cn.nukkit.blockentity.BlockEntity;
 import cn.nukkit.blockentity.BlockEntitySpawnable;
-import cn.nukkit.entity.Entity;
-import cn.nukkit.entity.EntityAsyncPrepare;
 import cn.nukkit.level.DimensionData;
 import cn.nukkit.level.GameRule;
 import cn.nukkit.level.GameRules;
@@ -17,8 +15,6 @@ import cn.nukkit.level.format.ChunkSection;
 import cn.nukkit.level.format.IChunk;
 import cn.nukkit.level.format.LevelConfig;
 import cn.nukkit.level.format.LevelProvider;
-import cn.nukkit.level.format.leveldb.LevelDBChunkSerializer.NormalTickInfo;
-import cn.nukkit.level.format.leveldb.LevelDBChunkSerializer.ScheduledTickInfo;
 import cn.nukkit.math.BlockVector3;
 import cn.nukkit.math.Vector3;
 import cn.nukkit.nbt.NBTIO;
@@ -58,13 +54,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -72,12 +66,12 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 @Slf4j
 public class LevelDBProvider implements LevelProvider {
-    static final HashMap<String, LevelDBStorage> CACHE = new HashMap<>();
+    static final Map<String, LevelDBStorage> CACHE = new ConcurrentHashMap<>();
     private static final byte[] levelDatMagic = new byte[]{10, 0, 0, 0, 68, 11, 0, 0};
     private final ThreadLocal<WeakReference<IChunk>> lastChunk = new ThreadLocal<>();
     protected final Long2ObjectNonBlockingMap<IChunk> chunks = new Long2ObjectNonBlockingMap<>();
-    private static final Map<Long, List<ScheduledTickInfo>> scheduledTicksMap = new HashMap<>();
-    private static final Map<Long, List<NormalTickInfo>> normalTicksMap = new HashMap<>();
+    private final Map<Long, List<LevelDBChunkSerializer.ScheduledTickInfo>> scheduledTicksMap = new ConcurrentHashMap<>();
+    private final Map<Long, List<LevelDBChunkSerializer.NormalTickInfo>> normalTicksMap = new ConcurrentHashMap<>();
     protected final LevelDat levelDat;
     protected final LevelDBStorage storage;
     protected final Level level;
@@ -96,16 +90,19 @@ public class LevelDBProvider implements LevelProvider {
     }
     
     public LevelDBProvider(Level level, String path) throws IOException {
-        this.storage = CACHE.computeIfAbsent(path, p -> {
-            try {
-                return new LevelDBStorage(level.getDimensionCount(), p, new Options()
-                        .createIfMissing(true)
-                        .compressionType(CompressionType.ZLIB_RAW)
-                        .blockSize(64 * 1024));
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        });
+        synchronized (CACHE) {
+            this.storage = CACHE.computeIfAbsent(path, p -> {
+                try {
+                    return new LevelDBStorage(0, p, new Options()
+                            .createIfMissing(true)
+                            .compressionType(CompressionType.ZLIB_RAW)
+                            .blockSize(64 * 1024));
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+            this.storage.incrementRefCount();
+        }
         this.path = path;
         this.level = level;
         var levelDat = readLevelDat();
@@ -197,27 +194,27 @@ public class LevelDBProvider implements LevelProvider {
         return chunk;
     }
 
-    public static Map<Long, List<ScheduledTickInfo>> getScheduledTicksMap() {
+    public Map<Long, List<LevelDBChunkSerializer.ScheduledTickInfo>> getScheduledTicksMap() {
         return scheduledTicksMap;
     }
-    public static Map<Long, List<NormalTickInfo>> getNormalTicksMap() {
+    public Map<Long, List<LevelDBChunkSerializer.NormalTickInfo>> getNormalTicksMap() {
         return normalTicksMap;
     }
 
-    public static void restoreBlockTicks(Level level, IChunk chunk) {
-        long chunkKey = ((long) chunk.getX() & 0xffffffffL) << 32 | ((long) chunk.getZ() & 0xffffffffL);
+    public void restoreBlockTicks(Level level, IChunk chunk) {
+        long chunkKey = Level.chunkHash(chunk.getX(), chunk.getZ());
 
-        List<ScheduledTickInfo> scheduledList = LevelDBProvider.getScheduledTicksMap().remove(chunkKey);
-        List<NormalTickInfo> normalList = LevelDBProvider.getNormalTicksMap().remove(chunkKey);
+        List<LevelDBChunkSerializer.ScheduledTickInfo> scheduledList = this.scheduledTicksMap.remove(chunkKey);
+        List<LevelDBChunkSerializer.NormalTickInfo> normalList = this.normalTicksMap.remove(chunkKey);
 
         restoreScheduledTicks(level, chunk, scheduledList);
         restoreNormalTicks(level, chunk, normalList);
     }
 
-    private static void restoreScheduledTicks(Level level, IChunk chunk, List<ScheduledTickInfo> scheduledList) {
+    private static void restoreScheduledTicks(Level level, IChunk chunk, List<LevelDBChunkSerializer.ScheduledTickInfo> scheduledList) {
         if (scheduledList == null || scheduledList.isEmpty()) return;
 
-        for (ScheduledTickInfo info : scheduledList) {
+        for (LevelDBChunkSerializer.ScheduledTickInfo info : scheduledList) {
             Block block = level.getBlock(info.x, info.y, info.z, info.layer);
             if (block.getId().equals(info.id)) {
                 chunk.getBlockUpdateScheduler().add(new BlockUpdateEntry(
@@ -231,7 +228,7 @@ public class LevelDBProvider implements LevelProvider {
         }
     }
 
-    private static void restoreNormalTicks(Level level, IChunk chunk, List<NormalTickInfo> normalList) {
+    private static void restoreNormalTicks(Level level, IChunk chunk, List<LevelDBChunkSerializer.NormalTickInfo> normalList) {
         if (normalList == null || normalList.isEmpty()) return;
 
         int batchSize = 32;
@@ -239,10 +236,10 @@ public class LevelDBProvider implements LevelProvider {
         for (int i = 0; i < total; i += batchSize) {
             int from = i;
             int to = Math.min(i + batchSize, total);
-            List<NormalTickInfo> sub = normalList.subList(from, to);
+            List<LevelDBChunkSerializer.NormalTickInfo> sub = normalList.subList(from, to);
 
             level.getScheduler().scheduleDelayedTask(() -> {
-                for (NormalTickInfo info : sub) {
+                for (LevelDBChunkSerializer.NormalTickInfo info : sub) {
                     Block block = level.getBlock(info.x, info.y, info.z);
                     if (block.getId().equals(info.id)) {
                         block.onUpdate(Level.BLOCK_UPDATE_NORMAL);

--- a/src/main/java/cn/nukkit/level/format/leveldb/LevelDBStorage.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/LevelDBStorage.java
@@ -3,7 +3,6 @@ package cn.nukkit.level.format.leveldb;
 import cn.nukkit.level.format.Chunk;
 import cn.nukkit.level.format.IChunk;
 import cn.nukkit.level.format.LevelProvider;
-import org.apache.logging.log4j.util.InternalApi;
 import org.iq80.leveldb.CompressionType;
 import org.iq80.leveldb.DB;
 import org.iq80.leveldb.Options;
@@ -13,7 +12,6 @@ import org.iq80.leveldb.impl.Iq80DBFactory;
 import cn.nukkit.level.util.LevelDBKeyUtil;
 import cn.nukkit.nbt.NBTIO;
 import cn.nukkit.nbt.tag.CompoundTag;
-import org.jetbrains.annotations.ApiStatus;
 
 import java.io.File;
 import java.io.IOException;
@@ -24,21 +22,21 @@ import java.nio.file.Path;
 public final class LevelDBStorage {
     private final DB db;
     private final String path;
-    private int dimSum;
+    private int refCount;
 
     public DB getDb() {
         return this.db;
     }
 
-    public LevelDBStorage(int dimSum, String path) throws IOException {
-        this(dimSum, path, new Options()
+    public LevelDBStorage(int refCount, String path) throws IOException {
+        this(refCount, path, new Options()
                 .createIfMissing(true)
                 .compressionType(CompressionType.ZLIB_RAW)
                 .blockSize(64 * 1024));
     }
 
-    public LevelDBStorage(int dimSum, String pathFolder, Options options) throws IOException {
-        this.dimSum = dimSum;
+    public LevelDBStorage(int refCount, String pathFolder, Options options) throws IOException {
+        this.refCount = refCount;
         this.path = pathFolder;
         Path path = Path.of(pathFolder);
         File folder = path.toFile();
@@ -50,6 +48,10 @@ public final class LevelDBStorage {
         File dbFolder = path.resolve("db").toFile();
         if (!dbFolder.exists()) dbFolder.mkdirs();
         db = new Iq80DBFactory().open(dbFolder, options);
+    }
+
+    public synchronized void incrementRefCount() {
+        this.refCount++;
     }
 
     public IChunk readChunk(int x, int z, LevelProvider levelProvider) throws IOException {
@@ -101,13 +103,15 @@ public final class LevelDBStorage {
     }
 
     public synchronized void close() {
-        dimSum--;
-        if (dimSum <= 0) {
-            try {
-                db.close();
-                LevelDBProvider.CACHE.remove(path);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
+        synchronized (LevelDBProvider.CACHE) {
+            refCount--;
+            if (refCount <= 0) {
+                try {
+                    db.close();
+                    LevelDBProvider.CACHE.remove(path);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
This PR addresses several critical race conditions and synchronization issues in the LevelDB provider that occurred during concurrent world or dimension loading.