### PR TITLE
fix: smithing table not preserving durability of upgraded items

### DIFF
--- a/src/main/java/org/powernukkitx/inventory/request/CraftRecipeActionProcessor.java
+++ b/src/main/java/org/powernukkitx/inventory/request/CraftRecipeActionProcessor.java
@@ -20,6 +20,7 @@ import org.powernukkitx.recipe.Recipe;
 import org.powernukkitx.recipe.SmithingTransformRecipe;
 import org.powernukkitx.recipe.UserDataShapelessRecipe;
 import org.powernukkitx.recipe.SmithingTrimRecipe;
+import org.powernukkitx.recipe.descriptor.DefaultDescriptor;
 import org.powernukkitx.recipe.descriptor.ItemDescriptor;
 import org.powernukkitx.registry.Registries;
 import org.powernukkitx.utils.ItemHelper;
@@ -277,7 +278,12 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
         ItemDescriptor expectEquipment = recipe.getBase();
         ItemDescriptor expectIngredient = recipe.getAddition();
         ItemDescriptor expectTemplate = recipe.getTemplate();
-        boolean match = expectEquipment.match(equipment);
+        boolean match;
+        if (expectEquipment instanceof DefaultDescriptor dd) {
+            match = equipment.getId().equals(dd.getItem().getId());
+        } else {
+            match = expectEquipment.match(equipment);
+        }
         match &= expectIngredient.match(ingredient);
         match &= expectTemplate.match(template);
         if (match) {
@@ -285,6 +291,9 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
             CompoundTag tag = equipment.getNbt();
             if (tag != null) {
                 result.setNbt(tag);
+            }
+            if (equipment.getDamage() > 0) {
+                result.setDamage(equipment.getDamage());
             }
             player.getCreativeOutputInventory().setItem(result);
             smithingInventory.decreaseCount(0, 1);


### PR DESCRIPTION
## Summary

When upgrading a damaged tool at the smithing table (e.g. a half-durability diamond sword → netherite sword), the result was shown at full durability on the client. Additionally, a damaged item could fail to match its smithing recipe entirely if the equipment descriptor performed a strict damage check.

Two fixes in `handleSmithingUpgrade`:

1. **Recipe match** — when the equipment descriptor is a `DefaultDescriptor`, compare by item ID only (ignore damage). The previous `match()` call would fail for any damaged equipment since damage > 0 doesn't equal the recipe's expected damage of 0.

2. **Result durability** — after cloning the result and copying the equipment's NBT, explicitly call `setDamage` when the input was damaged. `setNbt` updates the compound tag (which includes the `Damage` entry) but does not synchronise the item's internal damage field used in the network packet, causing the client to render full durability.

## Test plan

- [x] Upgrade a damaged diamond sword to netherite — result should keep the same durability
- [x] Upgrade a full-durability diamond sword — result should show full durability (no `Damage:0` added)
- [x] Verify enchantments and other NBT are preserved after upgrade

---
*Claude AI was used to help port this fix to the `b/migration` branch and open the pull request.*