### PR TITLE
fix: villagers unable to pathfind through closed wooden doors

### DIFF
--- a/src/main/java/cn/nukkit/entity/ai/route/posevaluator/DoorCapableWalkingPosEvaluator.java
+++ b/src/main/java/cn/nukkit/entity/ai/route/posevaluator/DoorCapableWalkingPosEvaluator.java
@@ -1,0 +1,21 @@
+package cn.nukkit.entity.ai.route.posevaluator;
+
+import cn.nukkit.block.BlockWoodenDoor;
+import cn.nukkit.entity.EntityIntelligent;
+import cn.nukkit.math.SimpleAxisAlignedBB;
+import cn.nukkit.math.Vector3;
+
+public class DoorCapableWalkingPosEvaluator extends WalkingPosEvaluator {
+
+    @Override
+    protected boolean isPassable(EntityIntelligent entity, Vector3 vector3) {
+        if (super.isPassable(entity, vector3)) return true;
+        double radius = (entity.getWidth() * entity.getScale()) / 2;
+        float height = entity.getHeight() * entity.getScale();
+        var bb = new SimpleAxisAlignedBB(
+                vector3.getX() - radius, vector3.getY(), vector3.getZ() - radius,
+                vector3.getX() + radius, vector3.getY() + height, vector3.getZ() + radius);
+        return entity.level.getCollisionBlocks(bb, false, false,
+                b -> !(b instanceof BlockWoodenDoor)).length == 0;
+    }
+}

--- a/src/main/java/cn/nukkit/entity/passive/EntityVillagerV2.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityVillagerV2.java
@@ -33,7 +33,7 @@ import cn.nukkit.entity.ai.executor.villager.WillingnessExecutor;
 import cn.nukkit.entity.ai.executor.villager.WorkExecutor;
 import cn.nukkit.entity.ai.memory.CoreMemoryTypes;
 import cn.nukkit.entity.ai.route.finder.impl.SimpleFlatAStarRouteFinder;
-import cn.nukkit.entity.ai.route.posevaluator.WalkingPosEvaluator;
+import cn.nukkit.entity.ai.route.posevaluator.DoorCapableWalkingPosEvaluator;
 import cn.nukkit.entity.ai.sensor.BlockSensor;
 import cn.nukkit.entity.ai.sensor.NearestEntitySensor;
 import cn.nukkit.entity.components.HealthComponent;
@@ -330,7 +330,7 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
                         new NearestEntitySensor(EntityZombie.class, CoreMemoryTypes.NEAREST_ZOMBIE, 8, 0)
                 ),
                 Set.of(new WalkController(), new LookController(true, true), new FluctuateController()),
-                new SimpleFlatAStarRouteFinder(new WalkingPosEvaluator(), this),
+                new SimpleFlatAStarRouteFinder(new DoorCapableWalkingPosEvaluator(), this),
                 this
         );
     }


### PR DESCRIPTION
## Summary
- Villagers have a `DoorExecutor` behavior that opens and closes wooden doors, but the A* pathfinder used `WalkingPosEvaluator` which treats closed doors as solid blocks — so the path was never routed through a doorway and the `DoorExecutor` never triggered.
- Added `DoorCapableWalkingPosEvaluator`, a subclass of `WalkingPosEvaluator` that overrides `isPassable()` to treat wooden doors as passable, allowing the pathfinder to route through them.
- Switched `EntityVillagerV2` to use this evaluator.

## Test plan
- Build a house with a closed wooden door
- Observe that a villager correctly paths through the doorway instead of being blocked by the closed door

---
*Claude AI was used to help port this fix to the `b/migration` branch and open the pull request.*