### PR TITLE
Fix grass fade below barrier

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockBarrier.java
+++ b/src/main/java/cn/nukkit/block/BlockBarrier.java
@@ -39,11 +39,6 @@ public class BlockBarrier extends BlockSolid {
     }
 
     @Override
-    public boolean canBeFlowedInto() {
-        return false;
-    }
-
-    @Override
     public double getHardness() {
         return -1;
     }
@@ -61,5 +56,10 @@ public class BlockBarrier extends BlockSolid {
     @Override
     public boolean canBePushed() {
         return false;
+    }
+
+    @Override
+    public int getLightFilter() {
+        return 1;
     }
 }


### PR DESCRIPTION
* Set Block.getLightFilter of BlockBarrier to 1 to prevent grass fading
* Remove redundant override Block.canBeFlowedInto