### PR TITLE
feat: add TimeModeQuery for /time query

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -697,7 +697,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         this.setEnableClientCommand(true);
 
         final SetTimePacket setTimePacket = new SetTimePacket();
-        setTimePacket.setTime(this.level.getTime());
+        setTimePacket.setTime((int) this.level.getTime());
         this.sendPacket(setTimePacket);
 
         this.noDamageTicks = 60;
@@ -4971,8 +4971,8 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
                 playerChunkManager.getUsedChunks().clear();
             }
 
-            SetTimePacket setTime = new SetTimePacket();
-            setTime.setTime(level.getTime());
+            final SetTimePacket setTime = new SetTimePacket();
+            setTime.setTime((int) level.getTime());
             this.sendPacket(setTime);
 
             GameRulesChangedPacket gameRulesChanged = new GameRulesChangedPacket();

--- a/src/main/java/cn/nukkit/command/defaults/TimeCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/TimeCommand.java
@@ -94,7 +94,7 @@ public class TimeCommand extends VanillaCommand {
                 }
                 final int value = list.getResult(1);
                 level.checkTime();
-                level.setTime(level.getTime() - level.getDayTime() + value);
+                level.setTime(value);
                 level.checkTime();
                 log.addSuccess("commands.time.set", String.valueOf(value)).output(true);
                 return 1;

--- a/src/main/java/cn/nukkit/command/defaults/TimeCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/TimeCommand.java
@@ -80,11 +80,7 @@ public class TimeCommand extends VanillaCommand {
                     log.addMessage("nukkit.command.generic.permission").output();
                     return 0;
                 }
-                int value = list.getResult(1);
-                if (value < 0) {
-                    log.addNumTooSmall(1, 0).output();
-                    return 0;
-                }
+                final int value = list.getResult(1);
                 level.checkTime();
                 level.setTime(level.getTime() + value);
                 level.checkTime();
@@ -96,11 +92,7 @@ public class TimeCommand extends VanillaCommand {
                     log.addMessage("nukkit.command.generic.permission").output();
                     return 0;
                 }
-                int value = list.getResult(1);
-                if (value < 0) {
-                    log.addNumTooSmall(1, 0).output();
-                    return 0;
-                }
+                final int value = list.getResult(1);
                 level.checkTime();
                 level.setTime(level.getTime() - level.getDayTime() + value);
                 level.checkTime();

--- a/src/main/java/cn/nukkit/command/defaults/TimeCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/TimeCommand.java
@@ -1,6 +1,5 @@
 package cn.nukkit.command.defaults;
 
-import cn.nukkit.Player;
 import cn.nukkit.command.CommandSender;
 import cn.nukkit.command.data.CommandEnum;
 import cn.nukkit.command.data.CommandParameter;
