### PR TITLE
Fix campfire fire

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockBush.java
+++ b/src/main/java/cn/nukkit/block/BlockBush.java
@@ -2,6 +2,7 @@ package cn.nukkit.block;
 
 import cn.nukkit.Player;
 import cn.nukkit.item.Item;
+import cn.nukkit.item.enchantment.Enchantment;
 import cn.nukkit.math.BlockFace;
 import org.jetbrains.annotations.NotNull;
 
@@ -39,6 +40,17 @@ public class BlockBush extends BlockFlowable {
             return true;
         }
         return false;
+    }
+
+    @Override
+    public Item[] getDrops(Item item) {
+        if (item.isShears() || item.hasEnchantment(Enchantment.ID_SILK_TOUCH)) {
+            return new Item[]{
+                    toItem()
+            };
+        }
+
+        return Item.EMPTY_ARRAY;
     }
 
 }

--- a/src/main/java/cn/nukkit/block/BlockCampfire.java
+++ b/src/main/java/cn/nukkit/block/BlockCampfire.java
@@ -169,11 +169,7 @@ public class BlockCampfire extends BlockTransparent implements Faceable, BlockEn
             return;
         }
 
-        EntityCombustByBlockEvent ev = new EntityCombustByBlockEvent(this, entity, 8);
-        Server.getInstance().getPluginManager().callEvent(ev);
-        if (!ev.isCancelled() && entity.isAlive()) {
-            entity.setOnFire(ev.getDuration());
-        }
+        entity.attack(getDamageEvent(entity));
     }
 
     protected EntityDamageEvent getDamageEvent(Entity entity) {


### PR DESCRIPTION
Fix campfires setting entities on fire when colliding.
In vanilla minecraft, campfires only deal damage and do not set entities on fire
