### PR TITLE
fix: randomize villager trade seed when job site block is replaced

### DIFF
--- a/src/main/java/cn/nukkit/entity/passive/EntityVillagerV2.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityVillagerV2.java
@@ -291,6 +291,9 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
                                 Block siteBlock = getMemoryStorage().get(CoreMemoryTypes.SITE_BLOCK);
                                 if (siteBlock != null && !siteBlock.getLevelBlock().getId().equals(siteBlock.getId())) {
                                     getMemoryStorage().clear(CoreMemoryTypes.SITE_BLOCK);
+                                    if (getTradeExp() == 0) {
+                                        setTradeSeed(new NukkitRandom().nextInt(Integer.MAX_VALUE - 1));
+                                    }
                                 }
 
                                 if (getMemoryStorage().isEmpty(CoreMemoryTypes.SITE_BLOCK)) {


### PR DESCRIPTION
## Summary
- When a villager's linked job site block is broken and replaced, the trade seed was not refreshed, causing the same trades to always be offered.
- Added a trade seed randomization when the site block is cleared and the villager has no trade experience (not yet leveled up), matching vanilla behavior.

## Test plan
- Link a villager to a job site block (e.g. lectern for librarian)
- Break and replace the job site block repeatedly
- Verify the villager offers different trades each time (as long as no trades have been made)

---
*Claude AI was used to help port this fix to the `b/migration` branch and open the pull request.*