### PR TITLE
refactor(BlockNoteblock): use Instrument#getId() instead of ordinal

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockNoteblock.java
+++ b/src/main/java/cn/nukkit/block/BlockNoteblock.java
@@ -205,11 +205,11 @@ public class BlockNoteblock extends BlockSolid implements RedstoneComponent, Blo
 
         Instrument instrument = this.getInstrument();
 
-        this.level.addLevelSoundEvent(this, SoundEvent.NOTE, instrument.ordinal() << 8 | this.getStrength());
+        this.level.addLevelSoundEvent(this, SoundEvent.NOTE, instrument.getId() << 8 | this.getStrength());
 
         final BlockEventPacket pk = new BlockEventPacket();
         pk.setBlockPosition(Vector3i.from(this.getFloorX(), this.getFloorY(), this.getFloorZ()));
-        pk.setEventType(instrument.ordinal());
+        pk.setEventType(instrument.getId());
         pk.setEventValue(this.getStrength());
         this.getLevel().addChunkPacket(this.getFloorX() >> 4, this.getFloorZ() >> 4, pk);
     }


### PR DESCRIPTION
This reintroduces the Instrument#getId() usage to ensure that index changes in instruments can be adapted more easily in the future.
For some reason, this change got dropped while resolving the merge conflicts.