### PR TITLE
fix: spawn iron golem in villages and alert them when a villager is attacked

### DIFF
--- a/src/main/java/cn/nukkit/entity/passive/EntityVillagerV2.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityVillagerV2.java
@@ -40,6 +40,7 @@ import cn.nukkit.entity.components.HealthComponent;
 import cn.nukkit.entity.components.MovementComponent;
 import cn.nukkit.entity.data.profession.Profession;
 import cn.nukkit.entity.item.EntityItem;
+import cn.nukkit.entity.mob.EntityIronGolem;
 import cn.nukkit.entity.mob.EntityZombie;
 import cn.nukkit.event.entity.EntityDamageByEntityEvent;
 import cn.nukkit.event.entity.EntityDamageEvent;
@@ -570,6 +571,11 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
             pk.setTargetRuntimeID(this.getId());
             pk.setType(ActorEvent.VILLAGER_ANGRY);
             Server.broadcastPacket(getViewers().values(), pk);
+            for (Entity e : getLevel().getCollidingEntities(getBoundingBox().grow(48, 8, 48))) {
+                if (e instanceof EntityIronGolem golem && golem.isAlive() && !golem.hasOwner(false)) {
+                    golem.getMemoryStorage().put(CoreMemoryTypes.ATTACK_TARGET, player);
+                }
+            }
             return true;
         }
 

--- a/src/main/java/cn/nukkit/level/generator/object/structures/jigsaw/village/VillageStructure.java
+++ b/src/main/java/cn/nukkit/level/generator/object/structures/jigsaw/village/VillageStructure.java
@@ -13,12 +13,12 @@ import cn.nukkit.block.BlockSnowLayer;
 import cn.nukkit.block.BlockUnknown;
 import cn.nukkit.blockentity.BlockEntityChest;
 import cn.nukkit.entity.Entity;
+import cn.nukkit.entity.EntityID;
 import cn.nukkit.inventory.Inventory;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemID;
 import cn.nukkit.level.Level;
 import cn.nukkit.level.Position;
-import cn.nukkit.level.format.IChunk;
 import cn.nukkit.level.generator.object.BlockManager;
 import cn.nukkit.level.generator.object.RandomizableContainer;
 import cn.nukkit.level.generator.object.structures.StructureHelper;
@@ -78,17 +78,37 @@ public abstract class VillageStructure extends JigsawStructure {
                 .filter(BlockUnknown.class::isInstance)
                 .forEach(block -> level.setBlock(block, BlockAir.STATE.toBlock(block), true, true));
 
+        int jigsawCount = 0;
+        double jigsawSumX = 0, jigsawSumZ = 0;
         for (Block block : placedBlocks) {
-            if (!(level.getBlock(block) instanceof BlockJigsaw)) {
+            if (!(block instanceof BlockJigsaw)) {
                 continue;
             }
             level.setBlock(block, BlockAir.STATE.toBlock(block), true, true);
+            int spawnX = block.getFloorX();
+            int spawnZ = block.getFloorZ();
+            int safeY = findSafeSpawnY(level, spawnX, block.getFloorY(), spawnZ, 2);
             Entity villager = Entity.createEntity(
                     Entity.VILLAGER_V2,
-                    new Position(block.getFloorX() + 0.5, block.getFloorY(), block.getFloorZ() + 0.5, level)
+                    new Position(spawnX + 0.5, safeY, spawnZ + 0.5, level)
             );
             if (villager != null) {
                 villager.spawnToAll();
+            }
+            jigsawSumX += spawnX;
+            jigsawSumZ += spawnZ;
+            jigsawCount++;
+        }
+
+        if (jigsawCount > 0) {
+            int centerX = (int) (jigsawSumX / jigsawCount);
+            int centerZ = (int) (jigsawSumZ / jigsawCount);
+            int baseY = level.getHighestBlockAt(centerX, centerZ) + 1;
+            int golemY = findSafeSpawnY(level, centerX, baseY, centerZ, 3);
+            Entity golem = Entity.createEntity(EntityID.IRON_GOLEM,
+                    new Position(centerX + 0.5, golemY, centerZ + 0.5, level));
+            if (golem != null) {
+                golem.spawnToAll();
             }
         }
     }
@@ -437,6 +457,17 @@ public abstract class VillageStructure extends JigsawStructure {
             return height + 1;
         }
         return getTerrainY(level, x, z) + 1;
+    }
+
+    private int findSafeSpawnY(Level level, int x, int startY, int z, int entityHeight) {
+        outer:
+        for (int y = startY; y <= startY + 16; y++) {
+            for (int dy = 0; dy < entityHeight; dy++) {
+                if (level.getBlock(x, y + dy, z).isSolid()) continue outer;
+            }
+            return y;
+        }
+        return startY;
     }
 
     protected boolean isReplaceableTerrainCover(Block block) {


### PR DESCRIPTION
## Summary
- Villages were generated without iron golems, which is not vanilla behavior. Added iron golem spawning at the village center during structure generation.
- Nearby unowned iron golems were not alerted when a player attacked a villager, so they would not defend it. Added a scan within 48 blocks on the `VILLAGER_ANGRY` event to set the attacking player as their target.
- Also fixed a bug where `level.getBlock(block) instanceof BlockJigsaw` was used instead of `block instanceof BlockJigsaw`, which could fail if the block had already been replaced by the time the check ran.
- Added `findSafeSpawnY` to ensure villagers and the golem do not spawn inside solid blocks.

## Test plan
- Generate a new village and verify an iron golem spawns at its center
- Hit a villager while an iron golem is nearby — verify the golem targets the attacking player
- Verify villagers spawn at a valid Y position and do not clip into terrain

---
*Claude AI was used to help port this fix to the `b/migration` branch and open the pull request.*