### PR TITLE
Fix ItemSpawnEgg NPE when meta is 0

### DIFF
--- a/src/main/java/cn/nukkit/item/ItemSpawnEgg.java
+++ b/src/main/java/cn/nukkit/item/ItemSpawnEgg.java
@@ -116,7 +116,11 @@ public class ItemSpawnEgg extends Item implements SpawnEggPickable {
 
     public @Nullable String getEntityName() {
         String entityIdentifier = Registries.ENTITY.getEntityIdentifier(getEntityNetworkId());
-        var path = entityIdentifier.split(":")[1];
+        if (entityIdentifier == null) {
+            return null;
+        }
+        String[] split = entityIdentifier.split(":");
+        var path = split.length > 1 ? split[1] : split[0];
         StringBuilder result = new StringBuilder();
         String[] parts = path.split("_");
         for (String part : parts) {


### PR DESCRIPTION
- Patch NPE in ItemSpawnEgg.getEntityName when meta is 0
- This change allows resolving legacy spawn eggs again (given via `/give @s spawn_egg <amount> <meta>`)