### PR TITLE
fix: skeleton bow drop chance and durability now match vanilla

### DIFF
--- a/src/main/java/cn/nukkit/entity/mob/EntitySkeleton.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntitySkeleton.java
@@ -108,7 +108,16 @@ public class EntitySkeleton extends EntityMob implements EntityWalkable, EntityS
 
         for (Item equipped : this.getEquipmentInventory().getContents().values()) {
             if (!equipped.isNull() && !equipped.hasEnchantment(Enchantment.ID_VANISHING_CURSE)) {
-                drops.add(equipped.clone());
+                if (equipped.getId().equals(Item.BOW)) {
+                    int chance = 85 + looting * 10;
+                    if (Utils.rand(0, 999) < chance) {
+                        Item drop = equipped.clone();
+                        drop.setDamage(Utils.rand(193, 384));
+                        drops.add(drop);
+                    }
+                } else {
+                    drops.add(equipped.clone());
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Skeletons were always dropping their bow at full durability with a 100% drop rate, which does not match vanilla Bedrock behaviour.

**Vanilla behaviour:**
- Bow drop chance: 8.5% base, +1% per Looting level
- Dropped bow is heavily damaged: damage value between 193 and 384 (out of 385 max), i.e. 50–99% durability consumed

**Before:** every skeleton kill guaranteed a full-durability bow.

**After:** `getDrops` now applies the correct chance and randomises the damage value on the dropped bow. Non-bow equipment (armour, other held items) is unaffected.

---
*Claude AI was used to help port this fix to the `b/migration` branch and open the pull request.*