### PR TITLE
fix: mounted rider state sync and ride seat metadata updates

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -943,11 +943,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         }
 
         //update server-side position and rotation and aabb
-        double diffX = clientPos.getX() - this.x;
-        double diffY = clientPos.getY() - this.y;
-        double diffZ = clientPos.getZ() - this.z;
-        this.setRotation(clientPos.getYaw(), clientPos.getPitch(), clientPos.getHeadYaw());
-        this.fastMove(diffX, diffY, diffZ);
+        this.applyClientLocationFromAuthInput(clientPos);
 
         //update server-side position and rotation and aabb
         Location last = new Location(this.lastX, this.lastY, this.lastZ, this.lastYaw, this.lastPitch, this.lastHeadYaw, this.level);
@@ -1036,6 +1032,15 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
                 this.nextChunkOrderRun = 20;
             }
         }
+    }
+
+    public void applyClientLocationFromAuthInput(Location clientPos) {
+        double diffX = clientPos.getX() - this.x;
+        double diffY = clientPos.getY() - this.y;
+        double diffZ = clientPos.getZ() - this.z;
+
+        this.setRotation(clientPos.getYaw(), clientPos.getPitch(), clientPos.getHeadYaw());
+        this.fastMove(diffX, diffY, diffZ);
     }
 
     /**

--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -2146,9 +2146,13 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
                 if (enabled) {
                     this.setDataFlag(ActorFlags.DOES_SERVER_AUTH_ONLY_DISMOUNT, true);
                     this.setDataFlag(ActorFlags.CAN_USE_VERTICAL_MOVEMENT_ACTION, true);
+                    this.setDataFlag(ActorFlags.BODY_ROTATION_ALWAYS_FOLLOWS_HEAD, true);
+                    this.setDataFlag(ActorFlags.USES_LEGACY_FRICTION, false);
                 } else {
                     this.setDataFlag(ActorFlags.DOES_SERVER_AUTH_ONLY_DISMOUNT, false);
                     this.setDataFlag(ActorFlags.CAN_USE_VERTICAL_MOVEMENT_ACTION, false);
+                    this.setDataFlag(ActorFlags.BODY_ROTATION_ALWAYS_FOLLOWS_HEAD, false);
+                    this.setDataFlag(ActorFlags.USES_LEGACY_FRICTION, true);
                 }
                 return true;
             }
@@ -2156,6 +2160,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
                 this.setDataFlag(ActorFlags.WASD_FREE_CAMERA_CONTROLLED, enabled);
                 this.setDataFlag(ActorFlags.WASD_CONTROLLED, false);
                 this.setDataFlag(ActorFlags.CAN_USE_VERTICAL_MOVEMENT_ACTION, false);
+                this.setDataFlag(ActorFlags.BODY_ROTATION_ALWAYS_FOLLOWS_HEAD, enabled);
                 this.setDataFlag(ActorFlags.DOES_SERVER_AUTH_ONLY_DISMOUNT, false);
                 return true;
             }
@@ -2359,7 +2364,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         if (ev.isCancelled()) return false;
 
         entity.riding = this;
-        entity.setDataFlag(ActorFlags.RIDING, true);
+        entity.setDataFlag(ActorFlags.RIDING, true, false);
         passengers.add(entity);
 
         if (!this.isPlayer && !(entity instanceof Player)) {
@@ -2506,38 +2511,44 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         for (int i = 0; i < passengers.size(); i++) {
             Entity p = passengers.get(i);
 
-            p.setSeatPosition(getSeatOffsetFor(i, p));
-
             RideableComponent.Seat sm = getRideSeatFor(i);
-            if (sm == null) continue;
+            Vector3f seatOffset = getSeatOffsetFor(i, p);
 
-            Vector3f raw = sm.position();
-            if (raw == null) raw = new Vector3f(0f, 0f, 0f);
-            p.seatRawOffset = raw;
+            p.setSeatPosition(seatOffset, false);
 
-            Float tpc = sm.thirdPersonCameraRadius();
-            if (tpc != null) p.setSeatThirdPersonCameraRadius(tpc);
+            if (sm != null) {
+                Vector3f raw = sm.position();
+                if (raw == null) raw = new Vector3f(0f, 0f, 0f);
+                p.seatRawOffset = raw;
 
-            Float relax = sm.cameraRelaxDistanceSmoothing();
-            if (relax != null) p.setSeatCameraRelaxDistanceSmoothing(relax);
+                Float tpc = sm.thirdPersonCameraRadius();
+                if (tpc != null) {
+                    p.setSeatThirdPersonCameraRadius(tpc, false);
+                }
 
-            Float lock = sm.lockRiderRotationDegrees();
-            if (lock != null) {
-                p.setDataProperty(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION, true);
-                p.setSeatLockRiderRotationDegrees(lock);
-            } else {
-                p.setDataProperty(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION, false);
-                p.setSeatLockRiderRotationDegrees(0.0f);
+                Float relax = sm.cameraRelaxDistanceSmoothing();
+                if (relax != null) {
+                    p.setSeatCameraRelaxDistanceSmoothing(relax, false);
+                }
+
+                Float lock = sm.lockRiderRotationDegrees();
+                if (lock != null) {
+                    p.setSeatLockRiderRotationDegrees(lock, false);
+                } else {
+                    p.setSeatLockRiderRotationDegrees(0.0f, false);
+                }
+
+                Float rot = sm.rotateRiderByDegrees();
+                if (rot != null) {
+                    p.setSeatRotationOffset(true, false);
+                    p.setSeatRotateRiderByDegrees(rot, false);
+                } else {
+                    p.setSeatRotationOffset(false, false);
+                    p.setSeatRotateRiderByDegrees(0.0f, false);
+                }
             }
 
-            Float rot = sm.rotateRiderByDegrees();
-            if (rot != null) {
-                p.setDataProperty(ActorDataTypes.SEAT_ROTATION_OFFSET, true);
-                p.setSeatRotateRiderByDegrees(rot);
-            } else {
-                p.setDataProperty(ActorDataTypes.SEAT_ROTATION_OFFSET, false);
-                p.setSeatRotateRiderByDegrees(0.0f);
-            }
+            p.sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), p.getSeatDataMap());
         }
     }
 
@@ -2556,6 +2567,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
 
     public boolean dismountEntity(Entity entity, boolean sendLinks, boolean riderInitiated) {
         int seatIndex = passengers.indexOf(entity);
+        Location lookLocation = entity.getLocation();
 
         EntityVehicleExitEvent ev = new EntityVehicleExitEvent(entity, this);
         server.getPluginManager().callEvent(ev);
@@ -2576,16 +2588,20 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
 
         entity.riding = null;
         entity.setDataFlag(ActorFlags.RIDING, false);
-        entity.setSeatPosition(new Vector3f());
+        entity.setSeatPosition(new Vector3f(), false);
         entity.seatRawOffset = null;
         passengers.remove(entity);
 
         Vector3 dismount = resolveDismountPosition(entity);
+        lookLocation.setComponents(dismount.x, dismount.y, dismount.z);
+
         if (entity instanceof Player p) {
-            p.teleport(dismount);
+            p.teleport(lookLocation);
             p.resetFallDistance();
         } else {
             entity.setPosition(dismount);
+            entity.setRotation((float) lookLocation.yaw, (float) lookLocation.pitch);
+            entity.updateMovement();
         }
 
         updatePassengers(sendLinks, false);
@@ -2667,13 +2683,13 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
     }
 
     public void clearSeatData(Player passenger) {
-        passenger.setDataProperty(ActorDataTypes.SEAT_CAMERA_RELAX_DISTANCE_SMOOTHING, 0.0f, false);
-        passenger.setDataProperty(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION, false, false);
-        passenger.setDataProperty(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION_DEGREES, 0.0f, false);
-        passenger.setDataProperty(ActorDataTypes.SEAT_THIRD_PERSON_CAMERA_RADIUS, 0.0f, false);
-        passenger.setDataProperty(ActorDataTypes.SEAT_ROTATION_OFFSET_DEGREES, 0.0f, false);
-        passenger.setDataProperty(ActorDataTypes.SEAT_ROTATION_OFFSET, false, true);
-        passenger.sendData(passenger);
+        passenger.setSeatCameraRelaxDistanceSmoothing(0.0f, false);
+        passenger.setSeatLockRiderRotationDegrees(0.0f, false);
+        passenger.setSeatThirdPersonCameraRadius(0.0f, false);
+        passenger.setSeatRotationOffset(false, false);
+        passenger.setSeatRotateRiderByDegrees(0.0f, false);
+
+        passenger.sendData(passenger, passenger.getSeatDataMap());
     }
 
 
@@ -2686,7 +2702,12 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
     }
 
     public void setSeatPosition(Vector3f pos) {
-        this.setDataProperty(ActorDataTypes.SEAT_OFFSET, pos.toNetwork());
+        this.setSeatPosition(pos, true);
+    }
+
+    public void setSeatPosition(Vector3f pos, boolean send) {
+        if (pos == null) return;
+        this.setDataProperty(ActorDataTypes.SEAT_OFFSET, pos.toNetwork(), send);
     }
 
     public @Nullable Float getSeatThirdPersonCameraRadius() {
@@ -2694,8 +2715,12 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
     }
 
     public void setSeatThirdPersonCameraRadius(@Nullable Float v) {
+        this.setSeatThirdPersonCameraRadius(v, true);
+    }
+
+    public void setSeatThirdPersonCameraRadius(@Nullable Float v, boolean send) {
         if (v == null) return;
-        this.setDataProperty(ActorDataTypes.SEAT_THIRD_PERSON_CAMERA_RADIUS, v);
+        this.setDataProperty(ActorDataTypes.SEAT_THIRD_PERSON_CAMERA_RADIUS, v, send);
     }
 
     public @Nullable Float getSeatCameraRelaxDistanceSmoothing() {
@@ -2703,8 +2728,12 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
     }
 
     public void setSeatCameraRelaxDistanceSmoothing(@Nullable Float v) {
+        this.setSeatCameraRelaxDistanceSmoothing(v, true);
+    }
+
+    public void setSeatCameraRelaxDistanceSmoothing(@Nullable Float v, boolean send) {
         if (v == null) return;
-        this.setDataProperty(ActorDataTypes.SEAT_CAMERA_RELAX_DISTANCE_SMOOTHING, v);
+        this.setDataProperty(ActorDataTypes.SEAT_CAMERA_RELAX_DISTANCE_SMOOTHING, v, send);
     }
 
     public @Nullable Float getSeatLockRiderRotationDegrees() {
@@ -2712,8 +2741,12 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
     }
 
     public void setSeatLockRiderRotationDegrees(@Nullable Float v) {
+        this.setSeatLockRiderRotationDegrees(v, true);
+    }
+
+    public void setSeatLockRiderRotationDegrees(@Nullable Float v, boolean send) {
         if (v == null) return;
-        this.setDataProperty(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION_DEGREES, v);
+        this.setDataProperty(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION_DEGREES, v, send);
     }
 
     public @Nullable Float getSeatRotateRiderByDegrees() {
@@ -2721,10 +2754,59 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
     }
 
     public void setSeatRotateRiderByDegrees(@Nullable Float v) {
-        if (v == null) return;
-        this.setDataProperty(ActorDataTypes.SEAT_ROTATION_OFFSET_DEGREES, v);
+        this.setSeatRotateRiderByDegrees(v, true);
     }
 
+    public void setSeatRotateRiderByDegrees(@Nullable Float v, boolean send) {
+        if (v == null) return;
+        this.setDataProperty(ActorDataTypes.SEAT_ROTATION_OFFSET_DEGREES, v, send);
+    }
+
+    public void setSeatLockPassengerRotation(boolean value) {
+        this.setSeatLockPassengerRotation(value, true);
+    }
+
+    public void setSeatLockPassengerRotation(boolean value, boolean send) {
+        this.setDataProperty(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION, value, send);
+    }
+
+    public void setSeatRotationOffset(boolean value) {
+        this.setSeatRotationOffset(value, true);
+    }
+
+    public void setSeatRotationOffset(boolean value, boolean send) {
+        this.setDataProperty(ActorDataTypes.SEAT_ROTATION_OFFSET, value, send);
+    }
+
+    protected ActorDataMap getSeatDataMap() {
+        ActorDataMap data = new ActorDataMap();
+
+        if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_OFFSET)) {
+            data.put(ActorDataTypes.SEAT_OFFSET, this.actorDataMap.get(ActorDataTypes.SEAT_OFFSET));
+        }
+
+        if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_THIRD_PERSON_CAMERA_RADIUS)) {
+            data.put(ActorDataTypes.SEAT_THIRD_PERSON_CAMERA_RADIUS, this.actorDataMap.get(ActorDataTypes.SEAT_THIRD_PERSON_CAMERA_RADIUS));
+        }
+
+        if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_CAMERA_RELAX_DISTANCE_SMOOTHING)) {
+            data.put(ActorDataTypes.SEAT_CAMERA_RELAX_DISTANCE_SMOOTHING, this.actorDataMap.get(ActorDataTypes.SEAT_CAMERA_RELAX_DISTANCE_SMOOTHING));
+        }
+
+        if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION_DEGREES)) {
+            data.put(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION_DEGREES, this.actorDataMap.get(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION_DEGREES));
+        }
+
+        if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_ROTATION_OFFSET)) {
+            data.put(ActorDataTypes.SEAT_ROTATION_OFFSET, this.actorDataMap.get(ActorDataTypes.SEAT_ROTATION_OFFSET));
+        }
+
+        if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_ROTATION_OFFSET_DEGREES)) {
+            data.put(ActorDataTypes.SEAT_ROTATION_OFFSET_DEGREES, this.actorDataMap.get(ActorDataTypes.SEAT_ROTATION_OFFSET_DEGREES));
+        }
+
+        return data;
+    }
 
     /// ///////////////////////////////////////////
     /// //////// UPDATE LINK PACKETS //////////////

--- a/src/main/java/cn/nukkit/entity/EntityPhysical.java
+++ b/src/main/java/cn/nukkit/entity/EntityPhysical.java
@@ -1373,17 +1373,7 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
     }
 
     protected float wrapDegrees(float angle) {
-        angle %= 360f;
-
-        if (angle >= 180f) {
-            angle -= 360f;
-        }
-
-        if (angle < -180f) {
-            angle += 360f;
-        }
-
-        return angle;
+        return angle - 360f * (float) Math.floor((angle + 180f) / 360f);
     }
 
     protected float approachDegrees(float current, float target, float maxStep) {

--- a/src/main/java/cn/nukkit/entity/EntityPhysical.java
+++ b/src/main/java/cn/nukkit/entity/EntityPhysical.java
@@ -13,6 +13,7 @@ import cn.nukkit.entity.custom.CustomEntityComponents;
 import cn.nukkit.entity.custom.CustomEntityDefinition;
 import cn.nukkit.event.entity.EntityDamageEvent;
 import cn.nukkit.event.player.EntityFreezeEvent;
+import cn.nukkit.level.Location;
 import cn.nukkit.level.format.IChunk;
 import cn.nukkit.math.AxisAlignedBB;
 import cn.nukkit.math.SimpleAxisAlignedBB;
@@ -64,6 +65,9 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
     private boolean wasOnSlipperyGround = false;
     private int slipperyEntryGraceTicks = 0;
     private double slipperyEntrySpeed = 0.0d;
+    private boolean airRideRotationInitialized = false;
+    private float airRideTargetYaw = 0f;
+    private int airRideRotationDelayTicks = 0;
 
 
     public EntityPhysical(IChunk chunk, CompoundTag nbt) {
@@ -480,6 +484,8 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
             return false;
         }
 
+        this.syncRiderLocationFromInput(rider, pk);
+
         if ((type == RideableComponent.InputType.GROUND || type == RideableComponent.InputType.WATER) && handleRideJumpOrDash(pk, type)) {
             return true;
         }
@@ -491,16 +497,26 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
         };
     }
 
+    protected void syncRiderLocationFromInput(Player rider, PlayerAuthInputPacket pk) {
+        org.cloudburstmc.math.vector.Vector3f pos = pk.getPosition();
+
+        rider.applyClientLocationFromAuthInput(new Location(
+                pos.getX(),
+                pos.getY(),
+                pos.getZ(),
+                pk.getInteractRotation().getY(),
+                pk.getInteractRotation().getX(),
+                pk.getInteractRotation().getY(),
+                rider.getLevel()
+        ));
+    }
+
     /**
      * Ground Input Controls
      */
     public boolean onRiderInputGroundControlled(Player rider, PlayerAuthInputPacket pk) {
-        int controlSeat = getControllingSeatIndex();
-        if (controlSeat < 0 || controlSeat >= passengers.size() || passengers.get(controlSeat) != rider) return false;
-
-        if (!(this instanceof EntityControlUtils me)) return false;
-        me.setMoveTarget(null);
-        me.setLookTarget(null);
+        if (!isControllingRider(rider)) return false;
+        if (!prepareManualRiderControl()) return false;
 
         // INPUT KNOBS
         final double DEADZONE = 0.08;        // stick drift tolerance
@@ -543,7 +559,7 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
 
             } else {
                 Vector2 dir = adjusted.normalize();
-                double yawRad = Math.toRadians(pk.getPlayerRotation().getY());
+                double yawRad = Math.toRadians(pk.getInteractRotation().getY());
                 double wishX = -Math.sin(yawRad) * dir.y + Math.cos(yawRad) * dir.x;
                 double wishZ =  Math.cos(yawRad) * dir.y + Math.sin(yawRad) * dir.x;
 
@@ -593,8 +609,8 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
             }
         }
 
