### PR TITLE
fix: spear attack not working while mounted

### DIFF
--- a/src/main/java/cn/nukkit/item/ItemSpear.java
+++ b/src/main/java/cn/nukkit/item/ItemSpear.java
@@ -48,7 +48,9 @@ public abstract class ItemSpear extends ItemTool {
 
         applyLunge(player);
 
-        if (movementSpeed < MINIMUM_SPEED || !player.isSprinting()) {
+        Entity riding = player.getRiding();
+
+        if (movementSpeed < MINIMUM_SPEED || (!player.isSprinting() && riding == null)) {
             SoundEvent missSound = getMissSound();
             if (missSound != null) {
                 player.getLevel().addLevelSoundEvent(player.getPosition(), missSound);
@@ -63,7 +65,7 @@ public abstract class ItemSpear extends ItemTool {
         Vector3 direction = player.getDirectionVector().normalize();
 
         double maxDistance = 5.0;
-        double minDot = 0.866;
+        double minDot = riding != null ? 0.75 : 0.866;
         double bestScore = -1;
 
         Entity target = null;
@@ -71,6 +73,7 @@ public abstract class ItemSpear extends ItemTool {
         AxisAlignedBB searchBox = player.getBoundingBox().grow(maxDistance, maxDistance, maxDistance);
 
         for (Entity entity : level.getNearbyEntities(searchBox, player)) {
+            if (entity == riding) continue;
             if (!(entity instanceof EntityLiving living) || !living.isAlive()) continue;
 
             Vector3 targetPos = entity.getPosition().add(0, living.getEyeHeight() * 0.5, 0);
@@ -169,7 +172,10 @@ public abstract class ItemSpear extends ItemTool {
         if (!player.isItemCoolDownEnd(this.getIdentifier())) return;
 
         player.setItemCoolDown(5, this.getIdentifier());
-        float playerSpeed = player.getMovementSpeed();
+        Entity riding = player.getRiding();
+        float playerSpeed = riding != null
+                ? (float) riding.getMotion().length()
+                : player.getMovementSpeed();
 
         if (playerSpeed < MINIMUM_SPEED) {
             return;
@@ -188,6 +194,7 @@ public abstract class ItemSpear extends ItemTool {
         double closestDistance = Double.MAX_VALUE;
 
         for (Entity entity : level.getNearbyEntities(hitBox, player)) {
+            if (entity == riding) continue;
             if (!(entity instanceof EntityLiving living) || !living.isAlive()) {
                 continue;
             }

--- a/src/main/java/cn/nukkit/network/process/handler/InventoryTransactionHandler.java
+++ b/src/main/java/cn/nukkit/network/process/handler/InventoryTransactionHandler.java
@@ -458,7 +458,10 @@ public class InventoryTransactionHandler implements PacketHandler<InventoryTrans
                     return;
                 }
 
-                spear.onSpearStab(player, player.getMovementSpeed());
+                float spearSpeed = player.getRiding() != null
+                        ? (float) player.getRiding().getMotion().length()
+                        : player.getMovementSpeed();
+                spear.onSpearStab(player, spearSpeed);
             }
             default -> log.debug("{} sent invalid item use action type {}", player.getName(), type);
         }


### PR DESCRIPTION
## Summary

- Spear attacks (stab + lunge) were silently ignored when the player was mounted because the speed check read `player.getMovementSpeed()` (always ~0 on a mount) instead of the mount's own velocity
- The mount entity was also included in the nearby-entity search, causing self-hits on the ridden entity
- Lunge gate was too strict: `!isSprinting()` blocked all attacks while mounted even at full mount speed
- `minDot` (cone angle) was slightly relaxed while mounted (0.75 vs 0.866) to compensate for reduced aim precision on a moving mount

## Changes

**`ItemSpear.java`**
- Speed source: use `riding.getMotion().length()` when mounted, `player.getMovementSpeed()` otherwise
- Lunge gate: `!isSprinting() && riding == null` — mounted sprint check skipped
- Search loop: skip the ridden entity to avoid self-hit
- `minDot` widened to `0.75` while mounted

**`InventoryTransactionProcessor.java`**
- `onSpearStab` call: same speed-source fix (mount motion vs player speed)

## Test plan

- [ ] Stab a mob while riding a horse at full gallop → should hit
- [ ] Lunge (right-click) a mob while mounted → should trigger correctly
- [ ] Dismount and verify normal sprint-stab still works
- [ ] Verify the ridden horse/camel is never targeted by the spear

---
*Claude AI was used to help port this fix to the `b/migration` branch and open the pull request.*