### PR TITLE
fix: guard EntityPhysical motion state before collision current updates

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -5228,12 +5228,16 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
                 this.motionY += dy;
                 this.motionZ += dz;
                 if (this instanceof EntityPhysical entityPhysical) {
+                    entityPhysical.ensurePhysicalMotionState();
+
                     entityPhysical.previousCurrentMotion.x = dx;
                     entityPhysical.previousCurrentMotion.y = dy;
                     entityPhysical.previousCurrentMotion.z = dz;
                 }
             } else {
                 if (this instanceof EntityPhysical entityPhysical) {
+                    entityPhysical.ensurePhysicalMotionState();
+
                     entityPhysical.previousCurrentMotion.x = 0;
                     entityPhysical.previousCurrentMotion.y = 0;
                     entityPhysical.previousCurrentMotion.z = 0;

--- a/src/main/java/cn/nukkit/entity/EntityPhysical.java
+++ b/src/main/java/cn/nukkit/entity/EntityPhysical.java
@@ -39,8 +39,8 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
     public final int tickSpread;
     /** Provide real-time latest collision box position */
     protected final AxisAlignedBB offsetBoundingBox;
-    protected final Vector3 previousCollideMotion;
-    protected final Vector3 previousCurrentMotion;
+    protected Vector3 previousCollideMotion;
+    protected Vector3 previousCurrentMotion;
     /** The time of free fall of an object */
     protected int fallingTick = 0;
     protected boolean needsRecalcMovement = true;
@@ -67,8 +67,20 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
         this.rideJumping = new AtomicInteger(-1);
     }
 
+    void ensurePhysicalMotionState() {
+        if (this.previousCollideMotion == null) {
+            this.previousCollideMotion = new Vector3();
+        }
+
+        if (this.previousCurrentMotion == null) {
+            this.previousCurrentMotion = new Vector3();
+        }
+    }
+
     @Override
     public void asyncPrepare(int currentTick) {
+        this.ensurePhysicalMotionState();
+
         // Calculates whether expensive entity motion needs to be recalculated
         this.needsRecalcMovement = this.level.tickRateOptDelay == 1 || ((currentTick + tickSpread) & (this.level.tickRateOptDelay - 1)) == 0;
         // Recalculate absolute position collision box
@@ -258,8 +270,9 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
     }
 
     protected void addPreviousLiquidMovement() {
-        if (previousCurrentMotion != null)
-            addTmpMoveMotion(previousCurrentMotion);
+        this.ensurePhysicalMotionState();
+
+        addTmpMoveMotion(previousCurrentMotion);
     }
 
     protected void handleFloatingMovement() {
@@ -299,6 +312,8 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
     }
 
     protected void handleCollideMovement(int currentTick) {
+        this.ensurePhysicalMotionState();
+
         if (!this.canBePushedByEntities()) {
             this.previousCollideMotion.setX(0);
             this.previousCollideMotion.setZ(0);


### PR DESCRIPTION
Fixes a possible NullPointerException when EntityPhysical motion cache fields are accessed before initialization.
Adds a small guard to initialize the motion state before physics, collision, and block-current handling, without changing existing movement behavior

NullPointer:
```
16:46:20 [Level Worker] [ERROR] Could not tick level "/pnx/server/worlds/InnerWorld": java.lang.NullPointerException: Cannot assign field "x" because "entityPhysical.previousCurrentMotion" is null
        at cn.nukkit.entity.Entity.checkBlockCollision(Entity.java:5237)
        at cn.nukkit.entity.Entity.entityBaseTick(Entity.java:1637)
        at cn.nukkit.entity.EntityLiving.entityBaseTick(EntityLiving.java:529)
        at cn.nukkit.entity.EntityPhysical.entityBaseTick(EntityPhysical.java:114)
        at cn.nukkit.entity.Entity.onUpdate(Entity.java:1875)
        at cn.nukkit.entity.EntityLiving.onUpdate(EntityLiving.java:236)
        at cn.nukkit.entity.EntityPhysical.onUpdate(EntityPhysical.java:104)
        at cn.powernukkitx.innerworld.entities.InnerOwnableEntity.onUpdate(InnerOwnableEntity.java:1360)
        at cn.powernukkitx.innerworld.entities.InnerMonster.onUpdate(InnerMonster.java:410)
        at cn.nukkit.level.Level.doTick(Level.java:1222)
        at cn.nukkit.level.Level.doTick(Level.java:1111)
        at cn.nukkit.utils.GameLoop.tick(GameLoop.java:74)
        at cn.nukkit.level.Level.lambda$initLevel$2(Level.java:618)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
        at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358)
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)

java.lang.NullPointerException: Cannot assign field "x" because "entityPhysical.previousCurrentMotion" is null
        at cn.nukkit.entity.Entity.checkBlockCollision(Entity.java:5237)
        at cn.nukkit.entity.Entity.entityBaseTick(Entity.java:1637)
        at cn.nukkit.entity.EntityLiving.entityBaseTick(EntityLiving.java:529)
        at cn.nukkit.entity.EntityPhysical.entityBaseTick(EntityPhysical.java:114)
        at cn.nukkit.entity.Entity.onUpdate(Entity.java:1875)
        at cn.nukkit.entity.EntityLiving.onUpdate(EntityLiving.java:236)
        at cn.nukkit.entity.EntityPhysical.onUpdate(EntityPhysical.java:104)
        at cn.powernukkitx.innerworld.entities.InnerOwnableEntity.onUpdate(InnerOwnableEntity.java:1360)
        at cn.powernukkitx.innerworld.entities.InnerMonster.onUpdate(InnerMonster.java:410)
        at cn.nukkit.level.Level.doTick(Level.java:1222)
        at cn.nukkit.level.Level.doTick(Level.java:1111)
        at cn.nukkit.utils.GameLoop.tick(GameLoop.java:74)
        at cn.nukkit.level.Level.lambda$initLevel$2(Level.java:618)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
        at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358)
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)```