### PR TITLE
Centralize server/network/session constants

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -168,6 +168,16 @@ import java.util.regex.Pattern;
 public class Server {
     public static final String BROADCAST_CHANNEL_ADMINISTRATIVE = "nukkit.broadcast.admin";
     public static final String BROADCAST_CHANNEL_USERS = "nukkit.broadcast.user";
+
+    private static final long TICK_DURATION_MS = 50;
+    private static final int MAX_TPS = 20;
+    private static final long TICK_EARLY_THRESHOLD_MS = 25;
+    private static final long TICK_SLEEP_MIN_MS = 5;
+    private static final long TICK_RESYNC_THRESHOLD_MS = 1000;
+    private static final int TICK_TITLE_INTERVAL = 0b1111;
+    private static final int TICK_QUERY_INTERVAL = 0b111111111;
+    private static final int TICK_AUTOSAVE_INTERVAL = 511;
+
     private static Server instance = null;
 
     private BanList banByName;
@@ -600,26 +610,7 @@ public class Server {
 
         this.serverID = UUID.randomUUID();
         this.pluginManager.loadPlugins(this.pluginPath);
-        {// trim
-            Registries.POTION.trim();
-            Registries.PACKET.trim();
-            Registries.ENTITY.trim();
-            Registries.BLOCKENTITY.trim();
-            Registries.BLOCKSTATE.trim();
-            Registries.ITEM_RUNTIMEID.trim();
-            Registries.BLOCK.trim();
-            Registries.ITEM.trim();
-            Registries.CREATIVE.trim();
-            Registries.BIOME.trim();
-            Registries.FUEL.trim();
-            Registries.GENERATOR.trim();
-            Registries.POPULATOR.trim();
-            Registries.GENERATE_STAGE.trim();
-            Registries.STRUCTURE.trim();
-            Registries.EFFECT.trim();
-            Registries.RECIPE.trim();
-            Registries.VOXEL_SHAPE.trim();
-        }
+        trimRegistries();
 
         this.enablePlugins(PluginLoadOrder.STARTUP);
 
@@ -798,49 +789,13 @@ public class Server {
         this.scoreboardManager.read();
 
         log.info("Reloading registries...");
-        {
-            Registries.POTION.reload();
-            Registries.PACKET.reload();
-            Registries.ENTITY.reload();
-            Registries.BLOCKENTITY.reload();
-            Registries.BLOCKSTATE.reload();
-            Registries.ITEM_RUNTIMEID.reload();
-            Registries.BLOCK.reload();
-            Registries.ITEM.reload();
-            Registries.CREATIVE.reload();
-            Registries.BIOME.reload();
-            Registries.FUEL.reload();
-            Registries.GENERATOR.reload();
-            Registries.GENERATE_STAGE.reload();
-            Registries.POPULATOR.reload();
-            Registries.GENERATE_FEATURE.reload();
-            Registries.STRUCTURE.reload();
-            Registries.EFFECT.reload();
-            Registries.RECIPE.reload();
-            Enchantment.reload();
-        }
+        reloadRegistries();
 
         this.pluginManager.loadPlugins(this.pluginPath);
         this.functionManager.reload();
 
         this.enablePlugins(PluginLoadOrder.STARTUP);
-        {
-            Registries.POTION.trim();
-            Registries.PACKET.trim();
-            Registries.ENTITY.trim();
-            Registries.BLOCKENTITY.trim();
-            Registries.BLOCKSTATE.trim();
-            Registries.ITEM_RUNTIMEID.trim();
-            Registries.BLOCK.trim();
-            Registries.ITEM.trim();
-            Registries.CREATIVE.trim();
-            Registries.BIOME.trim();
-            Registries.FUEL.trim();
-            Registries.GENERATOR.trim();
-            Registries.GENERATE_STAGE.trim();
-            Registries.EFFECT.trim();
-            Registries.RECIPE.trim();
-        }
+        trimRegistries();
         this.enablePlugins(PluginLoadOrder.POSTWORLD);
         this.network.setState(NetworkState.STARTED);
     }
@@ -1010,12 +965,12 @@ public class Server {
                     level.doTick(currentTick);
                     int tickMs = (int) (System.currentTimeMillis() - levelTime);
                     level.tickRateTime = tickMs;
-                    if ((currentTick & 511) == 0) { // % 511
+                    if ((currentTick & TICK_AUTOSAVE_INTERVAL) == 0) {
                         level.tickRateOptDelay = level.recalcTickOptDelay();
                     }
 
                     if (getSettings().levelSettings().autoTickRate()) {
-                        if (tickMs < 50 && level.getTickRate() > baseTickRate) {
+                        if (tickMs < TICK_DURATION_MS && level.getTickRate() > baseTickRate) {
                             int r;
                             level.setTickRate(r = level.getTickRate() - 1);
                             if (r > baseTickRate) {
@@ -1023,13 +978,13 @@ public class Server {
                             }
                             log.debug("Raising level \"{}\" tick rate to {} ticks", level.getName(),
                                     level.getTickRate());
-                        } else if (tickMs >= 50) {
+                        } else if (tickMs >= TICK_DURATION_MS) {
                             int autoTickRateLimit = getSettings().levelSettings().autoTickRateLimit();
                             if (level.getTickRate() == baseTickRate) {
-                                level.setTickRate(Math.max(baseTickRate + 1, Math.min(autoTickRateLimit, tickMs / 50)));
+                                level.setTickRate(Math.max(baseTickRate + 1, Math.min(autoTickRateLimit, tickMs / TICK_DURATION_MS)));
                                 log.debug("Level \"{}\" took {}ms, setting tick rate to {} ticks", level.getName(),
                                         NukkitMath.round(tickMs, 2), level.getTickRate());
-                            } else if ((tickMs / level.getTickRate()) >= 50
+                            } else if ((tickMs / level.getTickRate()) >= TICK_DURATION_MS
                                     && level.getTickRate() < autoTickRateLimit) {
                                 level.setTickRate(level.getTickRate() + 1);
                                 log.debug("Level \"{}\" took {}ms, setting tick rate to {} ticks", level.getName(),
@@ -1068,16 +1023,16 @@ public class Server {
         long tickTime = System.currentTimeMillis();
 
         long time = tickTime - this.nextTick;
-        if (time < -25) {
+        if (time < -TICK_EARLY_THRESHOLD_MS) {
             try {
-                Thread.sleep(Math.max(5, -time - 25));
+                Thread.sleep(Math.max(TICK_SLEEP_MIN_MS, -time - TICK_EARLY_THRESHOLD_MS));
             } catch (InterruptedException e) {
                 log.debug("The thread {} got interrupted", Thread.currentThread().getName(), e);
             }
         }
 
         long tickTimeNano = System.nanoTime();
-        if ((tickTime - this.nextTick) < -25) {
+        if ((tickTime - this.nextTick) < -TICK_EARLY_THRESHOLD_MS) {
             return;
         }
 
@@ -1088,12 +1043,12 @@ public class Server {
 
         this.checkTickUpdates(this.tickCounter);
 
-        if ((this.tickCounter & 0b1111) == 0) {
+        if ((this.tickCounter & TICK_TITLE_INTERVAL) == 0) {
             this.titleTick();
-            this.maxTick = 20;
+            this.maxTick = MAX_TPS;
             this.maxUse = 0;
 
-            if ((this.tickCounter & 0b111111111) == 0) {
+            if ((this.tickCounter & TICK_QUERY_INTERVAL) == 0) {
                 try {
                     this.getPluginManager().callEvent(this.queryRegenerateEvent = new QueryRegenerateEvent(this, 5));
                 } catch (Exception e) {
@@ -1115,13 +1070,13 @@ public class Server {
         }
 
         // Handle freezable array
-        int freezableArrayCompressTime = (int) (50 - (System.currentTimeMillis() - tickTime));
+        int freezableArrayCompressTime = (int) (TICK_DURATION_MS - (System.currentTimeMillis() - tickTime));
         if (freezableArrayCompressTime > 4) {
             getFreezableArrayManager().setMaxCompressionTime(freezableArrayCompressTime).tick();
         }
 
         long nowNano = System.nanoTime();
-        float tick = (float) Math.min(20, 1000000000 / Math.max(1000000, ((double) nowNano - tickTimeNano)));
+        float tick = (float) Math.min(MAX_TPS, 1000000000 / Math.max(1000000, ((double) nowNano - tickTimeNano)));
         float use = (float) Math.min(1, ((double) (nowNano - tickTimeNano)) / 50000000);
 
         if (this.maxTick > tick) {
@@ -1138,10 +1093,10 @@ public class Server {
         System.arraycopy(this.useAverage, 1, this.useAverage, 0, this.useAverage.length - 1);
         this.useAverage[this.useAverage.length - 1] = use;
 
-        if ((this.nextTick - tickTime) < -1000) {
+        if ((this.nextTick - tickTime) < -TICK_RESYNC_THRESHOLD_MS) {
             this.nextTick = tickTime;
         } else {
-            this.nextTick += 50;
+            this.nextTick += TICK_DURATION_MS;
         }
 
     }
@@ -1180,7 +1135,7 @@ public class Server {
         for (float aUseAverage : this.useAverage) {
             sum += aUseAverage;
         }
-        return ((float) Math.round(sum / count * 100)) / 100;
+        return (float) NukkitMath.round(sum / count, 2);
     }
 
     public String getCPULoad() {
@@ -1254,6 +1209,49 @@ public class Server {
 
     public long getLaunchTime() {
         return launchTime;
+    }
+
+    private static void trimRegistries() {
+        Registries.POTION.trim();
+        Registries.PACKET.trim();
+        Registries.ENTITY.trim();
+        Registries.BLOCKENTITY.trim();
+        Registries.BLOCKSTATE.trim();
+        Registries.ITEM_RUNTIMEID.trim();
+        Registries.BLOCK.trim();
+        Registries.ITEM.trim();
+        Registries.CREATIVE.trim();
+        Registries.BIOME.trim();
+        Registries.FUEL.trim();
+        Registries.GENERATOR.trim();
+        Registries.POPULATOR.trim();
+        Registries.GENERATE_STAGE.trim();
+        Registries.STRUCTURE.trim();
+        Registries.EFFECT.trim();
+        Registries.RECIPE.trim();
+        Registries.VOXEL_SHAPE.trim();
+    }
+
+    private static void reloadRegistries() {
+        Registries.POTION.reload();
+        Registries.PACKET.reload();
+        Registries.ENTITY.reload();
+        Registries.BLOCKENTITY.reload();
+        Registries.BLOCKSTATE.reload();
+        Registries.ITEM_RUNTIMEID.reload();
+        Registries.BLOCK.reload();
+        Registries.ITEM.reload();
+        Registries.CREATIVE.reload();
+        Registries.BIOME.reload();
+        Registries.FUEL.reload();
+        Registries.GENERATOR.reload();
+        Registries.GENERATE_STAGE.reload();
+        Registries.POPULATOR.reload();
+        Registries.GENERATE_FEATURE.reload();
+        Registries.STRUCTURE.reload();
+        Registries.EFFECT.reload();
+        Registries.RECIPE.reload();
+        Enchantment.reload();
     }
 
     // endregion

--- a/src/main/java/cn/nukkit/network/Network.java
+++ b/src/main/java/cn/nukkit/network/Network.java
@@ -58,6 +58,10 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 @Slf4j
 public class Network implements NetworkInterface {
+    public static final int RAKNET_SUPPORTED_PROTOCOL = 11;
+    public static final int BAN_FOREVER_YEAR = 9999;
+    public static final String FALLBACK_IP = "0.0.0.0";
+
     private final Server server;
     private final LinkedList<NetWorkStatisticData> netWorkStatisticDataList = new LinkedList<>();
     private final AtomicReference<List<NetworkIF>> hardWareNetworkInterfaces = new AtomicReference<>(null);
@@ -102,7 +106,7 @@ public class Network implements NetworkInterface {
             oclass = NioDatagramChannel.class;
             eventloopgroup = new NioEventLoopGroup(nettyThreadNumber, threadFactory);
         }
-        InetSocketAddress bindAddress = new InetSocketAddress(Strings.isNullOrEmpty(this.server.getIp()) ? "0.0.0.0" : this.server.getIp(), this.server.getPort());
+        InetSocketAddress bindAddress = new InetSocketAddress(Strings.isNullOrEmpty(this.server.getIp()) ? FALLBACK_IP : this.server.getIp(), this.server.getPort());
 
         this.pong = new BedrockPong()
                 .edition("MCPE")
@@ -120,7 +124,7 @@ public class Network implements NetworkInterface {
         this.channel = (RakServerChannel) new ServerBootstrap()
                 .channelFactory(RakChannelFactory.server(oclass))
                 .option(RakChannelOption.RAK_ADVERTISEMENT, getAdvertisement())
-                .option(RakChannelOption.RAK_SUPPORTED_PROTOCOLS, new int[] {11})
+                .option(RakChannelOption.RAK_SUPPORTED_PROTOCOLS, new int[] {RAKNET_SUPPORTED_PROTOCOL})
                 .option(RakChannelOption.RAK_PACKET_LIMIT, server.getSettings().networkSettings().packetLimit())
                 .option(RakChannelOption.RAK_SERVER_COOKIE_MODE, RakServerCookieMode.ACTIVE)
                 .group(eventloopgroup)
@@ -238,7 +242,7 @@ public class Network implements NetworkInterface {
      * @param address the address
      */
     public void blockAddress(InetAddress address) {
-        blockIpMap.put(address, LocalDateTime.of(9999, 1, 1, 0, 0));
+        blockIpMap.put(address, LocalDateTime.of(BAN_FOREVER_YEAR, 1, 1, 0, 0));
     }
 
     /**

--- a/src/main/java/cn/nukkit/network/connection/BedrockSession.java
+++ b/src/main/java/cn/nukkit/network/connection/BedrockSession.java
@@ -72,6 +72,31 @@ import java.util.function.Consumer;
 
 @Slf4j
 public class BedrockSession {
+    // Coalescing
+    private static final int COALESCE_TARGET_BYTES = 1200;
+    private static final int COALESCE_MIN_BYTES = 256;
+
+    // Estimate sizes for paced bulk packets
+    private static final int RP_CHUNK_ESTIMATE = 64 * 1024;
+    private static final int CREATIVE_CONTENT_ESTIMATE = 192 * 1024;
+    private static final int ITEM_REGISTRY_ESTIMATE = 8 * 1024;
+
+    // Clamp bounds for pacing config
+    private static final int PACING_FLUSH_MIN = 1;
+    private static final int PACING_FLUSH_MAX = 20;
+    private static final int PACING_BYTES_MIN = 64 * 1024;
+    private static final int PACING_BYTES_MAX = 64 * 1024 * 1024;
+
+    // Clamp bounds for rate limiting
+    private static final int INBOUND_RATE_MIN = 100;
+    private static final int INBOUND_RATE_MAX = 10_000;
+    private static final int PACKETS_PER_TICK_MIN = 50;
+    private static final int PACKETS_PER_TICK_MAX = 5_000;
+
+    // OutboundScheduler limits
+    private static final int MIN_BYTES_PER_SEC = 1024;
+    private static final int MIN_BYTES_PER_PACKET = 32;
+
     private final AtomicBoolean closed = new AtomicBoolean();
     protected final BedrockPeer peer;
     protected final int subClientId;
@@ -122,8 +147,8 @@ public class BedrockSession {
         int pacingMaxBytesPerSecond = pc.maxBytesPerSec;
         this.scheduler = new OutboundScheduler(
                 pacingMaxBytesPerSecond,
-                1200,
-                256,
+                COALESCE_TARGET_BYTES,
+                COALESCE_MIN_BYTES,
                 pacingFlushIntervalMillis
         );
 
@@ -744,12 +769,12 @@ public class BedrockSession {
 
     private static int estimateBytes(DataPacket pk) {
         if (pk instanceof ResourcePackChunkDataPacket rp) {
-            return (rp.data != null ? rp.data.length : 64 * 1024);
+            return (rp.data != null ? rp.data.length : RP_CHUNK_ESTIMATE);
         }
         return switch (pk.pid()) {
-            case ProtocolInfo.CREATIVE_CONTENT_PACKET -> 192 * 1024;
-            case ProtocolInfo.ITEM_REGISTRY_PACKET -> 8 * 1024;
-            default -> 256;
+            case ProtocolInfo.CREATIVE_CONTENT_PACKET -> CREATIVE_CONTENT_ESTIMATE;
+            case ProtocolInfo.ITEM_REGISTRY_PACKET -> ITEM_REGISTRY_ESTIMATE;
+            default -> COALESCE_MIN_BYTES;
         };
     }
 
@@ -768,8 +793,8 @@ public class BedrockSession {
         var net = Server.getInstance().getSettings().networkSettings();
 
         boolean en = net.pacingEnabled();
-        int flush = clamp(net.pacingFlushIntervalMillis(), 1, 20);
-        int bps = clamp(net.pacingMaxBytesPerSecond(), 64 * 1024, 64 * 1024 * 1024); // allow up to 64 MiB/s
+        int flush = clamp(net.pacingFlushIntervalMillis(), PACING_FLUSH_MIN, PACING_FLUSH_MAX);
+        int bps = clamp(net.pacingMaxBytesPerSecond(), PACING_BYTES_MIN, PACING_BYTES_MAX);
 
         return new PacingConfig(en, flush, bps);
     }
@@ -780,8 +805,8 @@ public class BedrockSession {
     private RateLimitConfig loadRateLimitConfigSafely() {
         RateLimitSettings settings = Server.getInstance().getSettings().networkSettings().rateLimitSettings();
         boolean en = settings.rateLimitEnabled();
-        int maxInbound = clamp(settings.maxInboundPacketsPerSecond(), 100, 10_000);
-        int maxPerTick = clamp(settings.maxPacketsPerTick(), 50, 5_000);
+        int maxInbound = clamp(settings.maxInboundPacketsPerSecond(), INBOUND_RATE_MIN, INBOUND_RATE_MAX);
+        int maxPerTick = clamp(settings.maxPacketsPerTick(), PACKETS_PER_TICK_MIN, PACKETS_PER_TICK_MAX);
         return new RateLimitConfig(en, maxInbound, maxPerTick);
     }
 
@@ -816,7 +841,7 @@ public class BedrockSession {
                           int coalesceTargetBytes,
                           int coalesceMinBytes,
                           int flushIntervalMillis) {
-            this.maxBytesPerSec = Math.max(1024, maxBytesPerSec);
+            this.maxBytesPerSec = Math.max(MIN_BYTES_PER_SEC, maxBytesPerSec);
             this.burstBytes = this.maxBytesPerSec; // burst = 1 second budget
             this.coalesceTargetBytes = coalesceTargetBytes;
             this.coalesceMinBytes = coalesceMinBytes;
@@ -826,12 +851,12 @@ public class BedrockSession {
 
         synchronized void enqueueResourcePackChunk(DataPacket pk, int estimatedBytes) {
             this.rpQ.addLast(pk);
-            this.headBytes += Math.max(estimatedBytes, 32);
+            this.headBytes += Math.max(estimatedBytes, MIN_BYTES_PER_PACKET);
         }
 
         synchronized void enqueueRegistryBulk(DataPacket pk, int estimatedBytes) {
             this.registryQ.addLast(pk);
-            this.headBytes += Math.max(estimatedBytes, 32);
+            this.headBytes += Math.max(estimatedBytes, MIN_BYTES_PER_PACKET);
         }
 
         synchronized void tryPump(BedrockPeer peer, int subClientId, BedrockSession session) {


### PR DESCRIPTION
Replace numerous hard-coded magic numbers with named constants and extract duplicated registry calls into helper methods.

- Server: introduce tick-related constants (TICK_DURATION_MS, MAX_TPS, TICK_* intervals, thresholds, etc.), replace inline literals in tick logic, use NukkitMath.round for use average, and extract registry trim/reload blocks into trimRegistries() and reloadRegistries() to remove duplication.
- Network: add RAKNET_SUPPORTED_PROTOCOL, BAN_FOREVER_YEAR and FALLBACK_IP constants; use them for bind address, supported protocols option, and blockAddress ban time.
- BedrockSession: add many constants for coalescing, pacing and rate-limiting bounds (e.g. COALESCE_TARGET_BYTES, RP_CHUNK_ESTIMATE, PACING_* limits, INBOUND_RATE_*), apply them to scheduler setup, packet size estimation, clamping ranges and outbound scheduler limits; replace literal minimums with named mins.

Overall this refactors magic numbers into configurable constants, reduces duplicated code, and clarifies intent for future tuning. No functional behavior changes intended beyond replacing literals with constants and clamped bounds.