### PR TITLE
feat: InventoryPickupItemEvent being fired for entities

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -48,7 +48,6 @@ import cn.nukkit.event.entity.EntityPortalEnterEvent;
 import cn.nukkit.event.entity.EntityPortalEnterEvent.PortalType;
 import cn.nukkit.event.entity.ProjectileLaunchEvent;
 import cn.nukkit.event.inventory.InventoryPickupArrowEvent;
-import cn.nukkit.event.inventory.InventoryPickupItemEvent;
 import cn.nukkit.event.inventory.InventoryPickupTridentEvent;
 import cn.nukkit.event.player.*;
 import cn.nukkit.event.player.PlayerInteractEvent.Action;
@@ -5158,9 +5157,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
                             return false;
                         }
 
-                        InventoryPickupItemEvent ev;
-                        this.server.getPluginManager().callEvent(ev = new InventoryPickupItemEvent(inventory, entityItem));
-                        if (ev.isCancelled()) {
+                        if (!inventory.callPickupItemEvent(entityItem)) {
                             return false;
                         }
 

--- a/src/main/java/cn/nukkit/block/BlockHopper.java
+++ b/src/main/java/cn/nukkit/block/BlockHopper.java
@@ -8,7 +8,6 @@ import cn.nukkit.blockentity.BlockEntityHopper;
 import cn.nukkit.entity.Entity;
 import cn.nukkit.entity.item.EntityItem;
 import cn.nukkit.event.inventory.InventoryMoveItemEvent;
-import cn.nukkit.event.inventory.InventoryPickupItemEvent;
 import cn.nukkit.inventory.ContainerInventory;
 import cn.nukkit.inventory.Inventory;
 import cn.nukkit.inventory.InventoryHolder;
@@ -291,10 +290,7 @@ public class BlockHopper extends BlockTransparent implements RedstoneComponent, 
 
                 int originalCount = item.getCount();
 
-                InventoryPickupItemEvent ev = new InventoryPickupItemEvent(hopperInv, itemEntity);
-                Server.getInstance().getPluginManager().callEvent(ev);
-
-                if (ev.isCancelled())
+                if (!hopperInv.callPickupItemEvent(itemEntity))
                     continue;
 
                 Item[] items = hopperInv.addItem(item);

--- a/src/main/java/cn/nukkit/entity/mob/EntityPiglin.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityPiglin.java
@@ -282,25 +282,23 @@ public class EntityPiglin extends EntityMob implements EntityWalkable {
     public void pickupItems(Entity entity) {
         if (!isAngry() && entity instanceof EntityInventoryHolder holder) {
             for (Entity i : entity.level.getNearbyEntities(entity.getBoundingBox().grow(1, 0.5, 1))) {
-                boolean pickup = false;
                 if (i instanceof EntityItem entityItem) {
                     Item item = entityItem.getItem();
-                    boolean wants = ((item.isArmor() || item.isTool()) && item.getTier() == ItemTool.TIER_GOLD)
-                            || item instanceof ItemPorkchop
-                            || (likesItem(item) && getItemInOffhand().isNull());
-                    if (!wants) {
+                    boolean gear = (item.isArmor() || item.isTool()) && item.getTier() == ItemTool.TIER_GOLD;
+                    boolean food = item instanceof ItemPorkchop;
+                    boolean offhand = likesItem(item) && getItemInOffhand().isNull();
+                    if (!gear && !food && !offhand) {
                         continue;
                     }
                     if (!holder.getInventory().callPickupItemEvent(entityItem)) {
                         continue;
                     }
-                    if ((item.isArmor() || item.isTool()) && item.getTier() == ItemTool.TIER_GOLD) {
-                        if (holder.equip(item)) {
-                            pickup = true;
-                        }
-                    } else if (item instanceof ItemPorkchop) {
+                    boolean pickup;
+                    if (gear) {
+                        pickup = holder.equip(item);
+                    } else if (food) {
                         pickup = true;
-                    } else if (likesItem(item) && getItemInOffhand().isNull()) {
+                    } else {
                         setItemInOffhand(item);
                         pickup = true;
                     }

--- a/src/main/java/cn/nukkit/entity/mob/EntityPiglin.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityPiglin.java
@@ -285,6 +285,15 @@ public class EntityPiglin extends EntityMob implements EntityWalkable {
                 boolean pickup = false;
                 if (i instanceof EntityItem entityItem) {
                     Item item = entityItem.getItem();
+                    boolean wants = ((item.isArmor() || item.isTool()) && item.getTier() == ItemTool.TIER_GOLD)
+                            || item instanceof ItemPorkchop
+                            || (likesItem(item) && getItemInOffhand().isNull());
+                    if (!wants) {
+                        continue;
+                    }
+                    if (!holder.getInventory().callPickupItemEvent(entityItem)) {
+                        continue;
+                    }
                     if ((item.isArmor() || item.isTool()) && item.getTier() == ItemTool.TIER_GOLD) {
                         if (holder.equip(item)) {
                             pickup = true;

--- a/src/main/java/cn/nukkit/entity/mob/EntityZombie.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityZombie.java
@@ -203,6 +203,9 @@ public class EntityZombie extends EntityMob implements EntityWalkable, EntitySmi
                 if (i instanceof EntityItem entityItem) {
                     Item item = entityItem.getItem();
                     if (item.isArmor() || item.isTool()) {
+                        if (!holder.getInventory().callPickupItemEvent(entityItem)) {
+                            continue;
+                        }
                         if (holder.equip(item)) {
                             final TakeItemActorPacket pk = new TakeItemActorPacket();
                             pk.setActorRuntimeID(entity.getId());

--- a/src/main/java/cn/nukkit/entity/passive/EntityAllay.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityAllay.java
@@ -157,14 +157,16 @@ public class EntityAllay extends EntityMob implements EntityFlyable {
                     Item item = nearestItem.getItem();
                     Item currentItem = getInventory().getItem(0).clone();
                     if(getInventory().canAddItem(item)) {
-                        if(currentItem.isNull()) {
-                            getInventory().setItem(0, item);
-                        } else {
-                            item.setCount(item.getCount() + currentItem.getCount());
-                            getInventory().setItem(0, item);
+                        if(getInventory().callPickupItemEvent(nearestItem)) {
+                            if(currentItem.isNull()) {
+                                getInventory().setItem(0, item);
+                            } else {
+                                item.setCount(item.getCount() + currentItem.getCount());
+                                getInventory().setItem(0, item);
+                            }
+                            this.level.addSound(this, Sound.RANDOM_POP);
+                            nearestItem.close();
                         }
-                        this.level.addSound(this, Sound.RANDOM_POP);
-                        nearestItem.close();
                     }
                 }
             } else {

--- a/src/main/java/cn/nukkit/entity/passive/EntityPanda.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityPanda.java
@@ -217,6 +217,9 @@ public class EntityPanda extends EntityAnimal implements EntityWalkable, EntityC
                 if (entity instanceof EntityItem entityItem) {
                     Item item = entityItem.getItem();
                     if (item.getId().equals(Block.BAMBOO)) {
+                        if (!getInventory().callPickupItemEvent(entityItem)) {
+                            continue;
+                        }
                         getInventory().addItem(item);
                         final TakeItemActorPacket pk = new TakeItemActorPacket();
                         pk.setActorRuntimeID(this.getId());

--- a/src/main/java/cn/nukkit/entity/passive/EntityVillagerV2.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityVillagerV2.java
@@ -939,6 +939,9 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
                     }) {
                         InventorySlice slice = new InventorySlice(getInventory(), 1, getInventory().getSize());
                         if (slice.canAddItem(item)) {
+                            if (!slice.callPickupItemEvent(entityItem)) {
+                                continue;
+                            }
                             final TakeItemActorPacket pk = new TakeItemActorPacket();
                             pk.setActorRuntimeID(this.getId());
                             pk.setItemRuntimeID(i.getId());

--- a/src/main/java/cn/nukkit/inventory/Inventory.java
+++ b/src/main/java/cn/nukkit/inventory/Inventory.java
@@ -257,13 +257,11 @@ public interface Inventory {
     }
 
     /**
-     * 当执行{@link #setItem(int, Item)}时该方法会被调用，此时物品已经put进slots
-     * <p>
      * This method is called when {@link #setItem(int, Item)} is executed, and the item has been put into slots
      *
-     * @param index  物品变动的格子索引<br>The grid index of the item's changes
-     * @param before 变动前的物品<br>Items before the change
-     * @param send   是否发送{@link org.cloudburstmc.protocol.bedrock.packet.InventorySlotPacket}到客户端<br>Whether to send {@link org.cloudburstmc.protocol.bedrock.packet.InventorySlotPacket} to the client
+     * @param index  The grid index of the item's changes
+     * @param before Items before the change
+     * @param send   Whether to send {@link org.cloudburstmc.protocol.bedrock.packet.InventorySlotPacket} to the client
      */
     void onSlotChange(int index, Item before, boolean send);
 

--- a/src/main/java/cn/nukkit/inventory/Inventory.java
+++ b/src/main/java/cn/nukkit/inventory/Inventory.java
@@ -1,7 +1,10 @@
 package cn.nukkit.inventory;
 
 import cn.nukkit.Player;
+import cn.nukkit.Server;
 import cn.nukkit.api.DoNotModify;
+import cn.nukkit.entity.item.EntityItem;
+import cn.nukkit.event.inventory.InventoryPickupItemEvent;
 import cn.nukkit.item.Item;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -235,6 +238,23 @@ public interface Inventory {
     void onClose(Player who);
 
     void close(Player who);
+
+    /**
+     * Fires an {@link InventoryPickupItemEvent} for this inventory picking up the given item entity.
+     * <p>
+     * Callers should invoke this right before consuming the {@link EntityItem} (and after deciding the
+     * item is wanted) so plugins can cancel the pickup. This only handles the event; the actual logic of
+     * adding the item to the inventory stays with the caller, since that differs between inventories
+     * (e.g. equipping armor, filling the offhand, or a plain {@code addItem}).
+     *
+     * @param item the item entity being picked up
+     * @return {@code true} if the pickup may proceed, {@code false} if a plugin cancelled it
+     */
+    default boolean callPickupItemEvent(EntityItem item) {
+        InventoryPickupItemEvent ev = new InventoryPickupItemEvent(this, item);
+        Server.getInstance().getPluginManager().callEvent(ev);
+        return !ev.isCancelled();
+    }
 
     /**
      * 当执行{@link #setItem(int, Item)}时该方法会被调用，此时物品已经put进slots


### PR DESCRIPTION
Previously, this event was only called for players and hoppers. This PR makes the event being fired for `EntityAllay`, `EntityPanda`, `EntityVillagerV2`, `EntityZombie`, `EntityPiglin`.


--
Comments via claude