### PR TITLE
fix: Custom spawn eggs in creative inventory not showing

### DIFF
--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -2711,6 +2711,31 @@ public abstract class Item implements Cloneable, ItemID {
                 .build();
     }
 
+    public ItemData toCreativeNetwork() {
+        final boolean hasNbt = this.getNbt() != null;
+        final boolean clearCreativeTag = this.isCreativeTagEmpty();
+
+        return ItemData.builder()
+                .definition(this.getItemDefinition())
+                .damage(this.getDamage())
+                .count(this.getCount())
+                .tag(clearCreativeTag || this.getNbt() == null ? null : this.getNbt().toNetwork())
+                .canPlace(!hasNbt || clearCreativeTag ? new String[0] : listTagToStringArray(this.getCanPlaceOn()))
+                .canBreak(!hasNbt || clearCreativeTag ? new String[0] : listTagToStringArray(this.getCanDestroy()))
+                .blockDefinition(new RuntimeBlockDefinition(this.isCreativeBlockDefinitionEmpty() ? 0 : (this.block == null ? Block.get(Block.AIR).getRuntimeId() : this.getBlock().getRuntimeId())))
+                .usingNetId(false)
+                .netId(0)
+                .build();
+    }
+
+    protected boolean isCreativeTagEmpty() {
+        return false;
+    }
+
+    protected boolean isCreativeBlockDefinitionEmpty() {
+        return false;
+    }
+
     public static Item fromNetwork(ItemData itemData) {
         if (itemData.getDefinition() == null) {
             return Item.AIR;

--- a/src/main/java/cn/nukkit/item/ItemCustomEntitySpawnEgg.java
+++ b/src/main/java/cn/nukkit/item/ItemCustomEntitySpawnEgg.java
@@ -16,6 +16,7 @@ import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.nbt.tag.DoubleTag;
 import cn.nukkit.nbt.tag.FloatTag;
 import cn.nukkit.registry.Registries;
+import cn.nukkit.utils.Identifier;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.Field;
@@ -154,27 +155,34 @@ public class ItemCustomEntitySpawnEgg extends Item implements SpawnEggPickable {
         return c;
     }
 
+    @Override
+    protected boolean isCreativeTagEmpty() {
+        return true;
+    }
+
+    @Override
+    protected boolean isCreativeBlockDefinitionEmpty() {
+        return true;
+    }
+
 
     // ---------- helpers ----------
     private void selfHealIdentifierFromNamedTag() {
         CompoundTag tag = this.getNbt();
         if (tag == null) return;
+
         CompoundTag pnxExtra = tag.getCompound(ROOT_PNX_EXTRA);
         if (pnxExtra == null) return;
+
         CompoundTag customEgg = pnxExtra.getCompound(COMP_CUSTOM_EGG);
         if (customEgg == null) return;
+
         String eggId = customEgg.getString(KEY_EGG_ID);
         if (eggId != null && !eggId.isEmpty() && !eggId.equals(super.getId())) {
-            setItemIdReflect(this, eggId);
+            this.id = eggId.intern();
+            this.identifier = new Identifier(eggId);
+            this.name = null;
         }
-    }
-
-    private static void setItemIdReflect(Item item, String id) {
-        try {
-            Field f = Item.class.getDeclaredField("id");
-            f.setAccessible(true);
-            f.set(item, id);
-        } catch (Throwable ignored) { }
     }
 
     public static @Nullable String entityIdFromEggId(String eggId) {
@@ -211,25 +219,40 @@ public class ItemCustomEntitySpawnEgg extends Item implements SpawnEggPickable {
 
     /** Bind the resolved item id to this egg and seed PNX extra data. */
     public void resolveSpawnEgg(String resolvedId) {
-        setItemIdReflect(this, resolvedId);
+        if (resolvedId == null || resolvedId.isBlank()) {
+            return;
+        }
 
-        CompoundTag root = this.getOrCreateNbt();
-        CompoundTag pnx  = root.getCompound(ROOT_PNX_EXTRA);
-        if (pnx == null) {
-            pnx = new CompoundTag();
-            root.putCompound(ROOT_PNX_EXTRA, pnx);
-        }
-        CompoundTag ce = pnx.getCompound(COMP_CUSTOM_EGG);
-        if (ce == null) {
-            ce = new CompoundTag();
-            pnx.putCompound(COMP_CUSTOM_EGG, ce);
-        }
-        ce.putString(KEY_EGG_ID, resolvedId);
+        String entityId = entityIdFromEggId(resolvedId);
 
-        String ent = entityIdFromEggId(resolvedId);
-        if (ent != null) {
-            ce.putString(KEY_ENTITY_ID, ent);
+        this.id = resolvedId.intern();
+        this.identifier = new Identifier(resolvedId);
+        this.name = null;
+
+        CompoundTag tag = this.getNbt();
+        if (tag == null) {
+            tag = new CompoundTag();
         }
+
+        CompoundTag pnxExtra = tag.getCompound(ROOT_PNX_EXTRA);
+        if (pnxExtra == null) {
+            pnxExtra = new CompoundTag();
+        }
+
+        CompoundTag customEgg = pnxExtra.getCompound(COMP_CUSTOM_EGG);
+        if (customEgg == null) {
+            customEgg = new CompoundTag();
+        }
+
+        customEgg.putString(KEY_EGG_ID, resolvedId);
+        if (entityId != null && !entityId.isEmpty()) {
+            customEgg.putString(KEY_ENTITY_ID, entityId);
+        }
+
+        pnxExtra.putCompound(COMP_CUSTOM_EGG, customEgg);
+        tag.putCompound(ROOT_PNX_EXTRA, pnxExtra);
+
+        super.setNbt(tag);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/registry/CreativeGroupsRegistry.java
+++ b/src/main/java/cn/nukkit/registry/CreativeGroupsRegistry.java
@@ -150,6 +150,9 @@ public class CreativeGroupsRegistry {
             int originalGroupId = data.getGroupIndex();
             int newGroupId = CreativeItemRegistry.LAST_ITEMS_INDEX;
 
+            String originalId = data.getItemInstance().getDefinition().getIdentifier();
+            String rebuiltId = item.getItemDefinition().getIdentifier();
+
             // Vanilla item: remap based on old group index
             if (!isCategoryFallbackIndex(originalGroupId)) {
                 Integer mapped = groupIndexMap.get(originalGroupId);
@@ -158,7 +161,7 @@ public class CreativeGroupsRegistry {
                 }
             } else {
                 // Custom item: use mapped group names from ITEM_GROUP_MAP saved on item/block registry
-                String key = item.getIdentifier().toString();
+                String key = originalId;
                 String groupName = CreativeItemRegistry.ITEM_GROUP_MAP.get(key);
                 CreativeCategory fallbackCategory = getCategoryFromFallbackIndex(originalGroupId);
                 boolean noGroup = groupName == null || groupName.isBlank() || "NONE".equalsIgnoreCase(groupName);
@@ -188,12 +191,22 @@ public class CreativeGroupsRegistry {
                     // No group set at all, fallback to last index of original category
                     int fallbackIndex = CreativeItemRegistry.getLastGroupIndexFrom(fallbackCategory.name());
                     log.debug("Group name not saved for item '{}'; falling back to last index {}",
-                             item.getName(), fallbackIndex);
+                             originalId, fallbackIndex);
                     newGroupId = fallbackIndex;
                 }
             }
-            rebuilt.add(new CreativeItemData(item.toNetwork(), data.getCreativeNetId(), newGroupId));
+
+            CreativeItemData rebuiltData;
+
+            if (originalId.endsWith("_spawn_egg")) {
+                rebuiltData = new CreativeItemData(item.toCreativeNetwork(), data.getCreativeNetId(), newGroupId);
+            } else {
+                rebuiltData = new CreativeItemData(data.getItemInstance(), data.getCreativeNetId(), newGroupId);
+            }
+
+            rebuilt.add(rebuiltData);
         }
+
         current.clear();
         current.addAll(rebuilt);
         CreativeItemRegistry.ITEM_GROUP_MAP.clear();

--- a/src/main/java/cn/nukkit/registry/CreativeItemRegistry.java
+++ b/src/main/java/cn/nukkit/registry/CreativeItemRegistry.java
@@ -1,5 +1,6 @@
 package cn.nukkit.registry;
 
+import cn.nukkit.Server;
 import cn.nukkit.block.BlockState;
 import cn.nukkit.item.Item;
 import cn.nukkit.item.ItemID;
@@ -589,5 +590,19 @@ public class CreativeItemRegistry implements ItemID, IRegistry<Integer, Item, It
             ITEM_DATA.add(new CreativeItemData(item.toNetwork(), index, groupId));
             MAP.put(index, item);
         }
+    }
+
+    public int getGroupIndexByName(String groupName) {
+        int index = 0;
+
+        for (var group : this.getCreativeGroups()) {
+            if (groupName.equals(group.getName())) {
+                return index;
+            }
+
+            index++;
+        }
+
+        return -1;
     }
 }


### PR DESCRIPTION
Fixes custom spawn eggs not appearing in the creative inventory after the Cloudburst protocol migration.

Creative entries now use a client-safe item representation with `tag=null`, `usingNetId=false`, `netId=0`, and an empty block runtime definition, while keeping normal item/runtime behavior unchanged.