@@ -45,41 +44,32 @@ public class TimeCommand extends VanillaCommand {
     @Override
     public int execute(CommandSender sender, String commandLabel, Map.Entry<String, ParamList> result, CommandLogger log) {
         var list = result.getValue();
+        final Level level = sender.getLocation().getLevel();
         switch (result.getKey()) {
             case "1arg" -> {
-                String mode = list.getResult(0);
+                final String mode = list.getResult(0);
                 if ("start".equals(mode)) {
                     if (!sender.hasPermission("nukkit.command.time.start")) {
                         log.addMessage("nukkit.command.generic.permission").output();
                         return 0;
                     }
-                    for (Level level : sender.getServer().getLevels().values()) {
-                        level.checkTime();
-                        level.startTime();
-                        level.checkTime();
-                    }
+                    level.checkTime();
+                    level.startTime();
+                    level.checkTime();
                     log.addSuccess("Restarted the time").output(true);
                 } else if ("stop".equals(mode)) {
                     if (!sender.hasPermission("nukkit.command.time.stop")) {
                         log.addMessage("nukkit.command.generic.permission").output();
                         return 0;
                     }
-                    for (Level level : sender.getServer().getLevels().values()) {
-                        level.checkTime();
-                        level.stopTime();
-                        level.checkTime();
-                    }
+                    level.checkTime();
+                    level.stopTime();
+                    level.checkTime();
                     log.addSuccess("Stopped the time").output(true);
                 } else if ("query".equals(mode)) {
                     if (!sender.hasPermission("nukkit.command.time.query")) {
                         log.addMessage("nukkit.command.generic.permission").output();
                         return 0;
-                    }
-                    Level level;
-                    if (sender instanceof Player) {
-                        level = ((Player) sender).getLevel();
-                    } else {
-                        level = sender.getServer().getDefaultLevel();
                     }
                     log.addSuccess("commands.time.query.gametime", String.valueOf(level.getTime())).output(true);
                 }
@@ -95,11 +85,9 @@ public class TimeCommand extends VanillaCommand {
                     log.addNumTooSmall(1, 0).output();
                     return 0;
                 }
-                for (Level level : sender.getServer().getLevels().values()) {
-                    level.checkTime();
-                    level.setTime(level.getTime() + value);
-                    level.checkTime();
-                }
+                level.checkTime();
+                level.setTime(level.getTime() + value);
+                level.checkTime();
                 log.addSuccess("commands.time.added", String.valueOf(value)).output(true);
                 return 1;
             }
@@ -113,11 +101,9 @@ public class TimeCommand extends VanillaCommand {
                     log.addNumTooSmall(1, 0).output();
                     return 0;
                 }
-                for (Level level : sender.getServer().getLevels().values()) {
-                    level.checkTime();
-                    level.setTime(value);
-                    level.checkTime();
-                }
+                level.checkTime();
+                level.setTime(level.getTime() - level.getDayTime() + value);
+                level.checkTime();
                 log.addSuccess("commands.time.set", String.valueOf(value)).output(true);
                 return 1;
             }
@@ -126,26 +112,19 @@ public class TimeCommand extends VanillaCommand {
                     log.addMessage("nukkit.command.generic.permission").output();
                     return 0;
                 }
-                int value = 0;
-                String str = list.getResult(1);
-                if ("day".equals(str)) {
-                    value = Level.TIME_DAY;
-                } else if ("night".equals(str)) {
-                    value = Level.TIME_NIGHT;
-                } else if ("midnight".equals(str)) {
-                    value = Level.TIME_MIDNIGHT;
-                } else if ("noon".equals(str)) {
-                    value = Level.TIME_NOON;
-                } else if ("sunrise".equals(str)) {
-                    value = Level.TIME_SUNRISE;
-                } else if ("sunset".equals(str)) {
-                    value = Level.TIME_SUNSET;
-                }
-                for (Level level : sender.getServer().getLevels().values()) {
-                    level.checkTime();
-                    level.setTime(value);
-                    level.checkTime();
-                }
+                final String str = list.getResult(1);
+                final int value = switch (str) {
+                    case "day" -> Level.TIME_DAY;
+                    case "night" -> Level.TIME_NIGHT;
+                    case "midnight" -> Level.TIME_MIDNIGHT;
+                    case "noon" -> Level.TIME_NOON;
+                    case "sunrise" -> Level.TIME_SUNRISE;
+                    case "sunset" -> Level.TIME_SUNSET;
+                    case null, default -> 0;
+                };
+                level.checkTime();
+                level.setTime(level.getTime() - level.getDayTime() + value);
+                level.checkTime();
                 log.addSuccess("commands.time.set", String.valueOf(value)).output(true);
                 return 1;
             }

--- a/src/main/java/cn/nukkit/command/defaults/TimeCommand.java
+++ b/src/main/java/cn/nukkit/command/defaults/TimeCommand.java
@@ -23,9 +23,6 @@ public class TimeCommand extends VanillaCommand {
                 "nukkit.command.time.start;" +
                 "nukkit.command.time.stop");
         this.commandParameters.clear();
-        this.commandParameters.put("1arg", new CommandParameter[]{
-                CommandParameter.newEnum("mode", new CommandEnum("TimeMode", "query", "start", "stop"))
-        });
         this.commandParameters.put("add", new CommandParameter[]{
                 CommandParameter.newEnum("mode", new CommandEnum("TimeModeAdd", "add")),
                 CommandParameter.newType("amount", CommandParamType.INT)
@@ -38,6 +35,13 @@ public class TimeCommand extends VanillaCommand {
                 CommandParameter.newEnum("mode", new CommandEnum("TimeModeSet", "set")),
                 CommandParameter.newEnum("time", new CommandEnum("TimeSpec", "day", "night", "midnight", "noon", "sunrise", "sunset"))
         });
+        this.commandParameters.put("timeModeQuery", new CommandParameter[]{
+                CommandParameter.newEnum("mode", new CommandEnum("TimeModeQuery", "query")),
+                CommandParameter.newEnum("mode", new CommandEnum("TimeQuery", "daytime", "gametime", "day"))
+        });
+        this.commandParameters.put("timeModeOther", new CommandParameter[]{
+                CommandParameter.newEnum("mode", new CommandEnum("TimeMode", "start", "stop"))
+        });
         this.enableParamTree();
     }
 
@@ -46,35 +50,6 @@ public class TimeCommand extends VanillaCommand {
         var list = result.getValue();
         final Level level = sender.getLocation().getLevel();
         switch (result.getKey()) {
-            case "1arg" -> {
-                final String mode = list.getResult(0);
-                if ("start".equals(mode)) {
-                    if (!sender.hasPermission("nukkit.command.time.start")) {
-                        log.addMessage("nukkit.command.generic.permission").output();
-                        return 0;
-                    }
-                    level.checkTime();
-                    level.startTime();
-                    level.checkTime();
-                    log.addSuccess("Restarted the time").output(true);
-                } else if ("stop".equals(mode)) {
-                    if (!sender.hasPermission("nukkit.command.time.stop")) {
-                        log.addMessage("nukkit.command.generic.permission").output();
-                        return 0;
-                    }
-                    level.checkTime();
-                    level.stopTime();
-                    level.checkTime();
-                    log.addSuccess("Stopped the time").output(true);
-                } else if ("query".equals(mode)) {
-                    if (!sender.hasPermission("nukkit.command.time.query")) {
-                        log.addMessage("nukkit.command.generic.permission").output();
-                        return 0;
-                    }
-                    log.addSuccess("commands.time.query.gametime", String.valueOf(level.getTime())).output(true);
-                }
-                return 1;
-            }
             case "add" -> {
                 if (!sender.hasPermission("nukkit.command.time.add")) {
                     log.addMessage("nukkit.command.generic.permission").output();
@@ -118,6 +93,48 @@ public class TimeCommand extends VanillaCommand {
                 level.setTime(level.getTime() - level.getDayTime() + value);
                 level.checkTime();
                 log.addSuccess("commands.time.set", String.valueOf(value)).output(true);
+                return 1;
+            }
+            case "timeModeQuery" -> {
+                if (!sender.hasPermission("nukkit.command.time.query")) {
+                    log.addMessage("nukkit.command.generic.permission").output();
+                    return 0;
+                }
+                final String mode = list.getResult(1);
+                switch (mode) {
+                    case "daytime" -> log.addSuccess("commands.time.query.daytime", String.valueOf(level.getDayTime())).output(true);
+                    case "gametime" -> log.addSuccess("commands.time.query.gametime", String.valueOf(level.getTime())).output(true);
+                    case "day" -> log.addSuccess("commands.time.query.day", String.valueOf(level.getDay())).output(true);
+                }
+                return 1;
+            }
+            case "timeModeOther" -> {
+                final String mode = list.getResult(0);
+                if ("start".equals(mode)) {
+                    if (!sender.hasPermission("nukkit.command.time.start")) {
+                        log.addMessage("nukkit.command.generic.permission").output();
+                        return 0;
+                    }
+                    level.checkTime();
+                    level.startTime();
+                    level.checkTime();
+                    log.addSuccess("Restarted the time").output(true);
+                } else if ("stop".equals(mode)) {
+                    if (!sender.hasPermission("nukkit.command.time.stop")) {
+                        log.addMessage("nukkit.command.generic.permission").output();
+                        return 0;
+                    }
+                    level.checkTime();
+                    level.stopTime();
+                    level.checkTime();
+                    log.addSuccess("Stopped the time").output(true);
+                } else if ("query".equals(mode)) {
+                    if (!sender.hasPermission("nukkit.command.time.query")) {
+                        log.addMessage("nukkit.command.generic.permission").output();
+                        return 0;
+                    }
+                    log.addSuccess("commands.time.query.gametime", String.valueOf(level.getTime())).output(true);
+                }
                 return 1;
             }
             default -> {

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -4461,13 +4461,31 @@ public class Level implements Metadatable {
 
     /**
      * Get the elapsed game time for this level (accumulates continuously)
+     *
+     * @return the elapsed game time for this level
      */
     public long getTime() {
         return time;
     }
 
+    /**
+     * Get the current day time, derived from the elapsed game time of this level
+     *
+     * @return the current day time of this level
+     * @see #getTime()
+     */
     public int getDayTime() {
         return (int) (this.getTime() % Level.TIME_FULL);
+    }
+
+    /**
+     * Get the current day, derived from the elapsed game time of this level
+     *
+     * @return the current day of this level
+     * @see #getTime()
+     */
+    public int getDay() {
+        return (int) (this.getTime() / Level.TIME_FULL);
     }
 
     public boolean isDay() {

--- a/src/main/java/cn/nukkit/level/Level.java
+++ b/src/main/java/cn/nukkit/level/Level.java
@@ -344,7 +344,8 @@ public class Level implements Metadatable {
     public int tickRateOptDelay = 1;
     public GameRules gameRules;
     private AtomicReference<LevelProvider> provider;
-    private float time;
+    /// Cumulative world game time in ticks. Stored as a long (the provider persists it as a long)
+    private long time;
     private int nextTimeSendTick;
     private final String name;
     private final String folderPath;
@@ -1059,14 +1060,14 @@ public class Level implements Metadatable {
 
     public void checkTime() {
         if (!this.stopTime && this.gameRules.getBoolean(GameRule.DO_DAYLIGHT_CYCLE)) {
-            float prior = this.time;
+            long prior = this.time;
             this.time += tickRate;
             if (prior % TIME_FULL > TIME_NIGHT && this.time % TIME_FULL < TIME_DAY) this.noSleepNights++;
         }
     }
 
     public void sendTime(Player... players) {
-        SetTimePacket pk = new SetTimePacket();
+        final SetTimePacket pk = new SetTimePacket();
         pk.setTime((int) this.time);
 
         Server.broadcastPacket(players, pk);
@@ -1445,7 +1446,7 @@ public class Level implements Metadatable {
         }
 
         if (playerCount > 0 && sleepingPlayerCount / playerCount * 100 >= this.gameRules.getInteger(GameRule.PLAYERS_SLEEPING_PERCENTAGE)) {
-            int time = this.getTime() % Level.TIME_FULL;
+            int time = (int) (this.getTime() % Level.TIME_FULL);
 
             if (isNight() || isThundering()) {
                 this.setTime(this.getTime() + Level.TIME_FULL - time);
@@ -1662,7 +1663,7 @@ public class Level implements Metadatable {
         this.server.getPluginManager().callEvent(new LevelSaveEvent(this));
 
         LevelProvider levelProvider = this.requireProvider();
-        levelProvider.setTime((int) this.time);
+        levelProvider.setTime(this.time);
         levelProvider.setRaining(this.raining);
         levelProvider.setRainTime(this.rainTime);
         levelProvider.setThundering(this.thundering);
@@ -2180,7 +2181,7 @@ public class Level implements Metadatable {
         return calculateCelestialAngle(getTime(), tickDiff);
     }
 
-    public float calculateCelestialAngle(int time, float tickDiff) {
+    public float calculateCelestialAngle(long time, float tickDiff) {
         int i = (int) (time % 24000L);
         float angle = ((float) i + tickDiff) / 24000.0F - 0.25F;
 
@@ -4459,16 +4460,14 @@ public class Level implements Metadatable {
     }
 
     /**
-     * 获取这个地图经历的时间(一直会累加)
-     * <p>
-     * Get the elapsed time for this level
+     * Get the elapsed game time for this level (accumulates continuously)
      */
-    public int getTime() {
-        return (int) time;
+    public long getTime() {
+        return time;
     }
 
     public int getDayTime() {
-        return this.getTime() % Level.TIME_FULL;
+        return (int) (this.getTime() % Level.TIME_FULL);
     }
 
     public boolean isDay() {
@@ -4480,11 +4479,9 @@ public class Level implements Metadatable {
     }
 
     /**
-     * 设置这个地图经历的时间
-     * <p>
-     * Set the elapsed time for this level
+     * Set the elapsed game time for this level
      */
-    public void setTime(int time) {
+    public void setTime(long time) {
         if (isRaining()) {
             if (getTime() % TIME_FULL != time % TIME_FULL) {
                 //Day changed


### PR DESCRIPTION
This PR adds support for setting the game time with `/time set <amount>`, TimeModeQuery (#2605) for `/time query` and allows negative values in `/time add` and `/time set` to match vanilla.

Additionally, it adds a new method to the `Level` class: `getDay()`. Returns the current in-game day of the level. 