-        this.yaw = pk.getPlayerRotation().getY();
-        this.headYaw = pk.getPlayerRotation().getY();
+        this.yaw = pk.getInteractRotation().getY();
+        this.headYaw = pk.getInteractRotation().getY();
         return true;
     }
 
@@ -864,21 +880,18 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
 
     /** Air Input Controls */
     public boolean onRiderInputAirControlled(Player rider, PlayerAuthInputPacket pk) {
-        int controlSeat = getControllingSeatIndex();
-        if (controlSeat < 0 || controlSeat >= passengers.size() || passengers.get(controlSeat) != rider) return false;
-
-        if (!(this instanceof EntityControlUtils me)) return false;
-        me.setMoveTarget(null);
-        me.setLookTarget(null);
+        if (!isControllingRider(rider)) {
+            resetAirRideRotation();
+            return false;
+        }
+        if (!prepareManualRiderControl()) return false;
 
         // INPUT KNOBS
         final double HORIZONTAL_TUNE = 0.97d;   // Horizontal movement speed
         final double VERTICAL_TUNE = 0.60d;   // Vertical movement speed
         final double FRICTION_KNOB = 7.0d;      // Knob to parity with BDS speed
 
-        setYaw(pk.getInteractRotation().getY());
-        setHeadYaw(pk.getInteractRotation().getY());
-        setPitch(pk.getInteractRotation().getX());
+        applyAirRideRotation(pk.getInteractRotation().getY());
 
         Vector2f input = Vector2f.fromNetwork(pk.getRawMoveVector());
         float forward = input.y;
@@ -932,12 +945,8 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
      * Water Input Controls
      */
     public boolean onRiderInputWaterControlled(Player rider, PlayerAuthInputPacket pk) {
-        int controlSeat = getControllingSeatIndex();
-        if (controlSeat < 0 || controlSeat >= passengers.size() || passengers.get(controlSeat) != rider) return false;
-
-        if (!(this instanceof EntityControlUtils me)) return false;
-        me.setMoveTarget(null);
-        me.setLookTarget(null);
+        if (!isControllingRider(rider)) return false;
+        if (!prepareManualRiderControl()) return false;
 
         // INPUT KNOBS
         final double HORIZONTAL_TUNE = 0.97d;
@@ -1347,5 +1356,166 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
         return maxY;
     }
 
+    protected int getAirRideRotationDelayTicks() {
+        return 2;
+    }
+
+    protected float getAirRideYawTurnSpeed() {
+        return 4.21875f;
+    }
+
+    protected float getAirRideYawInputThreshold() {
+        return 2.0f;
+    }
+
+    protected float getAirRideYawStopDistance() {
+        return 1.25f;
+    }
+
+    protected float wrapDegrees(float angle) {
+        angle %= 360f;
+
+        if (angle >= 180f) {
+            angle -= 360f;
+        }
+
+        if (angle < -180f) {
+            angle += 360f;
+        }
+
+        return angle;
+    }
+
+    protected float approachDegrees(float current, float target, float maxStep) {
+        float delta = wrapDegrees(target - current);
+
+        if (delta > maxStep) {
+            delta = maxStep;
+        } else if (delta < -maxStep) {
+            delta = -maxStep;
+        }
+
+        return current + delta;
+    }
+
+    protected void applyAirRideRotation(float targetYaw) {
+        float currentYaw = (float) this.getYaw();
+
+        if (!this.airRideRotationInitialized) {
+            this.airRideRotationInitialized = true;
+            this.airRideTargetYaw = currentYaw;
+            this.airRideRotationDelayTicks = 0;
+        }
+
+        float distanceToCurrentTarget = Math.abs(wrapDegrees(this.airRideTargetYaw - currentYaw));
+        boolean targetReached = distanceToCurrentTarget <= getAirRideYawStopDistance();
+
+        if (targetReached) {
+            float yawDelta = Math.abs(wrapDegrees(targetYaw - this.airRideTargetYaw));
+
+            if (yawDelta > getAirRideYawInputThreshold()) {
+                this.airRideTargetYaw = targetYaw;
+                this.airRideRotationDelayTicks = getAirRideRotationDelayTicks();
+            }
+        }
+
+        if (this.airRideRotationDelayTicks > 0) {
+            this.airRideRotationDelayTicks--;
+            return;
+        }
+
+        float newYaw = approachDegrees(currentYaw, this.airRideTargetYaw, getAirRideYawTurnSpeed());
+
+        if (Math.abs(wrapDegrees(newYaw - currentYaw)) > 0.01f) {
+            this.setYaw(newYaw);
+            this.setHeadYaw(newYaw);
+        }
+
+        if (Math.abs(this.getPitch()) > 0.01f) {
+            this.setPitch(0f);
+        }
+    }
+
+    protected void resetAirRideRotation() {
+        this.airRideRotationInitialized = false;
+        this.airRideTargetYaw = 0f;
+        this.airRideRotationDelayTicks = 0;
+    }
+
+    protected boolean shouldLockBodyRotationWhenStoodOn() {
+        return false;
+    }
+
+    protected boolean hasEntityStandingOnTop() {
+        if (this.passengers != null && !this.passengers.isEmpty()) return false;
+        if (this.level == null || this.getBoundingBox() == null) return false;
+
+        AxisAlignedBB bb = this.getBoundingBox();
+
+        double topY = bb.getMaxY();
+        double pad = 0.10d;
+
+        AxisAlignedBB area = new SimpleAxisAlignedBB(
+                bb.getMinX() + pad,
+                topY - 0.35d,
+                bb.getMinZ() + pad,
+                bb.getMaxX() - pad,
+                topY + 2.20d,
+                bb.getMaxZ() - pad
+        );
+
+        for (Entity e : this.level.getNearbyEntitiesSafe(area, this)) {
+            if (!(e instanceof Player p)) continue;
+            if (!p.isAlive()) continue;
+            if (this.isPassenger(p)) continue;
+
+            AxisAlignedBB pbb = p.getBoundingBox();
+            if (pbb == null) continue;
+
+            double feetY = pbb.getMinY();
+
+            if (feetY >= topY - 0.45d && feetY <= topY + 2.00d) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected boolean isControllingRider(Player rider) {
+        int controlSeat = getControllingSeatIndex();
+        return controlSeat >= 0 && controlSeat < passengers.size() && passengers.get(controlSeat) == rider;
+    }
+
+    protected boolean prepareManualRiderControl() {
+        if (!(this instanceof EntityControlUtils me)) return false;
+
+        me.setMoveTarget(null);
+        me.setLookTarget(null);
+        return true;
+    }
+
+
+    @Override
+    public boolean mountEntity(Entity entity, boolean riderInitiated) {
+        boolean result = super.mountEntity(entity, riderInitiated);
+
+        if (result && this.getInputControlType() == RideableComponent.InputType.AIR) {
+            this.resetAirRideRotation();
+        }
+
+        return result;
+    }
+
+    @Override
+    public boolean dismountEntity(Entity entity, boolean sendLinks, boolean riderInitiated) {
+        boolean result = super.dismountEntity(entity, sendLinks, riderInitiated);
+
+        if (result && this.getInputControlType() == RideableComponent.InputType.AIR && this.passengers.isEmpty()) {
+            this.resetAirRideRotation();
+        }
+
+        return result;
+    }
     // INPUT CONTROLS HELPERS END
 }

--- a/src/main/java/cn/nukkit/entity/passive/EntityHappyGhast.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityHappyGhast.java
@@ -82,9 +82,12 @@ public class EntityHappyGhast extends EntityAnimal implements EntityFlyable, Inv
 
     private EntityArmorInventory armorInventory;
     private volatile boolean playerOnTopCached;
-    private volatile boolean hasPassengers;
-    private Vector3 frozenAnchorPos;
     private int dismountUnlockDelayTicks = 0;
+    private boolean topRotationLocked = false;
+    private boolean wasPlatformLocked = false;
+    private Vector3 forcedPlatformLockPosition;
+    private float forcedPlatformLockYaw = 0f;
+    private volatile int forcedPlatformLockTicks = 0;
 
     @Override
     public String getOriginalName() {
@@ -172,6 +175,11 @@ public class EntityHappyGhast extends EntityAnimal implements EntityFlyable, Inv
     }
 
     @Override
+    protected boolean shouldLockBodyRotationWhenStoodOn() {
+        return true;
+    }
+
+    @Override
     public RideableComponent getComponentRideable() {
         if (!this.isHarnessed() || this.isBaby()) return null;
 
@@ -239,6 +247,7 @@ public class EntityHappyGhast extends EntityAnimal implements EntityFlyable, Inv
 
     @Override
     public boolean canBePushedByEntities() {
+        if (this.isLockedAsPlatform()) return false;
         return this.canMove();
     }
 
@@ -303,13 +312,20 @@ public class EntityHappyGhast extends EntityAnimal implements EntityFlyable, Inv
                 armorInventory.sendContents(player);
                 this.setInputControls(false);
                 this.setHomePosition();
+
+                this.setDataFlag(ActorFlags.BODY_ROTATION_BLOCKED, false);
+                this.setDataFlag(ActorFlags.ROTATION_AXIS_ALIGNED, false);
+                this.setDataFlag(ActorFlags.BODY_ROTATION_ALWAYS_FOLLOWS_HEAD, false);
                 return true;
             }
         }
 
-        if (this.isHarnessed() && mountEntity(player, true)) {
-            this.hasPassengers = true;
-            return false;
+        if (this.isHarnessed()) {
+            this.clearTopRotationLockForRiding();
+
+            if (mountEntity(player, true)) {
+                return false;
+            }
         }
 
         return false;
@@ -321,8 +337,10 @@ public class EntityHappyGhast extends EntityAnimal implements EntityFlyable, Inv
 
         if (result && this.passengers.isEmpty()) {
             this.setHomePosition();
-            this.hasPassengers = false;
             this.dismountUnlockDelayTicks = 10;
+            this.forcedPlatformLockTicks = 3;
+
+            this.forceImmediatePlatformLockAfterDismount();
         }
         return result;
     }
@@ -331,6 +349,37 @@ public class EntityHappyGhast extends EntityAnimal implements EntityFlyable, Inv
     public void spawnTo(Player player) {
         super.spawnTo(player);
         armorInventory.sendContents(player);
+    }
+
+    private boolean isLockedAsPlatform() {
+        return !this.isBaby()
+                && this.playerOnTopCached
+                && (this.passengers == null || this.passengers.isEmpty());
+    }
+
+    private boolean hasMountedPassengers() {
+        return this.passengers != null && !this.passengers.isEmpty();
+    }
+
+    private boolean refreshPlatformLockStateForAi() {
+        boolean controlled = this.hasControllingPassenger();
+        boolean mounted = this.hasMountedPassengers();
+
+        if (controlled || mounted || this.isBaby()) {
+            this.playerOnTopCached = false;
+            this.forcedPlatformLockTicks = 0;
+            this.forcedPlatformLockPosition = null;
+            return false;
+        }
+
+        if (this.forcedPlatformLockTicks > 0) {
+            this.playerOnTopCached = true;
+            return true;
+        }
+
+        boolean standingOnTop = this.isPlayerStandingOnTop();
+        this.playerOnTopCached = standingOnTop;
+        return standingOnTop;
     }
 
     public boolean isHarnessed() {
@@ -355,51 +404,62 @@ public class EntityHappyGhast extends EntityAnimal implements EntityFlyable, Inv
         this.setBooleanEntityProperty(PROP_CAN_MOVE, value);
     }
 
-    private static float snapYawToCardinal(double yaw) {
-        double y = yaw % 360f;
-        if (y < 0f) y += 360f;
-        return Math.round(y / 90f) * 90f;
-    }
+    private void applyBodyRotationFlagsFromTopPresence(boolean playerOnTop) {
+        boolean mounted = this.hasMountedPassengers();
 
-    private void applyMobilityFromTopPresence(boolean playerOnTop) {
-        boolean mounted = this.hasPassengers;
-        boolean shouldMove = mounted || !playerOnTop;
+        if (mounted) {
+            this.topRotationLocked = false;
 
-        if (!shouldMove) {
-            if (this.frozenAnchorPos == null) {
-                this.frozenAnchorPos = new Vector3(this.getX(), this.getY(), this.getZ());
-            }
-
-            // Snap yaw to cardinal
-            float snapped = snapYawToCardinal(this.getYaw());
-            this.setRotation(snapped, 0f);
-            this.setHeadYaw(snapped);
-            this.setPitch(0f);
-
-            // Clear AI intentions
-            this.setMoveTarget(null);
-            this.setLookTarget(null);
-
-            // Kill direction vectors used by controllers
-            this.getMemoryStorage().clear(CoreMemoryTypes.MOVE_DIRECTION_START);
-            this.getMemoryStorage().clear(CoreMemoryTypes.MOVE_DIRECTION_END);
-            this.getMemoryStorage().put(CoreMemoryTypes.SHOULD_UPDATE_MOVE_DIRECTION, false);
-
-            // Hard pin to anchor
-            this.setMotion(new Vector3(0, 0, 0));
-            this.setMovementSpeed(0f);
-            this.setPosition(this.frozenAnchorPos);
-
-            this.getBehaviorGroup().setForceUpdateRoute(true);
-            this.setCanMove(false);
+            this.setDataFlag(ActorFlags.BODY_ROTATION_BLOCKED, false);
+            this.setDataFlag(ActorFlags.ROTATION_AXIS_ALIGNED, false);
+            this.setDataFlag(ActorFlags.BODY_ROTATION_ALWAYS_FOLLOWS_HEAD, true);
             return;
         }
 
-        // Mobile again
-        if (this.canMove()) return;
+        if (playerOnTop) {
+            this.setDataFlag(ActorFlags.BODY_ROTATION_ALWAYS_FOLLOWS_HEAD, true);
+            this.setDataFlag(ActorFlags.ROTATION_AXIS_ALIGNED, true);
 
-        this.frozenAnchorPos = null;
-        this.setCanMove(true);
+            if (!this.topRotationLocked) {
+                this.snapBodyToClosestCardinal();
+                this.topRotationLocked = true;
+            }
+
+            this.setDataFlag(ActorFlags.BODY_ROTATION_BLOCKED, true);
+            return;
+        }
+
+        this.topRotationLocked = false;
+
+        this.setDataFlag(ActorFlags.BODY_ROTATION_BLOCKED, false);
+        this.setDataFlag(ActorFlags.ROTATION_AXIS_ALIGNED, false);
+        this.setDataFlag(ActorFlags.BODY_ROTATION_ALWAYS_FOLLOWS_HEAD, false);
+    }
+
+    private void clearTopRotationLockForRiding() {
+        this.setDataFlag(ActorFlags.BODY_ROTATION_BLOCKED, false);
+        this.setDataFlag(ActorFlags.ROTATION_AXIS_ALIGNED, false);
+        this.setDataFlag(ActorFlags.BODY_ROTATION_ALWAYS_FOLLOWS_HEAD, true);
+    }
+
+    private void enterPlatformLock() {
+        this.setMoveTarget(null);
+        this.setLookTarget(null);
+
+        this.getMemoryStorage().clear(CoreMemoryTypes.MOVE_DIRECTION_START);
+        this.getMemoryStorage().clear(CoreMemoryTypes.MOVE_DIRECTION_END);
+        this.getMemoryStorage().put(CoreMemoryTypes.SHOULD_UPDATE_MOVE_DIRECTION, false);
+
+        this.getBehaviorGroup().setForceUpdateRoute(true);
+
+        this.setMotion(new Vector3(0, 0, 0));
+        this.setMovementSpeed(0f);
+        this.updateMovement();
+    }
+
+    private void exitPlatformLock() {
+        this.forcedPlatformLockTicks = 0;
+        this.forcedPlatformLockPosition = null;
 
         this.setMoveTarget(null);
         this.setLookTarget(null);
@@ -409,51 +469,131 @@ public class EntityHappyGhast extends EntityAnimal implements EntityFlyable, Inv
         this.getMemoryStorage().put(CoreMemoryTypes.SHOULD_UPDATE_MOVE_DIRECTION, true);
 
         this.getBehaviorGroup().setForceUpdateRoute(true);
+
+        this.setMotion(new Vector3(0, 0, 0));
         this.setMovementSpeed(this.getMovementSpeedDefault());
+    }
+
+    private void forceImmediatePlatformLockAfterDismount() {
+        this.forcedPlatformLockYaw = snapYawToCardinal(this.getYaw());
+        this.forcedPlatformLockPosition = new Vector3(this.getX(), this.getY(), this.getZ());
+        this.forcedPlatformLockTicks = 6;
+
+        this.applyForcedDismountLock();
+    }
+
+    private void applyForcedDismountLock() {
+        this.playerOnTopCached = true;
+        this.wasPlatformLocked = true;
+        this.topRotationLocked = true;
+
+        this.setMoveTarget(null);
+        this.setLookTarget(null);
+
+        this.getMemoryStorage().clear(CoreMemoryTypes.MOVE_DIRECTION_START);
+        this.getMemoryStorage().clear(CoreMemoryTypes.MOVE_DIRECTION_END);
+        this.getMemoryStorage().put(CoreMemoryTypes.SHOULD_UPDATE_MOVE_DIRECTION, false);
+
+        this.getBehaviorGroup().setForceUpdateRoute(true);
+
+        this.setMotion(new Vector3(0, 0, 0));
+        this.setMovementSpeed(0f);
+
+        if (this.forcedPlatformLockPosition != null) {
+            this.setPosition(this.forcedPlatformLockPosition);
+        }
+
+        this.setRotation(this.forcedPlatformLockYaw, 0f);
+        this.setHeadYaw(this.forcedPlatformLockYaw);
+        this.setPitch(0f);
+
+        this.setDataFlag(ActorFlags.BODY_ROTATION_ALWAYS_FOLLOWS_HEAD, true);
+        this.setDataFlag(ActorFlags.ROTATION_AXIS_ALIGNED, true);
+        this.setDataFlag(ActorFlags.BODY_ROTATION_BLOCKED, true);
+
+        this.updateMovement();
+    }
+
+    private boolean isPlayerStandingOnTop() {
+        if (this.isBaby()) return false;
+        if (this.passengers != null && !this.passengers.isEmpty()) return false;
+
+        final double topY = this.getY() + this.getHeight();
+
+        final double half = this.getWidth() * 0.5;
+        final double pad = 0.10;
+
+        final double minY = topY - 0.35;
+        final double maxY = topY + 2.20;
+
+        AxisAlignedBB box = new SimpleAxisAlignedBB(
+                this.getX() - half + pad,
+                minY,
+                this.getZ() - half + pad,
+                this.getX() + half - pad,
+                maxY,
+                this.getZ() + half - pad
+        );
+
+        for (Entity e : this.level.getNearbyEntitiesSafe(box, this)) {
+            if (!(e instanceof Player p) || !p.isAlive()) continue;
+            if (this.isPassenger(p)) continue;
+
+            AxisAlignedBB pbb = p.getBoundingBox();
+            if (pbb == null) continue;
+
+            double feetY = pbb.getMinY();
+
+            if (feetY >= topY - 0.45 && feetY <= topY + 2.00) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static float snapYawToCardinal(double yaw) {
+        double y = yaw % 360f;
+        if (y < 0f) y += 360f;
+
+        float snapped = (float) (Math.round(y / 90f) * 90f);
+        if (snapped >= 360f) snapped -= 360f;
+
+        return snapped;
+    }
+
+    private void snapBodyToClosestCardinal() {
+        float snapped = snapYawToCardinal(this.getYaw());
+
+        this.setRotation(snapped, 0f);
+        this.setHeadYaw(snapped);
+        this.setPitch(0f);
+
+        this.updateMovement();
     }
 
 
     @Override
     public boolean onUpdate(int currentTick) {
         boolean updated = super.onUpdate(currentTick);
-        boolean mounted = this.passengers != null && !this.passengers.isEmpty();
-        this.hasPassengers = mounted;
-        boolean standingOnTop = false;
 
-        if (!mounted) {
-            final double topY = this.getY() + this.getHeight();
+        boolean mounted = this.hasMountedPassengers();
 
-            final double half = this.getWidth() * 0.5;
-            final double pad = 0.10;
-
-            final double minY = topY - 0.35;
-            final double maxY = topY + 2.20;
-
-            AxisAlignedBB box = new SimpleAxisAlignedBB(
-                    this.getX() - half + pad,
-                    minY,
-                    this.getZ() - half + pad,
-                    this.getX() + half - pad,
-                    maxY,
-                    this.getZ() + half - pad
-            );
-
-            for (Entity e : this.level.getNearbyEntitiesSafe(box, this)) {
-                if (!(e instanceof Player p) || !p.isAlive()) continue;
-
-                AxisAlignedBB pbb = p.getBoundingBox();
-                if (pbb == null) continue;
-
-                double feetY = pbb.getMinY();
-
-                if (feetY >= topY - 0.45 && feetY <= topY + 2.00) {
-                    standingOnTop = true;
-                    break;
-                }
-            }
+        if (this.dismountUnlockDelayTicks > 0 && !mounted) {
+            this.dismountUnlockDelayTicks--;
         }
 
-        this.playerOnTopCached = mounted || standingOnTop;
+        if (this.forcedPlatformLockTicks > 0) {
+            this.playerOnTopCached = true;
+            this.applyForcedDismountLock();
+            return updated;
+        }
+
+        boolean standingOnTop = !mounted && this.isPlayerStandingOnTop();
+        this.playerOnTopCached = standingOnTop;
+
+        this.applyBodyRotationFlagsFromTopPresence(standingOnTop);
+
         return updated;
     }
 
@@ -482,28 +622,27 @@ public class EntityHappyGhast extends EntityAnimal implements EntityFlyable, Inv
         return new BehaviorGroup(
                 this.tickSpread,
                 Set.of(
-                        new Behavior(
-                                new AnimalGrowExecutor(),
-                                all(
-                                        e -> e.isAgeable(),
-                                        e -> e.isBaby(),
-                                        e -> !e.isGrowthPaused(),
-                                        e -> e.getTicksGrowLeft() > 0
-                                ),
-                                1, 1, 1200
-                        )
+                    new Behavior(
+                            new AnimalGrowExecutor(),
+                            all(
+                                    e -> e.isAgeable(),
+                                    e -> e.isBaby(),
+                                    e -> !e.isGrowthPaused(),
+                                    e -> e.getTicksGrowLeft() > 0
+                            ),
+                            1, 1, 1200
+                    )
                 ),
                 Set.of(
-                        new Behavior( // Return home if too far
-                                new MoveToTargetExecutor(CoreMemoryTypes.NEAREST_BLOCK, this.getDefaultFlyingSpeed() * 8f, true),
-                                entity -> {
-                                    EntityHappyGhast g = (EntityHappyGhast) entity;
+                    new Behavior( // Return home if too far
+                            new MoveToTargetExecutor(CoreMemoryTypes.NEAREST_BLOCK, this.getDefaultFlyingSpeed() * 8f, true),
+                            entity -> {
+                                EntityHappyGhast g = (EntityHappyGhast) entity;
+                                if (!g.canMove()) return false;
+                                if (g.hasMountedPassengers()) return false;
 
-                                    if (!g.canMove()) return false;
-                                    if (g.hasPassengers) return false;
-
-                                    Block home = entity.getMemoryStorage().get(CoreMemoryTypes.NEAREST_BLOCK);
-                                    if (home == null) return false;
+                                Block home = entity.getMemoryStorage().get(CoreMemoryTypes.NEAREST_BLOCK);
+                                if (home == null) return false;
 
                             double max = g.roamDistance();
                             return entity.distanceSquared(home) > (max * max);
@@ -515,11 +654,11 @@ public class EntityHappyGhast extends EntityAnimal implements EntityFlyable, Inv
                             entity -> {
                                 EntityHappyGhast g = (EntityHappyGhast) entity;
                                 if (!g.canMove()) return false;
-                                if (g.hasPassengers) return false;
+                                if (g.hasMountedPassengers()) return false;
                                 if (g.dismountUnlockDelayTicks > 0) return false;
                                 return TemptExecutor.hasTemptingPlayer(entity, true, 16, TEMPT_ITEMS);
                             },
-                        3, 1
+                            3, 1
                     ),
                     new Behavior( // Hover roam near home
                         new HoverRandomRoamExecutor(
@@ -534,7 +673,7 @@ public class EntityHappyGhast extends EntityAnimal implements EntityFlyable, Inv
                         entity -> {
                             EntityHappyGhast g = (EntityHappyGhast) entity;
                             if (!g.canMove()) return false;
-                            if (g.hasPassengers) return false;
+                            if (g.hasMountedPassengers()) return false;
                             return true;
                         },
                         2, 1
@@ -551,52 +690,114 @@ public class EntityHappyGhast extends EntityAnimal implements EntityFlyable, Inv
                                 },
                                 e -> {
                                     EntityHappyGhast g = (EntityHappyGhast) e;
-                                    return !g.hasPassengers && g.dismountUnlockDelayTicks <= 0;
+                                    return !g.hasMountedPassengers() && !g.isLockedAsPlatform() && g.dismountUnlockDelayTicks <= 0;
                                 }
                             ),
                         1, 1, 100
                     )
                 ),
                 Set.of(
-                        new NearestPlayerSensor(56, 0, 20),
-                        // Ensure HOME memory exists + stays valid
-                        new ISensor() {
-                            @Override
-                            public void sense(EntityIntelligent entity) {
-                                EntityHappyGhast g = (EntityHappyGhast) entity;
-                                if (entity.getMemoryStorage().isEmpty(CoreMemoryTypes.NEAREST_BLOCK))
-                                    g.setHomePosition();
-                            }
-
-                            @Override
-                            public int getPeriod() {
-                                return 60;
-                            }
-                        },
-                        new ISensor() {
-                            @Override
-                            public void sense(EntityIntelligent entity) {
-                                EntityHappyGhast g = (EntityHappyGhast) entity;
-                                if (g.dismountUnlockDelayTicks > 0 && !g.hasPassengers) g.dismountUnlockDelayTicks--;
-                                g.applyMobilityFromTopPresence(g.playerOnTopCached);
-                            }
-
-                            @Override
-                            public int getPeriod() {
-                                return 1;
-                            }
+                    new NearestPlayerSensor(56, 0, 20),
+                    // Ensure HOME memory exists + stays valid
+                    new ISensor() {
+                        @Override
+                        public void sense(EntityIntelligent entity) {
+                            EntityHappyGhast g = (EntityHappyGhast) entity;
+                            if (entity.getMemoryStorage().isEmpty(CoreMemoryTypes.NEAREST_BLOCK))
+                                g.setHomePosition();
                         }
+
+                        @Override
+                        public int getPeriod() {
+                            return 60;
+                        }
+                    }
                 ),
                 Set.of(
-                        new SpaceMoveController(),
-                        new LookController(
-                                () -> this.canMove() && !this.hasPassengers && this.dismountUnlockDelayTicks <= 0,
-                                () -> this.canMove() && !this.hasPassengers && this.dismountUnlockDelayTicks <= 0
-                        ),
-                        new LiftController()
+                    new SpaceMoveController(),
+                    new LookController(
+                            () -> this.canMove(),
+                            () -> this.canMove()
+                    ),
+                    new LiftController()
                 ),
                 new SimpleSpaceAStarRouteFinder(new HoveringPosEvaluator(), this),
                 this
         );
+    }
+
+    @Override
+    public void asyncPrepare(int currentTick) {
+        if (this.forcedPlatformLockTicks > 0) {
+            this.applyForcedDismountLock();
+
+            isActive = level.isHighLightChunk(getChunkX(), getChunkZ());
+            this.needsRecalcMovement = this.level.tickRateOptDelay == 1 || ((currentTick + tickSpread) & (this.level.tickRateOptDelay - 1)) == 0;
+            this.calculateOffsetBoundingBox();
+
+            this.forcedPlatformLockTicks--;
+            return;
+        }
+
+        boolean controlled = this.hasControllingPassenger();
+        boolean platformLocked = this.refreshPlatformLockStateForAi();
+
+        if (controlled) {
+            this.wasPlatformLocked = false;
+            return;
+        }
+
+        if (platformLocked) {
+            if (!this.wasPlatformLocked) {
+                this.enterPlatformLock();
+                this.wasPlatformLocked = true;
+            }
+
+            isActive = level.isHighLightChunk(getChunkX(), getChunkZ());
+            this.needsRecalcMovement = this.level.tickRateOptDelay == 1 || ((currentTick + tickSpread) & (this.level.tickRateOptDelay - 1)) == 0;
+            this.calculateOffsetBoundingBox();
+
+            this.setMotion(new Vector3(0, 0, 0));
+            this.setMovementSpeed(0f);
+
+            if (this.forcedPlatformLockTicks > 0) {
+                this.forcedPlatformLockTicks--;
+            }
+
+            return;
+        }
+
+        if (this.wasPlatformLocked) {
+            this.exitPlatformLock();
+            this.wasPlatformLocked = false;
+        }
+
+        isActive = level.isHighLightChunk(getChunkX(), getChunkZ());
+
+        if (!this.isImmobile()) {
+            var behaviorGroup = getBehaviorGroup();
+            if (behaviorGroup == null) return;
+
+            behaviorGroup.collectSensorData(this);
+            behaviorGroup.evaluateCoreBehaviors(this);
+            behaviorGroup.evaluateBehaviors(this);
+            behaviorGroup.tickRunningCoreBehaviors(this);
+            behaviorGroup.tickRunningBehaviors(this);
+            behaviorGroup.updateRoute(this);
+            behaviorGroup.applyController(this);
+        }
+
+        this.needsRecalcMovement = this.level.tickRateOptDelay == 1 || ((currentTick + tickSpread) & (this.level.tickRateOptDelay - 1)) == 0;
+        this.calculateOffsetBoundingBox();
+
+        if (!this.isImmobile()) {
+            if (needsRecalcMovement) {
+                handleCollideMovement(currentTick);
+            }
+
+            addTmpMoveMotionXZ(previousCollideMotion);
+            handleFloatingMovement();
+            handlePassableBlockFrictionMovement();
+        }
     }
 }


### PR DESCRIPTION
Updates core ride handling so mounted players keep their server-side location and rotation synchronized from `PlayerAuthInputPacket` while riding, preventing stale rider state on dismount. Also improves Happy Ghast BDS parity by preserving the client-side correlation between rider head rotation and the ridden entity, including corrected ride seat metadata batching and platform-lock behavior after dismount.
