### PR TITLE
enhancement: Add beforeStop plugin lifecycle hook

### DIFF
--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -177,7 +177,7 @@ public class Server {
     private final AtomicBoolean isRunning = new AtomicBoolean(true);
     private final LongList busyingTime = LongLists.synchronize(new LongArrayList(0));
     private boolean hasStopped = false;
-    private boolean hasBeforeStopped = false;
+    private final AtomicBoolean hasBeforeStopped = new AtomicBoolean(false);
     private PluginManager pluginManager;
     private ServerScheduler scheduler;
     /**
@@ -932,8 +932,7 @@ public class Server {
     }
 
     private void beforeStop() {
-        if (!this.hasBeforeStopped) {
-            this.hasBeforeStopped = true;
+        if (this.hasBeforeStopped.compareAndSet(false, true)) {
             this.pluginManager.beforeStopPlugins();
         }
     }

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -177,6 +177,7 @@ public class Server {
     private final AtomicBoolean isRunning = new AtomicBoolean(true);
     private final LongList busyingTime = LongLists.synchronize(new LongArrayList(0));
     private boolean hasStopped = false;
+    private boolean hasBeforeStopped = false;
     private PluginManager pluginManager;
     private ServerScheduler scheduler;
     /**
@@ -849,6 +850,8 @@ public class Server {
      * Shutdown the server
      */
     public void shutdown() {
+        this.beforeStop();
+
         network.setState(NetworkState.STOPPING);
         isRunning.compareAndSet(true, false);
     }
@@ -862,6 +865,8 @@ public class Server {
         }
 
         try {
+            this.beforeStop();
+
             network.setState(NetworkState.STOPPING);
             isRunning.compareAndSet(true, false);
 
@@ -923,6 +928,13 @@ public class Server {
         } catch (Exception e) {
             log.error("Exception happened while shutting down, exiting the process", e);
             System.exit(1);
+        }
+    }
+
+    private void beforeStop() {
+        if (!this.hasBeforeStopped) {
+            this.hasBeforeStopped = true;
+            this.pluginManager.beforeStopPlugins();
         }
     }
 

--- a/src/main/java/cn/nukkit/plugin/Plugin.java
+++ b/src/main/java/cn/nukkit/plugin/Plugin.java
@@ -80,7 +80,9 @@ public interface Plugin extends CommandExecutor {
     /**
      * Called before the server starts stopping.
      */
-    void beforeStop();
+    default void beforeStop() {
+
+    }
 
     /**
      * 返回这个Nukkit插件是否已停用。<br>

--- a/src/main/java/cn/nukkit/plugin/Plugin.java
+++ b/src/main/java/cn/nukkit/plugin/Plugin.java
@@ -8,17 +8,14 @@ import java.io.File;
 import java.io.InputStream;
 
 /**
- * 所有Nukkit插件必须实现的接口。<br>
- * An interface what must be implemented by all Nukkit plugins.
+ * Represents the base contract that all Nukkit plugins must implement.
  *
- * <p>对于插件作者，我们建议让插件主类继承{@link cn.nukkit.plugin.PluginBase}类，而不是实现这个接口。<br>
- * For plugin developers: it's recommended to use {@link cn.nukkit.plugin.PluginBase} for an actual plugin
- * instead of implement this interface.</p>
+ * <p>Plugin developers should usually extend {@link PluginBase} instead of
+ * implementing this interface directly.</p>
  *
  * @author MagicDroidX(code) @ Nukkit Project
- * @author 粉鞋大妈(javadoc) @ Nukkit Project
- * @see cn.nukkit.plugin.PluginBase
- * @see cn.nukkit.plugin.PluginDescription
+ * @see PluginBase
+ * @see PluginDescription
  * @since Nukkit 1.0 | Nukkit API 1.0.0
  */
 public interface Plugin extends CommandExecutor {
@@ -27,274 +24,255 @@ public interface Plugin extends CommandExecutor {
     Plugin[] EMPTY_ARRAY = new Plugin[0];
 
     /**
-     * 在一个Nukkit插件被加载时调用的方法。这个方法会在{@link Plugin#onEnable()}之前调用。<br>
-     * Called when a Nukkit plugin is loaded, before {@link Plugin#onEnable()} .
+     * Called when this plugin is loaded, before {@link #onEnable()}.
      *
-     * <p>应该填写加载插件时需要作出的动作。例如：初始化数组、初始化数据库连接。<br>
-     * Use this to init a Nukkit plugin, such as init arrays or init database connections.</p>
+     * <p>Use this method to initialize internal data structures, load static resources,
+     * or prepare database connections before the plugin is enabled.</p>
      *
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
     void onLoad();
 
     /**
-     * 在一个Nukkit插件被启用时调用的方法。<br>
-     * Called when a Nukkit plugin is enabled.
+     * Called when this plugin is enabled.
      *
-     * <p>应该填写插件启用时需要作出的动作。例如：读取配置文件、读取资源、连接数据库。<br>
-     * Use this to open config files, open resources, connect databases.</p>
+     * <p>Use this method to open configuration files, register listeners,
+     * connect to databases, or start plugin services.</p>
      *
-     * <p>注意到可能存在的插件管理器插件，这个方法在插件多次重启时可能被调用多次。<br>
-     * Notes that there may be plugin manager plugins,
-     * this method can be called many times when a plugin is restarted many times.</p>
+     * <p>This method may be called more than once if the plugin is disabled and
+     * enabled again by a plugin manager.</p>
      *
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
     void onEnable();
 
     /**
-     * 返回这个Nukkit插件是否已启用。<br>
-     * Whether this Nukkit plugin is enabled.
+     * Returns whether this plugin is currently enabled.
      *
-     * @return 这个插件是否已经启用。<br>Whether this plugin is enabled.
+     * @return {@code true} if this plugin is enabled
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
     boolean isEnabled();
 
     /**
-     * 在一个Nukkit插件被停用时调用的方法。<br>
-     * Called when a Nukkit plugin is disabled.
+     * Called when this plugin is disabled.
      *
-     * <p>应该填写插件停用时需要作出的动作。例如：关闭数据库，断开资源。<br>
-     * Use this to free open things and finish actions,
-     * such as disconnecting databases and close resources.</p>
+     * <p>Use this method to stop tasks, save data, close database connections,
+     * unregister resources, and release anything opened by the plugin.</p>
      *
-     * <p>注意到可能存在的插件管理器插件，这个方法在插件多次重启时可能被调用多次。<br>
-     * Notes that there may be plugin manager plugins,
-     * this method can be called many times when a plugin is restarted many times.</p>
+     * <p>This method may be called more than once if the plugin is restarted
+     * by a plugin manager.</p>
      *
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
     void onDisable();
 
     /**
-     * Called before the server starts stopping.
+     * Called synchronously before the server begins its shutdown process.
+     *
+     * <p>This hook allows plugins to perform early shutdown work before the normal
+     * disable phase starts. Shutdown will wait until this method returns.</p>
      */
     default void beforeStop() {
 
     }
 
     /**
-     * 返回这个Nukkit插件是否已停用。<br>
-     * Whether this Nukkit plugin is disabled.
+     * Returns whether this plugin is currently disabled.
      *
-     * @return 这个插件是否已经停用。<br>Whether this plugin is disabled.
+     * @return {@code true} if this plugin is disabled
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
     boolean isDisabled();
 
     /**
-     * 返回这个Nukkit插件的数据文件夹。<br>
-     * The data folder of this Nukkit plugin.
+     * Returns the data folder of this plugin.
      *
-     * <p>一般情况下，数据文件夹名字与插件名字相同，而且都放在nukkit安装目录下的plugins文件夹里。<br>
-     * Under normal circumstances, the data folder has the same name with the plugin,
-     * and is placed in the 'plugins' folder inside the nukkit installation directory.</p>
+     * <p>Under normal circumstances, the data folder has the same name as the plugin
+     * and is placed in the {@code plugins} folder inside the Nukkit installation directory.</p>
      *
-     * @return 这个插件的数据文件夹。<br>The data folder of this plugin.
+     * @return the data folder of this plugin
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
     File getDataFolder();
 
     /**
-     * 返回描述这个Nukkit插件的{@link PluginDescription}对象。<br>
-     * The description this Nukkit plugin as a {@link PluginDescription} object.
+     * Returns the description of this plugin.
      *
-     * <p>对于jar格式的Nukkit插件，插件的描述在plugin.yml文件内定义。<br>
-     * For jar-packed Nukkit plugins, the description is defined in the 'plugin.yml' file.</p>
+     * <p>For jar-packed plugins, the description is defined in the {@code plugin.yml} file.</p>
      *
-     * @return 这个插件的描述。<br>A description of this plugin.
-     * @see cn.nukkit.plugin.PluginDescription
+     * @return the description of this plugin
+     * @see PluginDescription
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
     PluginDescription getDescription();
 
     /**
-     * 读取这个插件特定的资源文件，并返回为{@code InputStream}对象。<br>
-     * Reads a resource of this plugin, and returns as an {@code InputStream} object.
+     * Opens a resource from this plugin and returns it as an {@link InputStream}.
      *
-     * <p>对于jar格式的Nukkit插件，Nukkit会在jar包内的资源文件夹(一般为resources文件夹)寻找资源文件。<br>
-     * For jar-packed Nukkit plugins, Nukkit will look for your resource file in the resources folder,
-     * which is normally named 'resources' and placed in plugin jar file.</p>
+     * <p>For jar-packed plugins, Nukkit looks for the resource inside the plugin jar,
+     * usually in the plugin resources directory.</p>
      *
-     * <p>当你需要把一个文件的所有内容读取为字符串，可以使用{@link cn.nukkit.utils.Utils#readFile}函数，
-     * 来从{@code InputStream}读取所有内容为字符串。例如：<br>
-     * When you need to read the whole file content as a String, you can use {@link cn.nukkit.utils.Utils#readFile}
-     * to read from a {@code InputStream} and get whole content as a String. For example:</p>
-     * <p><code>String string = Utils.readFile(this.getResource("string.txt"));</code></p>
+     * <p>To read the whole resource as a {@link String}, use
+     * {@link cn.nukkit.utils.Utils#readFile(InputStream)}:</p>
      *
-     * @param filename 要读取的资源文件名字。<br>The name of the resource file to read.
-     * @return 读取的资源文件的 {@code InputStream}对象。若错误会返回{@code null}<br>
-     * The resource as an {@code InputStream} object, or {@code null} when an error occurred.
+     * <pre>{@code
+     * String string = Utils.readFile(this.getResource("string.txt"));
+     * }</pre>
+     *
+     * @param filename the name of the resource file to read
+     * @return the resource as an {@link InputStream}, or {@code null} if the resource could not be found or opened
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
     InputStream getResource(String filename);
 
     /**
-     * 保存这个Nukkit插件的资源。<br>
-     * Saves the resource of this plugin.
+     * Saves a plugin resource to this plugin's data folder without replacing an existing file.
      *
-     * <p>对于jar格式的Nukkit插件，Nukkit会在jar包内的资源文件夹寻找资源文件，然后保存到数据文件夹。<br>
-     * For jar-packed Nukkit plugins, Nukkit will look for your resource file in the resources folder,
-     * which is normally named 'resources' and placed in plugin jar file, and copy it into data folder.</p>
+     * <p>For jar-packed plugins, Nukkit looks for the resource inside the plugin jar
+     * and copies it into the plugin data folder.</p>
      *
-     * <p>这个函数通常用来在插件被加载(load)时，保存默认的资源文件。这样插件在启用(enable)时不会错误读取空的资源文件，
-     * 用户也无需从开发者处手动下载资源文件后再使用插件。<br>
-     * This is usually used to save the default plugin resource when the plugin is LOADED .If this is used,
-     * it won't happen to load an empty resource when plugin is ENABLED, and plugin users are not required to get
-     * default resources from the developer and place it manually. </p>
+     * <p>This is usually used to save default plugin resources during the load phase,
+     * so plugin users do not need to manually copy default resources into the data folder.</p>
      *
-     * <p>如果需要替换已存在的资源文件，建议使用{@link cn.nukkit.plugin.Plugin#saveResource(String, boolean)}<br>
-     * If you need to REPLACE an existing resource file, it's recommended
-     * to use {@link cn.nukkit.plugin.Plugin#saveResource(String, boolean)}.</p>
+     * <p>To replace an existing resource file, use {@link #saveResource(String, boolean)}.</p>
      *
-     * @param filename 要保存的资源文件名字。<br>The name of the resource file to save.
-     * @return 保存是否成功。<br>true if the saving action is successful.
-     * @see cn.nukkit.plugin.Plugin#saveDefaultConfig
-     * @see cn.nukkit.plugin.Plugin#saveResource(String, boolean)
+     * @param filename the name of the resource file to save
+     * @return {@code true} if the resource was saved successfully
+     * @see #saveDefaultConfig()
+     * @see #saveResource(String, boolean)
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
     boolean saveResource(String filename);
 
     /**
-     * 保存或替换这个Nukkit插件的资源。<br>
-     * Saves or replaces the resource of this plugin.
+     * Saves a plugin resource to this plugin's data folder.
      *
-     * <p>对于jar格式的Nukkit插件，Nukkit会在jar包内的资源文件夹寻找资源文件，然后保存到数据文件夹。<br>
-     * For jar-packed Nukkit plugins, Nukkit will look for your resource file in the resources folder,
-     * which is normally named 'resources' and placed in plugin jar file, and copy it into data folder.</p>
+     * <p>For jar-packed plugins, Nukkit looks for the resource inside the plugin jar
+     * and copies it into the plugin data folder.</p>
      *
-     * <p>如果需要保存默认的资源文件，建议使用{@link cn.nukkit.plugin.Plugin#saveResource(String)}<br>
-     * If you need to SAVE DEFAULT resource file, it's recommended
-     * to use {@link cn.nukkit.plugin.Plugin#saveResource(String)}.</p>
-     *
-     * @param filename 要保存的资源文件名字。<br>The name of the resource file to save.
-     * @param replace  是否替换目标文件。<br>if true, Nukkit will replace the target resource file.
-     * @return 保存是否成功。<br>true if the saving action is successful.
-     * @see cn.nukkit.plugin.Plugin#saveResource(String)
+     * @param filename the name of the resource file to save
+     * @param replace  whether to replace the target file if it already exists
+     * @return {@code true} if the resource was saved successfully
+     * @see #saveResource(String)
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
-
     boolean saveResource(String filename, boolean replace);
 
+    /**
+     * Saves a plugin resource to this plugin's data folder using a custom output name.
+     *
+     * <p>For jar-packed plugins, Nukkit looks for the resource inside the plugin jar
+     * and copies it into the plugin data folder. If {@code replace} is {@code false},
+     * an existing target file will not be overwritten.</p>
+     *
+     * @param filename   the name of the resource inside the plugin jar
+     * @param outputName the target file name or relative path in the plugin data folder
+     * @param replace    whether to replace the target file if it already exists
+     * @return {@code true} if the resource was saved successfully
+     * @see #saveResource(String)
+     * @see #saveResource(String, boolean)
+     */
     boolean saveResource(String filename, String outputName, boolean replace);
 
     /**
-     * 返回这个Nukkit插件配置文件的{@link cn.nukkit.utils.Config}对象。<br>
-     * The config file this Nukkit plugin as a {@link cn.nukkit.utils.Config} object.
+     * Returns the configuration of this plugin.
      *
-     * <p>一般地，插件的配置保存在数据文件夹下的config.yml文件。<br>
-     * Normally, the plugin config is saved in the 'config.yml' file in its data folder.</p>
+     * <p>Normally, the plugin configuration is saved in the {@code config.yml} file
+     * in the plugin data folder.</p>
      *
-     * @return 插件的配置文件。<br>The configuration of this plugin.
-     * @see cn.nukkit.plugin.Plugin#getDataFolder
+     * @return the configuration of this plugin
+     * @see #getDataFolder()
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
     Config getConfig();
 
     /**
-     * 保存这个Nukkit插件的配置文件。<br>
-     * Saves the plugin config.
+     * Saves this plugin's current configuration to disk.
      *
-     * @see cn.nukkit.plugin.Plugin#getDataFolder
+     * @see #getDataFolder()
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
     void saveConfig();
 
     /**
-     * 保存这个Nukkit插件的默认配置文件。<br>
-     * Saves the DEFAULT plugin config.
+     * Saves the default plugin configuration to the plugin data folder.
      *
-     * <p>执行这个函数时，Nukkit会在资源文件夹内寻找开发者配置好的默认配置文件config.yml，然后保存在数据文件夹。
-     * 如果数据文件夹已经有一个config.yml文件，Nukkit不会替换这个文件。<br>
-     * When this is used, Nukkit will look for the default 'config.yml' file which is configured by plugin developer
-     * and save it to the data folder. If a config.yml file exists in the data folder, Nukkit won't replace it.</p>
+     * <p>Nukkit looks for the default {@code config.yml} file provided by the plugin
+     * developer and saves it to the plugin data folder. If {@code config.yml} already
+     * exists in the data folder, it will not be replaced.</p>
      *
-     * <p>这个函数通常用来在插件被加载(load)时，保存默认的配置文件。这样插件在启用(enable)时不会错误读取空的配置文件，
-     * 用户也无需从开发者处手动下载配置文件保存后再使用插件。<br>
-     * This is usually used to save the default plugin config when the plugin is LOADED .If this is used,
-     * it won't happen to load an empty config when plugin is ENABLED, and plugin users are not required to get
-     * default config from the developer and place it manually. </p>
+     * <p>This is usually used during the load phase to ensure the plugin has a default
+     * configuration file before it is enabled.</p>
      *
-     * @see cn.nukkit.plugin.Plugin#getDataFolder
-     * @see cn.nukkit.plugin.Plugin#saveResource
+     * @see #getDataFolder()
+     * @see #saveResource(String)
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
     void saveDefaultConfig();
 
     /**
-     * 重新读取这个Nukkit插件的默认配置文件。<br>
-     * Reloads the plugin config.
+     * Reloads this plugin's configuration from disk.
      *
-     * <p>执行这个函数时，Nukkit会从数据文件夹中的config.yml文件重新加载配置。
-     * 这样用户在调整插件配置后，无需重启就可以马上使用新的配置。<br>
-     * By using this, Nukkit will reload the config from 'config.yml' file, then it isn't necessary to restart
-     * for plugin user who changes the config and needs to use new config at once.</p>
+     * <p>This reloads the configuration from {@code config.yml}, allowing changes
+     * to be applied without restarting the server.</p>
      *
-     * @see cn.nukkit.plugin.Plugin#getDataFolder
+     * @see #getDataFolder()
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
     void reloadConfig();
 
     /**
-     * 返回运行这个插件的服务器的{@link cn.nukkit.Server}对象。<br>
-     * Gets the server which is running this plugin, and returns as a {@link cn.nukkit.Server} object.
+     * Returns the server instance that is running this plugin.
      *
-     * @see cn.nukkit.Server
+     * @return the server instance
+     * @see Server
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
     Server getServer();
 
     /**
-     * 返回这个插件的名字。<br>
      * Returns the name of this plugin.
      *
-     * <p>Nukkit会从已经读取的插件描述中获取插件的名字。<br>
-     * Nukkit will read plugin name from plugin description.</p>
+     * <p>The plugin name is read from the plugin description.</p>
      *
-     * @see cn.nukkit.plugin.Plugin#getDescription
+     * @return the plugin name
+     * @see #getDescription()
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
     String getName();
 
     /**
-     * 返回这个插件的日志记录器为{@link cn.nukkit.plugin.PluginLogger}对象。<br>
-     * Returns the logger of this plugin as a {@link cn.nukkit.plugin.PluginLogger} object.
+     * Returns this plugin's logger.
      *
-     * <p>使用日志记录器，你可以在控制台和日志文件输出信息。<br>
-     * You can use a plugin logger to output messages to the console and log file.</p>
+     * <p>The logger can be used to output messages to the console and log file.</p>
      *
-     * @see cn.nukkit.plugin.PluginLogger
+     * @return this plugin's logger
+     * @see PluginLogger
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
     PluginLogger getLogger();
 
     /**
-     * 返回这个插件的加载器为{@link cn.nukkit.plugin.PluginLoader}对象。<br>
-     * Returns the loader of this plugin as a {@link cn.nukkit.plugin.PluginLoader} object.
+     * Returns the loader responsible for loading this plugin.
      *
-     * @see cn.nukkit.plugin.PluginLoader
+     * @return this plugin's loader
+     * @see PluginLoader
      * @since Nukkit 1.0 | Nukkit API 1.0.0
      */
     PluginLoader getPluginLoader();
 
+    /**
+     * Returns the class loader used to load this plugin.
+     *
+     * @return this plugin's class loader
+     */
     ClassLoader getPluginClassLoader();
 
     /**
-     * 返回这个插件的文件{@code File}对象。<br>
-     * Returns the {@code File} object of this plugin itself.
+     * Returns the file that contains this plugin.
      *
-     * @return 这个插件的文件 {@code File}对象。<br>The {@code File} object of this plugin itself.
+     * @return the plugin file
      */
     File getFile();
 }

--- a/src/main/java/cn/nukkit/plugin/Plugin.java
+++ b/src/main/java/cn/nukkit/plugin/Plugin.java
@@ -78,6 +78,11 @@ public interface Plugin extends CommandExecutor {
     void onDisable();
 
     /**
+     * Called before the server starts stopping.
+     */
+    void beforeStop();
+
+    /**
      * 返回这个Nukkit插件是否已停用。<br>
      * Whether this Nukkit plugin is disabled.
      *

--- a/src/main/java/cn/nukkit/plugin/PluginBase.java
+++ b/src/main/java/cn/nukkit/plugin/PluginBase.java
@@ -61,6 +61,11 @@ public abstract class PluginBase implements Plugin {
     }
 
     @Override
+    public void beforeStop() {
+
+    }
+
+    @Override
     public final boolean isEnabled() {
         return isEnabled;
     }

--- a/src/main/java/cn/nukkit/plugin/PluginManager.java
+++ b/src/main/java/cn/nukkit/plugin/PluginManager.java
@@ -543,7 +543,7 @@ public class PluginManager {
             if (previous != InternalPlugin.INSTANCE && previous.isEnabled()) {
                 try {
                     previous.beforeStop();
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     log.error("An error occurred while running beforeStop for plugin {}, {}, {}",
                             previous.getDescription().getName(), previous.getDescription().getVersion(), previous.getDescription().getMain(), e);
                 }

--- a/src/main/java/cn/nukkit/plugin/PluginManager.java
+++ b/src/main/java/cn/nukkit/plugin/PluginManager.java
@@ -535,6 +535,22 @@ public class PluginManager {
         }
     }
 
+    public void beforeStopPlugins() {
+        ListIterator<Plugin> plugins = new ArrayList<>(this.getPlugins().values()).listIterator(this.getPlugins().size());
+
+        while (plugins.hasPrevious()) {
+            Plugin previous = plugins.previous();
+            if (previous != InternalPlugin.INSTANCE && previous.isEnabled()) {
+                try {
+                    previous.beforeStop();
+                } catch (Exception e) {
+                    log.error("An error occurred while running beforeStop for plugin {}, {}, {}",
+                            previous.getDescription().getName(), previous.getDescription().getVersion(), previous.getDescription().getMain(), e);
+                }
+            }
+        }
+    }
+
     public void disablePlugin(Plugin plugin) {
         if (InternalPlugin.INSTANCE == plugin) {
             throw new UnsupportedOperationException("The PowerNukkitX Internal plugin can't be disabled.");

--- a/src/main/java/cn/nukkit/plugin/PluginManager.java
+++ b/src/main/java/cn/nukkit/plugin/PluginManager.java
@@ -536,10 +536,11 @@ public class PluginManager {
     }
 
     public void beforeStopPlugins() {
-        ListIterator<Plugin> plugins = new ArrayList<>(this.getPlugins().values()).listIterator(this.getPlugins().size());
+        List<Plugin> plugins = new ArrayList<>(this.getPlugins().values());
+        ListIterator<Plugin> iterator = plugins.listIterator(plugins.size());
 
-        while (plugins.hasPrevious()) {
-            Plugin previous = plugins.previous();
+        while (iterator.hasPrevious()) {
+            Plugin previous = iterator.previous();
             if (previous != InternalPlugin.INSTANCE && previous.isEnabled()) {
                 try {
                     previous.beforeStop();


### PR DESCRIPTION
## Summary

This PR adds a new `beforeStop()` hook for plugins.

The hook runs before the server enters the normal shutdown flow, giving plugins a chance to do final preparation while the server is still running.

This can be useful for saving state, sending final messages, stopping custom services, or doing cleanup that should happen before `onDisable()`.

## Notes

- `beforeStop()` is a default method, so existing plugins are not required to implement it.
- The hook is only executed once during shutdown.
- Plugins are called in reverse order, matching the disable flow.
- Errors from one plugin are logged and do not stop the remaining plugins from running their hook.