### PR TITLE
fix!: store level time as long to stop the day/night cycle freezing

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -697,7 +697,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         this.setEnableClientCommand(true);
 
         final SetTimePacket setTimePacket = new SetTimePacket();
-        setTimePacket.setTime(this.level.getTime());
+        setTimePacket.setTime((int) this.level.getTime());
         this.sendPacket(setTimePacket);
 
         this.noDamageTicks = 60;
@@ -4971,8 +4971,8 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
                 playerChunkManager.getUsedChunks().clear();
             }
 
-            SetTimePacket setTime = new SetTimePacket();
-            setTime.setTime(level.getTime());
+            final SetTimePacket setTime = new SetTimePacket();
+            setTime.setTime((int) level.getTime());
             this.sendPacket(setTime);
 
             GameRulesChangedPacket gameRulesChanged = new GameRulesChangedPacket();

--- a/src/main/java/cn/nukkit/command/defaults/TimeCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/TimeCommand.java
@@ -1,6 +1,5 @@
 package cn.nukkit.command.defaults;
 
-import cn.nukkit.Player;
 import cn.nukkit.command.CommandSender;
 import cn.nukkit.command.data.CommandEnum;
 import cn.nukkit.command.data.CommandParameter;
@@ -45,41 +44,32 @@ public class TimeCommand extends VanillaCommand {
     @Override
     public int execute(CommandSender sender, String commandLabel, Map.Entry<String, ParamList> result, CommandLogger log) {
         var list = result.getValue();
+        final Level level = sender.getLocation().getLevel();
         switch (result.getKey()) {
             case "1arg" -> {
-                String mode = list.getResult(0);
+                final String mode = list.getResult(0);
                 if ("start".equals(mode)) {
                     if (!sender.hasPermission("nukkit.command.time.start")) {
                         log.addMessage("nukkit.command.generic.permission").output();
                         return 0;
                     }
-                    for (Level level : sender.getServer().getLevels().values()) {
-                        level.checkTime();
-                        level.startTime();
-                        level.checkTime();
-                    }
+                    level.checkTime();
+                    level.startTime();
+                    level.checkTime();
                     log.addSuccess("Restarted the time").output(true);
                 } else if ("stop".equals(mode)) {
                     if (!sender.hasPermission("nukkit.command.time.stop")) {
                         log.addMessage("nukkit.command.generic.permission").output();
                         return 0;
                     }
-                    for (Level level : sender.getServer().getLevels().values()) {
-                        level.checkTime();
-                        level.stopTime();
-                        level.checkTime();
-                    }
+                    level.checkTime();
+                    level.stopTime();
+                    level.checkTime();
                     log.addSuccess("Stopped the time").output(true);
                 } else if ("query".equals(mode)) {
                     if (!sender.hasPermission("nukkit.command.time.query")) {
                         log.addMessage("nukkit.command.generic.permission").output();
                         return 0;
-                    }
-                    Level level;
-                    if (sender instanceof Player) {
-                        level = ((Player) sender).getLevel();
-                    } else {
-                        level = sender.getServer().getDefaultLevel();
                     }
                     log.addSuccess("commands.time.query.gametime", String.valueOf(level.getTime())).output(true);
                 }
@@ -95,11 +85,9 @@ public class TimeCommand extends VanillaCommand {
                     log.addNumTooSmall(1, 0).output();
                     return 0;
                 }
-                for (Level level : sender.getServer().getLevels().values()) {
-                    level.checkTime();
-                    level.setTime(level.getTime() + value);
-                    level.checkTime();
-                }
+                level.checkTime();
+                level.setTime(level.getTime() + value);
+                level.checkTime();
                 log.addSuccess("commands.time.added", String.valueOf(value)).output(true);
                 return 1;
             }
@@ -113,11 +101,9 @@ public class TimeCommand extends VanillaCommand {
                     log.addNumTooSmall(1, 0).output();
                     return 0;
                 }
-                for (Level level : sender.getServer().getLevels().values()) {
-                    level.checkTime();
-                    level.setTime(value);
-                    level.checkTime();
-                }
+                level.checkTime();
+                level.setTime(level.getTime() - level.getDayTime() + value);
+                level.checkTime();
                 log.addSuccess("commands.time.set", String.valueOf(value)).output(true);
                 return 1;
             }
@@ -126,26 +112,19 @@ public class TimeCommand extends VanillaCommand {
                     log.addMessage("nukkit.command.generic.permission").output();
                     return 0;
                 }
-                int value = 0;
-                String str = list.getResult(1);
-                if ("day".equals(str)) {
-                    value = Level.TIME_DAY;
-                } else if ("night".equals(str)) {
-                    value = Level.TIME_NIGHT;
-                } else if ("midnight".equals(str)) {
-                    value = Level.TIME_MIDNIGHT;
-                } else if ("noon".equals(str)) {
-                    value = Level.TIME_NOON;
-                } else if ("sunrise".equals(str)) {
-                    value = Level.TIME_SUNRISE;
-                } else if ("sunset".equals(str)) {
-                    value = Level.TIME_SUNSET;
-                }
-                for (Level level : sender.getServer().getLevels().values()) {
-                    level.checkTime();
-                    level.setTime(value);
-                    level.checkTime();
-                }
+                final String str = list.getResult(1);
+                final int value = switch (str) {
+                    case "day" -> Level.TIME_DAY;
+                    case "night" -> Level.TIME_NIGHT;
+                    case "midnight" -> Level.TIME_MIDNIGHT;
+                    case "noon" -> Level.TIME_NOON;
+                    case "sunrise" -> Level.TIME_SUNRISE;
+                    case "sunset" -> Level.TIME_SUNSET;
+                    case null, default -> 0;
+                };
+                level.checkTime();
+                level.setTime(level.getTime() - level.getDayTime() + value);
+                level.checkTime();
                 log.addSuccess("commands.time.set", String.valueOf(value)).output(true);
                 return 1;
             }

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -344,7 +344,8 @@ public class Level implements Metadatable {
     public int tickRateOptDelay = 1;
     public GameRules gameRules;
     private AtomicReference<LevelProvider> provider;
-    private float time;
+    /// Cumulative world game time in ticks. Stored as a long (the provider persists it as a long)
+    private long time;
     private int nextTimeSendTick;
     private final String name;
     private final String folderPath;
@@ -1059,14 +1060,14 @@ public class Level implements Metadatable {
 
     public void checkTime() {
         if (!this.stopTime && this.gameRules.getBoolean(GameRule.DO_DAYLIGHT_CYCLE)) {
-            float prior = this.time;
+            long prior = this.time;
             this.time += tickRate;
             if (prior % TIME_FULL > TIME_NIGHT && this.time % TIME_FULL < TIME_DAY) this.noSleepNights++;
         }
     }
 
     public void sendTime(Player... players) {
-        SetTimePacket pk = new SetTimePacket();
+        final SetTimePacket pk = new SetTimePacket();
         pk.setTime((int) this.time);
 
         Server.broadcastPacket(players, pk);
@@ -1445,7 +1446,7 @@ public class Level implements Metadatable {
         }
 
         if (playerCount > 0 && sleepingPlayerCount / playerCount * 100 >= this.gameRules.getInteger(GameRule.PLAYERS_SLEEPING_PERCENTAGE)) {
-            int time = this.getTime() % Level.TIME_FULL;
+            int time = (int) (this.getTime() % Level.TIME_FULL);
 
             if (isNight() || isThundering()) {
                 this.setTime(this.getTime() + Level.TIME_FULL - time);
@@ -1662,7 +1663,7 @@ public class Level implements Metadatable {
         this.server.getPluginManager().callEvent(new LevelSaveEvent(this));
 
         LevelProvider levelProvider = this.requireProvider();
-        levelProvider.setTime((int) this.time);
+        levelProvider.setTime(this.time);
         levelProvider.setRaining(this.raining);
         levelProvider.setRainTime(this.rainTime);
         levelProvider.setThundering(this.thundering);
@@ -2180,7 +2181,7 @@ public class Level implements Metadatable {
         return calculateCelestialAngle(getTime(), tickDiff);
     }
 
-    public float calculateCelestialAngle(int time, float tickDiff) {
+    public float calculateCelestialAngle(long time, float tickDiff) {
         int i = (int) (time % 24000L);
         float angle = ((float) i + tickDiff) / 24000.0F - 0.25F;
 
@@ -4459,16 +4460,14 @@ public class Level implements Metadatable {
     }
 
     /**
-     * 获取这个地图经历的时间(一直会累加)
-     * <p>
-     * Get the elapsed time for this level
+     * Get the elapsed game time for this level (accumulates continuously)
      */
-    public int getTime() {
-        return (int) time;
+    public long getTime() {
+        return time;
     }
 
     public int getDayTime() {
-        return this.getTime() % Level.TIME_FULL;
+        return (int) (this.getTime() % Level.TIME_FULL);
     }
 
     public boolean isDay() {
@@ -4480,11 +4479,9 @@ public class Level implements Metadatable {
     }
 
     /**
-     * 设置这个地图经历的时间
-     * <p>
-     * Set the elapsed time for this level
+     * Set the elapsed game time for this level
      */
-    public void setTime(int time) {
+    public void setTime(long time) {
         if (isRaining()) {
             if (getTime() % TIME_FULL != time % TIME_FULL) {
                 //Day changed


### PR DESCRIPTION
This PR fixes the day/night cycle randomly freezing and "resetting every 30 seconds" on long-running worlds, plus two correctness bugs in the `/time` command.

On long-lived worlds the time of day would appear to advance, then snap back every ~30 seconds, eventually freezing entirely. Reproduced with `/time query` reading `16,790,000`,  just past 2^24 (16 777 216).

`Level.time` was a `float`. A `float` can only represent consecutive integers up to 2^24 ≈ 16.7M ticks (~9.7 days of active ticking). Past that, the spacing between representable values grows to 2+, so `this.time += 1` in `checkTime()` rounds straight back to the same value → the server clock freezes. The client free-runs the daylight cycle locally and gets snapped back to the frozen value by the periodic `SetTimePacket` (every 30s), which is the visible "reset".

The provider already persisted time as a `long`, so the value was being narrowed on load and truncated on save.

### Changes

- `Level.time`: `float` → `long`
- `getTime()` / `setTime()`: `int` → `long`
- `getDayTime()` casts the `long` modulo back to `int`; `calculateCelestialAngle` now takes a `long`
- Save path persists the full `long` instead of truncating through `int`
- `Player` `SetTimePacket` senders cast to `int` for the wire field
- `/time set <value>` and `/time set <preset>` now set only the day-time component, preserving the elapsed-day count (`setTime(getTime() - getDayTime() + value)`) instead of overwriting the cumulative clock. Previously `/time set day` rewound game time toward 0
- All `/time` subcommands (`set`/`add`/`start`/`stop`/`query`) now act on the command sender's level only, instead of looping over every loaded level and modifying all worlds at once
- Minor refactor (switch expression for presets, `final` locals)

### API changes
- `Level#getTime()` now returns `long` (was `int`)
- `Level#setTime(long)` (was `setTime(int)`)
- `Level#calculateCelestialAngle(long, float)` (was `int`)