### PR TITLE
Revert "Fix: load chunk before teleporting a player"

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -5432,10 +5432,6 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
             to = ev.getTo();
         }
 
-        if (!to.getLevel().isChunkLoaded((int) to.getX() >> 4, (int) to.getZ() >> 4)) {
-            to.getLevel().loadChunk((int) to.getX() >> 4, (int) to.getZ() >> 4, true);
-        }
-
         final Entity currentRide = getRiding();
         if (currentRide != null && !currentRide.dismountEntity(this, true, false)) {
             return false;


### PR DESCRIPTION
Reverts PowerNukkitX/PowerNukkitX#2550

This causes problems.
Also not neccessary since we already load chunks before teleporting using PlayerChunkManager