### PR TITLE
Fix: chest block entity pairing corruption on chunk unload

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -34,6 +34,8 @@ import cn.nukkit.lang.LangCode;
 import cn.nukkit.lang.TextContainer;
 import cn.nukkit.level.DimensionEnum;
 import cn.nukkit.level.GameRule;
+import cn.nukkit.blockentity.BlockEntity;
+import cn.nukkit.entity.Entity;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.Position;
 import cn.nukkit.level.format.LevelConfig;
@@ -1104,9 +1106,21 @@ public class Server {
 
         if (this.autoSave && ++this.autoSaveTicker >= this.autoSaveTicks) {
             this.autoSaveTicker = 0;
-            CompletableFuture.runAsync(() -> {
-                this.doAutoSave();
-            });
+            for (Level level : this.levelArray) {
+                for (BlockEntity be : level.getBlockEntities().values()) {
+                    if (!be.closed) {
+                        be.saveNBT();
+                        be.serializationSnapshot = be.namedTag.copy();
+                    }
+                }
+                for (Entity entity : level.getEntities()) {
+                    if (!(entity instanceof Player) && !entity.closed) {
+                        entity.saveNBT();
+                        entity.serializationSnapshot = entity.namedTag.copy();
+                    }
+                }
+            }
+            CompletableFuture.runAsync(this::doAutoSave);
         }
 
         if (this.sendUsageTicker > 0 && --this.sendUsageTicker == 0) {

--- a/src/main/java/cn/nukkit/blockentity/BlockEntity.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntity.java
@@ -29,6 +29,7 @@ public abstract class BlockEntity extends Position implements BlockEntityID {
     public boolean movable;
     public boolean closed = false;
     public CompoundTag namedTag;
+    public volatile CompoundTag serializationSnapshot;
     protected Server server;
 
     public static BlockEntity createBlockEntity(String type, Position position, Object... args) {

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityChest.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityChest.java
@@ -31,8 +31,11 @@ public class BlockEntityChest extends BlockEntitySpawnableContainer {
     @Override
     public void close() {
         if (!closed) {
-            unpair();
-            this.getInventory().getViewers().forEach(p -> p.removeWindow(this.getInventory()));
+            DoubleChestInventory dblInv = this.doubleInventory;
+            if (dblInv != null) {
+                dblInv.getViewers().forEach(p -> p.removeWindow(dblInv));
+                this.doubleInventory = null;
+            }
             this.getRealInventory().getViewers().forEach(p -> p.removeWindow(this.getRealInventory()));
 
             this.closed = true;
@@ -89,11 +92,15 @@ public class BlockEntityChest extends BlockEntitySpawnableContainer {
                 }
             }
         } else {
-            if (level.isChunkLoaded(this.namedTag.getInt("pairx") >> 4, this.namedTag.getInt("pairz") >> 4)) {
+            int pairChunkX = this.namedTag.getInt("pairx") >> 4;
+            int pairChunkZ = this.namedTag.getInt("pairz") >> 4;
+            IChunk pairChunk = level.getChunkIfLoaded(pairChunkX, pairChunkZ);
+            if (pairChunk != null && pairChunk.isInitiated()) {
                 this.doubleInventory = null;
                 this.namedTag.remove("pairx");
                 this.namedTag.remove("pairz");
                 this.namedTag.remove("pairlead");
+                this.setDirty();
             }
         }
     }
@@ -159,6 +166,7 @@ public class BlockEntityChest extends BlockEntitySpawnableContainer {
         this.doubleInventory = null;
         this.namedTag.remove("pairx");
         this.namedTag.remove("pairz");
+        this.setDirty();
 
         this.spawnToAll();
 
@@ -167,6 +175,7 @@ public class BlockEntityChest extends BlockEntitySpawnableContainer {
             chest.namedTag.remove("pairz");
             chest.doubleInventory = null;
             chest.checkPairing();
+            chest.setDirty();
             chest.spawnToAll();
         }
         this.checkPairing();

--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -185,6 +185,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
     public int freezingTicks = 0;//0 - 140
     public float scale = 1;
     public CompoundTag namedTag;
+    public volatile CompoundTag serializationSnapshot;
     public boolean isCollided = false;
     public boolean isCollidedHorizontally = false;
     public boolean isCollidedVertically = false;

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -982,13 +982,12 @@ public class Level implements Metadatable {
 
     public Map<Integer, Player> getChunkPlayers(int chunkX, int chunkZ) {
         long index = Level.chunkHash(chunkX, chunkZ);
-        if (this.chunkLoaders.containsKey(index)) {
-            return this.chunkLoaders.get(index).entrySet()
+        Map<Integer, ChunkLoader> loaders = this.chunkLoaders.get(index);
+        if (loaders != null) {
+            return loaders.entrySet()
                     .stream()
                     .filter(e -> (e.getValue() instanceof Player p && p.getPlayerChunkManager().isSentChunk(index)))
-                    .collect(HashMap::new, (m, e) -> {
-                        m.put(e.getKey(), (Player) e.getValue());
-                    }, HashMap::putAll);
+                    .collect(HashMap::new, (m, e) -> m.put(e.getKey(), (Player) e.getValue()), HashMap::putAll);
         }
         return Collections.emptyMap();
     }
@@ -1015,13 +1014,16 @@ public class Level implements Metadatable {
     public void registerChunkLoader(ChunkLoader loader, int chunkX, int chunkZ, boolean autoLoad) {
         int hash = loader.getLoaderId();
         long index = Level.chunkHash(chunkX, chunkZ);
-        if (!this.chunkLoaders.containsKey(index)) {
-            this.chunkLoaders.put(index, new HashMap<>());
-        } else if (this.chunkLoaders.get(index).containsKey(hash)) {
+        Map<Integer, ChunkLoader> loaders = this.chunkLoaders.get(index);
+        if (loaders == null) {
+            loaders = new ConcurrentHashMap<>();
+            this.chunkLoaders.put(index, loaders);
+        }
+        if (loaders.containsKey(hash)) {
             return;
         }
 
-        this.chunkLoaders.get(index).put(hash, loader);
+        loaders.put(hash, loader);
 
         if (!this.loaders.containsKey(hash)) {
             this.loaderCounter.put(hash, 1);

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -4337,6 +4337,18 @@ public class Level implements Metadatable {
                     }
 
                     if (chunk.hasChanged() || !chunk.getBlockEntities().isEmpty() || entities > 0) {
+                        for (BlockEntity be : chunk.getBlockEntities().values()) {
+                            if (!be.closed) {
+                                be.saveNBT();
+                                be.serializationSnapshot = be.namedTag.copy();
+                            }
+                        }
+                        for (Entity e : chunk.getEntities().values()) {
+                            if (!(e instanceof Player) && !e.closed) {
+                                e.saveNBT();
+                                e.serializationSnapshot = e.namedTag.copy();
+                            }
+                        }
                         levelProvider.setChunk(x, z, chunk);
                         levelProvider.saveChunk(x, z);
                     }
@@ -4745,6 +4757,20 @@ public class Level implements Metadatable {
                         .collect(Collectors.toUnmodifiableSet());
 
                 if (!chunksToSave.isEmpty() && getAutoSave()) {
+                    for (IChunk c : chunksToSave) {
+                        for (BlockEntity be : c.getBlockEntities().values()) {
+                            if (!be.closed) {
+                                be.saveNBT();
+                                be.serializationSnapshot = be.namedTag.copy();
+                            }
+                        }
+                        for (Entity e : c.getEntities().values()) {
+                            if (!(e instanceof Player) && !e.closed) {
+                                e.saveNBT();
+                                e.serializationSnapshot = e.namedTag.copy();
+                            }
+                        }
+                    }
                     requireProvider().saveChunks(chunksToSave);
                 }
 

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -1023,15 +1023,14 @@ public class Level implements Metadatable {
             return;
         }
 
-        loaders.put(hash, loader);
-
-        if (!this.loaders.containsKey(hash)) {
-            this.loaderCounter.put(hash, 1);
-            synchronized (this.loaders) {
+        synchronized (this.loaders) {
+            loaders.put(hash, loader);
+            if (!this.loaders.containsKey(hash)) {
+                this.loaderCounter.put(hash, 1);
                 this.loaders.put(hash, loader);
+            } else {
+                this.loaderCounter.put(hash, this.loaderCounter.get(hash) + 1);
             }
-        } else {
-            this.loaderCounter.put(hash, this.loaderCounter.get(hash) + 1);
         }
 
         this.cancelUnloadChunkRequest(chunkX, chunkZ);
@@ -1054,14 +1053,14 @@ public class Level implements Metadatable {
                     return this.unloadChunkRequest(chunkX, chunkZ, isSafeUnload);
                 }
 
-                int count = this.loaderCounter.get(loaderId);
-                if (--count == 0) {
-                    this.loaderCounter.remove(loaderId);
-                    synchronized (this.loaders) {
+                synchronized (this.loaders) {
+                    int count = this.loaderCounter.get(loaderId);
+                    if (--count == 0) {
+                        this.loaderCounter.remove(loaderId);
                         this.loaders.remove(loaderId);
+                    } else {
+                        this.loaderCounter.put(loaderId, count);
                     }
-                } else {
-                    this.loaderCounter.put(loaderId, count);
                 }
                 return true;
             }

--- a/src/main/java/cn/nukkit/level/format/leveldb/LevelDBChunkSerializer.java
+++ b/src/main/java/cn/nukkit/level/format/leveldb/LevelDBChunkSerializer.java
@@ -31,6 +31,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import it.unimi.dsi.fastutil.objects.ReferenceArrayList;
+import lombok.extern.slf4j.Slf4j;
 import org.iq80.leveldb.DB;
 import org.iq80.leveldb.WriteBatch;
 
@@ -50,6 +51,7 @@ import java.util.Set;
  *
  * @author Cool_Loong
  */
+@Slf4j
 public class LevelDBChunkSerializer {
     public static final LevelDBChunkSerializer INSTANCE = new LevelDBChunkSerializer();
 
@@ -349,17 +351,28 @@ public class LevelDBChunkSerializer {
     }
 
     private void serializeTileAndEntity(WriteBatch writeBatch, IChunk chunk) {
-        //Write blockEntities
-        Collection<BlockEntity> blockEntities = chunk.getBlockEntities().values();
+        List<BlockEntity> blockEntitySnapshot = new ArrayList<>(chunk.getBlockEntities().values());
         ByteBuf tileBuffer = ByteBufAllocator.DEFAULT.ioBuffer();
         try (final LittleEndianByteBufOutputStream bufOutputStream = new LittleEndianByteBufOutputStream(tileBuffer);
              final NBTOutputStream nbtOutputStream = new NBTOutputStream(bufOutputStream, ByteOrder.LITTLE_ENDIAN, false)) {
             byte[] key = LevelDBKeyUtil.BLOCK_ENTITIES.getKey(chunk.getX(), chunk.getZ(), chunk.getProvider().getDimensionData());
-            if (blockEntities.isEmpty()) writeBatch.delete(key);
+            if (blockEntitySnapshot.isEmpty()) writeBatch.delete(key);
             else {
-                for (BlockEntity blockEntity : blockEntities) {
-                    blockEntity.saveNBT();
-                    nbtOutputStream.writeTag(blockEntity.namedTag);
+                for (BlockEntity blockEntity : blockEntitySnapshot) {
+                    try {
+                        CompoundTag tag = blockEntity.serializationSnapshot;
+                        if (tag != null) {
+                            blockEntity.serializationSnapshot = null;
+                        } else {
+                            blockEntity.saveNBT();
+                            tag = blockEntity.namedTag.copy();
+                        }
+                        nbtOutputStream.writeTag(tag);
+                    } catch (Exception e) {
+                        log.error("Failed to serialize block entity {} at {},{},{} in chunk [{},{}]",
+                                blockEntity.getSaveId(), (int) blockEntity.x, (int) blockEntity.y, (int) blockEntity.z,
+                                chunk.getX(), chunk.getZ(), e);
+                    }
                 }
                 writeBatch.put(key, Utils.convertByteBuf2Array(tileBuffer));
             }
@@ -369,18 +382,30 @@ public class LevelDBChunkSerializer {
             tileBuffer.release();
         }
 
-        Collection<Entity> entities = chunk.getEntities().values();
+        List<Entity> entitySnapshot = new ArrayList<>(chunk.getEntities().values());
         ByteBuf entityBuffer = ByteBufAllocator.DEFAULT.ioBuffer();
         try (final LittleEndianByteBufOutputStream bufOutputStream = new LittleEndianByteBufOutputStream(entityBuffer);
              final NBTOutputStream nbtOutputStream = new NBTOutputStream(bufOutputStream, ByteOrder.LITTLE_ENDIAN, false)) {
             byte[] key = LevelDBKeyUtil.ENTITIES.getKey(chunk.getX(), chunk.getZ(), chunk.getProvider().getDimensionData());
-            if (entities.isEmpty()) {
+            if (entitySnapshot.isEmpty()) {
                 writeBatch.delete(key);
             } else {
-                for (Entity e : entities) {
+                for (Entity e : entitySnapshot) {
                     if (!(e instanceof Player) && !e.closed && e.canBeSavedWithChunk()) {
-                        e.saveNBT();
-                        nbtOutputStream.writeTag(e.namedTag);
+                        try {
+                            CompoundTag tag = e.serializationSnapshot;
+                            if (tag != null) {
+                                e.serializationSnapshot = null;
+                            } else {
+                                e.saveNBT();
+                                tag = e.namedTag.copy();
+                            }
+                            nbtOutputStream.writeTag(tag);
+                        } catch (Exception ex) {
+                            log.error("Failed to serialize entity {} at {},{},{} in chunk [{},{}]",
+                                    e.getIdentifier(), (int) e.x, (int) e.y, (int) e.z,
+                                    chunk.getX(), chunk.getZ(), ex);
+                        }
                     }
                 }
                 writeBatch.put(key, Utils.convertByteBuf2Array(entityBuffer));


### PR DESCRIPTION
## Changes
- Removed `unpair()` from `close()`: If a chunk unloads with a double chest spanning over two chunks, the chest is unpaired, thus potentially writing a corrupted state to storage.
- Hardened `checkPairing()` against uninitialized chunks: A chunk may be loaded but not yet have its block entities created by `initChunk()` - the old check would falsely conclude the pair was missing and unpair.
- Added dirty tracking to pairing-related changes