### PR TITLE
feat: PNX Annotation Processing Tool

### DIFF
--- a/src/main/java/cn/nukkit/command/Command.java
+++ b/src/main/java/cn/nukkit/command/Command.java
@@ -54,7 +54,7 @@ import java.util.stream.Collectors;
  */
 public abstract class Command {
 
-    private final String name;
+    private String name;
 
     private String nextLabel;
 
@@ -86,6 +86,16 @@ public abstract class Command {
     @Getter
     @Setter
     private boolean isUnregistered = false;
+
+    /**
+     * Creates a command with no name yet. Intended for frameworks that build a
+     * command reflectively and then assign its name via {@link #setName(String)}
+     * (for example the PNX {@code @Command} annotation processor). Subclasses
+     * written by hand should prefer {@link #Command(String)}.
+     */
+    protected Command() {
+        this("");
+    }
 
     public Command(String name) {
         this(name, "", null, EmptyArrays.EMPTY_STRINGS);
@@ -501,6 +511,30 @@ public abstract class Command {
      */
     public void setUsage(String usageMessage) {
         this.usageMessage = usageMessage;
+    }
+
+    /**
+     * Assigns the name of this command and the name-derived fields (label and
+     * command data). Intended to be called once, right after construction via
+     * the no-argument {@link #Command()} constructor, before the command is
+     * registered; for example by the PNX {@code @Command} annotation processor.
+     * Renaming an already registered command is not supported.
+     *
+     * @param name the command name
+     * @throws IllegalStateException if the command is already registered, since
+     *                               renaming it would desync the command map key
+     */
+    public void setName(String name) {
+        if (this.isRegistered()) {
+            throw new IllegalStateException("Cannot rename command '" + this.name + "' after it has been registered");
+        }
+        this.name = name.toLowerCase(Locale.ENGLISH);
+        this.nextLabel = name;
+        this.label = name;
+        this.commandData = new NukkitCommandData(name);
+        if (this.usageMessage == null || this.usageMessage.isEmpty() || this.usageMessage.equals("/")) {
+            this.usageMessage = "/" + name;
+        }
     }
 
     /**

--- a/src/main/java/cn/nukkit/plugin/JavaPluginLoader.java
+++ b/src/main/java/cn/nukkit/plugin/JavaPluginLoader.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.jar.JarEntry;
@@ -218,7 +219,7 @@ public class JavaPluginLoader implements PluginLoader {
         try {
             Class<?> clazz = Class.forName(bootstrap, true, plugin.getPluginClassLoader());
             clazz.getMethod("init", Plugin.class).invoke(null, plugin);
-        } catch (java.lang.reflect.InvocationTargetException e) {
+        } catch (InvocationTargetException e) {
             log.error("Generated bootstrap {} failed while wiring plugin {}",
                     bootstrap, plugin.getDescription().getName(), e.getCause());
         } catch (ReflectiveOperationException e) {

--- a/src/main/java/cn/nukkit/plugin/JavaPluginLoader.java
+++ b/src/main/java/cn/nukkit/plugin/JavaPluginLoader.java
@@ -174,6 +174,7 @@ public class JavaPluginLoader implements PluginLoader {
         if (plugin instanceof PluginBase && !plugin.isEnabled()) {
             log.info(this.server.getLanguage().tr("nukkit.plugin.enable", plugin.getDescription().getFullName()));
             ((PluginBase) plugin).setEnabled(true);
+            runBootstrap((PluginBase) plugin);
             this.server.getPluginManager().callEvent(new PluginEnableEvent(plugin));
         }
     }
@@ -193,6 +194,36 @@ public class JavaPluginLoader implements PluginLoader {
             this.server.getServiceManager().cancel(plugin);
             this.server.getPluginManager().callEvent(new PluginDisableEvent(plugin));
             ((PluginBase) plugin).setEnabled(false);
+        }
+    }
+
+    /**
+     * Invokes the generated {@code init(Plugin)} of the plugin's bootstrap class,
+     * if the descriptor declares one.
+     * <p>
+     * The bootstrap class is produced by the PNX annotation processor (see
+     * {@code cn.nukkit.plugin.annotation}) and contains the listener
+     * registrations, task schedules and command registrations derived from the
+     * plugin's annotations. It runs right after the plugin is enabled, because
+     * {@code registerEvents} and the scheduler reject registrations from a plugin
+     * that is not yet enabled.
+     *
+     * @param plugin the plugin being enabled
+     */
+    private void runBootstrap(PluginBase plugin) {
+        String bootstrap = plugin.getDescription().getBootstrap();
+        if (bootstrap == null || bootstrap.isBlank()) {
+            return;
+        }
+        try {
+            Class<?> clazz = Class.forName(bootstrap, true, plugin.getPluginClassLoader());
+            clazz.getMethod("init", Plugin.class).invoke(null, plugin);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            log.error("Generated bootstrap {} failed while wiring plugin {}",
+                    bootstrap, plugin.getDescription().getName(), e.getCause());
+        } catch (ReflectiveOperationException e) {
+            log.error("Failed to invoke generated bootstrap {} for plugin {}",
+                    bootstrap, plugin.getDescription().getName(), e);
         }
     }
 

--- a/src/main/java/cn/nukkit/plugin/PluginDescription.java
+++ b/src/main/java/cn/nukkit/plugin/PluginDescription.java
@@ -56,6 +56,7 @@ public class PluginDescription {
     private final List<String> authors = new ArrayList<>();
     private String website;
     private String prefix;
+    private String bootstrap;
     private PluginLoadOrder order = PluginLoadOrder.POSTWORLD;
 
     private List<Permission> permissions = new ArrayList<>();
@@ -133,6 +134,10 @@ public class PluginDescription {
 
         if (plugin.containsKey("prefix")) {
             this.prefix = (String) plugin.get("prefix");
+        }
+
+        if (plugin.containsKey("bootstrap")) {
+            this.bootstrap = (String) plugin.get("bootstrap");
         }
 
         if (plugin.containsKey("load")) {
@@ -276,6 +281,20 @@ public class PluginDescription {
      */
     public List<String> getSoftDepend() {
         return softDepend;
+    }
+
+    /**
+     * Gets the fully qualified name of the generated bootstrap class, if any.
+     * <p>
+     * Emitted by the PNX annotation processor (see
+     * {@code cn.nukkit.plugin.annotation}). When present, the plugin loader
+     * invokes its {@code init(Plugin)} method on enable to wire up annotated
+     * listeners and scheduled tasks, so the plugin author does not call it.
+     *
+     * @return the bootstrap class name, or null if the plugin does not use one
+     */
+    public String getBootstrap() {
+        return bootstrap;
     }
 
     /**

--- a/src/main/java/cn/nukkit/plugin/annotation/Command.java
+++ b/src/main/java/cn/nukkit/plugin/annotation/Command.java
@@ -1,0 +1,77 @@
+package cn.nukkit.plugin.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a {@link cn.nukkit.command.Command} subclass for automatic registration.
+ * <p>
+ * The name and the rest of the command metadata live on the annotation, so the
+ * annotated class needs <b>no constructor</b> — the PNX annotation processor
+ * instantiates it via the no-argument {@link cn.nukkit.command.Command#Command()}
+ * constructor, applies the metadata below (name through
+ * {@link cn.nukkit.command.Command#setName(String)}, the rest through the
+ * matching setters) and registers it with the server command map when the plugin
+ * is enabled.
+ * <p>
+ * Example:
+ * <pre>
+ * &#64;Command(name = "heal", aliases = {"h"}, permission = "myplugin.heal",
+ *          description = "Heals a player")
+ * public class HealCommand extends Command {
+ *     &#64;Override
+ *     public boolean execute(CommandSender sender, String label, String[] args) {
+ *         // ...
+ *         return true;
+ *     }
+ * }
+ * </pre>
+ * Constraints (enforced by the processor, each violation is a compile error):
+ * <ul>
+ *     <li>The annotated type must extend {@link cn.nukkit.command.Command}.</li>
+ *     <li>The annotated type must be a concrete (non-abstract) class with an
+ *     accessible no-argument constructor (the implicit default is fine).</li>
+ * </ul>
+ *
+ * @see PluginMeta
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface Command {
+
+    /**
+     * The command name (the label players type). Required.
+     */
+    String name();
+
+    /**
+     * Alternative names for the command. Optional.
+     */
+    String[] aliases() default {};
+
+    /**
+     * The permission required to use the command. Optional.
+     */
+    String permission() default "";
+
+    /**
+     * A human readable description. Optional.
+     */
+    String description() default "";
+
+    /**
+     * The usage message. Optional; defaults to {@code "/" + name} when omitted.
+     */
+    String usage() default "";
+
+    /**
+     * Whether to enable the command parameter tree
+     * ({@link cn.nukkit.command.Command#enableParamTree()}) for advanced argument
+     * parsing and overloads. Enabled by default.
+     */
+    boolean enableParamTree() default true;
+}

--- a/src/main/java/cn/nukkit/plugin/annotation/EventListener.java
+++ b/src/main/java/cn/nukkit/plugin/annotation/EventListener.java
@@ -1,0 +1,30 @@
+package cn.nukkit.plugin.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks an event listener class for automatic registration.
+ * <p>
+ * At compile time the PNX annotation processor collects every type carrying this
+ * annotation and generates code that registers an instance of each with the
+ * server's plugin manager when the owning plugin is enabled. The author no
+ * longer writes {@code getServer().getPluginManager().registerEvents(...)}.
+ * <p>
+ * Constraints (enforced by the processor, each violation is a compile error):
+ * <ul>
+ *     <li>The annotated type must implement {@link cn.nukkit.event.Listener}.</li>
+ *     <li>The annotated type must be a concrete (non-abstract) class with an
+ *     accessible no-argument constructor.</li>
+ * </ul>
+ *
+ * @see PluginMeta
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface EventListener {
+}

--- a/src/main/java/cn/nukkit/plugin/annotation/PluginAnnotationProcessor.java
+++ b/src/main/java/cn/nukkit/plugin/annotation/PluginAnnotationProcessor.java
@@ -1,0 +1,413 @@
+package cn.nukkit.plugin.annotation;
+
+import cn.nukkit.plugin.PluginLoadOrder;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+import javax.tools.Diagnostic;
+import javax.tools.FileObject;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardLocation;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Compile-time processor for the PNX plugin annotations.
+ * <ol>
+ *     <li>{@link PluginMeta} on the main class produces a {@code plugin.yml}
+ *     descriptor in the plugin jar.</li>
+ *     <li>{@link EventListener} types are registered with the plugin manager.</li>
+ *     <li>{@link ScheduleTask} classes and methods are scheduled with the server
+ *     scheduler.</li>
+ * </ol>
+ * The listener registrations and task schedules are emitted into a single
+ * generated {@code PNXPluginBootstrap} class whose {@code init(Plugin)} method
+ * the server invokes automatically when the plugin is enabled (its name is
+ * recorded under the {@code bootstrap} key of the generated descriptor), so the
+ * author never has to call it.
+ */
+@SupportedAnnotationTypes({
+        "cn.nukkit.plugin.annotation.PluginMeta",
+        "cn.nukkit.plugin.annotation.EventListener",
+        "cn.nukkit.plugin.annotation.ScheduleTask",
+        "cn.nukkit.plugin.annotation.Command"
+})
+public class PluginAnnotationProcessor extends AbstractProcessor {
+    private static final String BOOTSTRAP_CLASS = "PNXPluginBootstrap";
+
+    private Elements elements;
+    private Types types;
+    private Messager messager;
+    private Filer filer;
+
+    /** Generated once; guards against re-emission in later processing rounds. */
+    private boolean generated = false;
+
+    @Override
+    public synchronized void init(ProcessingEnvironment env) {
+        super.init(env);
+        this.elements = env.getElementUtils();
+        this.types = env.getTypeUtils();
+        this.messager = env.getMessager();
+        this.filer = env.getFiler();
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (roundEnv.processingOver()) {
+            return false;
+        }
+
+        List<String> listeners = new ArrayList<>();
+        List<ClassTask> classTasks = new ArrayList<>();
+        List<MethodTask> methodTasks = new ArrayList<>();
+        List<CommandEntry> commands = new ArrayList<>();
+
+        for (Element e : roundEnv.getElementsAnnotatedWith(EventListener.class)) {
+            collectListener(e, listeners);
+        }
+        for (Element e : roundEnv.getElementsAnnotatedWith(ScheduleTask.class)) {
+            collectTask(e, classTasks, methodTasks);
+        }
+        for (Element e : roundEnv.getElementsAnnotatedWith(Command.class)) {
+            collectCommand(e, commands);
+        }
+
+        Set<? extends Element> metas = roundEnv.getElementsAnnotatedWith(PluginMeta.class);
+        if (metas.isEmpty() || generated) {
+            return false;
+        }
+        if (metas.size() > 1) {
+            for (Element m : metas) {
+                error(m, "Only one type may be annotated with @PluginMeta per project; found "
+                        + metas.size() + ".");
+            }
+            return false;
+        }
+
+        TypeElement main = (TypeElement) metas.iterator().next();
+        if (!validateMain(main)) {
+            return false;
+        }
+
+        generated = true;
+        generate(main, listeners, classTasks, methodTasks, commands);
+        return false;
+    }
+
+    private void collectListener(Element e, List<String> out) {
+        if (e.getKind() != ElementKind.CLASS) {
+            error(e, "@EventListener may only be placed on a class.");
+            return;
+        }
+        TypeElement type = (TypeElement) e;
+        if (!isConcreteInstantiable(type, "@EventListener")) {
+            return;
+        }
+        if (!isAssignableTo(type, "cn.nukkit.event.Listener")) {
+            error(e, "@EventListener class must implement cn.nukkit.event.Listener.");
+            return;
+        }
+        out.add(type.getQualifiedName().toString());
+    }
+
+    private void collectTask(Element e, List<ClassTask> classOut, List<MethodTask> methodOut) {
+        ScheduleTask cfg = e.getAnnotation(ScheduleTask.class);
+        if (e.getKind() == ElementKind.CLASS) {
+            TypeElement type = (TypeElement) e;
+            if (!isConcreteInstantiable(type, "@ScheduleTask")) {
+                return;
+            }
+            if (!isAssignableTo(type, "java.lang.Runnable")) {
+                error(e, "@ScheduleTask class must implement Runnable (e.g. extend cn.nukkit.scheduler.Task).");
+                return;
+            }
+            classOut.add(new ClassTask(type.getQualifiedName().toString(), cfg));
+        } else if (e.getKind() == ElementKind.METHOD) {
+            ExecutableElement method = (ExecutableElement) e;
+            Set<Modifier> mods = method.getModifiers();
+            if (!mods.contains(Modifier.PUBLIC) || !mods.contains(Modifier.STATIC)) {
+                error(e, "@ScheduleTask method must be public and static.");
+                return;
+            }
+            if (!method.getParameters().isEmpty()) {
+                error(e, "@ScheduleTask method must take no parameters.");
+                return;
+            }
+            String owner = ((TypeElement) method.getEnclosingElement()).getQualifiedName().toString();
+            methodOut.add(new MethodTask(owner, method.getSimpleName().toString(), cfg));
+        } else {
+            error(e, "@ScheduleTask may only be placed on a class or a public static method.");
+        }
+    }
+
+    private void collectCommand(Element e, List<CommandEntry> out) {
+        if (e.getKind() != ElementKind.CLASS) {
+            error(e, "@Command may only be placed on a class.");
+            return;
+        }
+        TypeElement type = (TypeElement) e;
+        if (!isConcreteInstantiable(type, "@Command")) {
+            return;
+        }
+        if (!isAssignableTo(type, "cn.nukkit.command.Command")) {
+            error(e, "@Command class must extend cn.nukkit.command.Command.");
+            return;
+        }
+        out.add(new CommandEntry(type.getQualifiedName().toString(), e.getAnnotation(Command.class)));
+    }
+
+    private boolean validateMain(TypeElement main) {
+        if (main.getKind() != ElementKind.CLASS) {
+            error(main, "@PluginMeta may only be placed on a class.");
+            return false;
+        }
+        if (!isAssignableTo(main, "cn.nukkit.plugin.PluginBase")) {
+            error(main, "@PluginMeta class must extend cn.nukkit.plugin.PluginBase.");
+            return false;
+        }
+        return true;
+    }
+
+    /** Concrete class with an accessible no-argument constructor. */
+    private boolean isConcreteInstantiable(TypeElement type, String label) {
+        if (type.getModifiers().contains(Modifier.ABSTRACT)) {
+            error(type, label + " class must not be abstract.");
+            return false;
+        }
+        if (type.getNestingKind().isNested() && !type.getModifiers().contains(Modifier.STATIC)) {
+            error(type, label + " nested class must be static so it can be instantiated.");
+            return false;
+        }
+        boolean sawCtor = false;
+        for (Element enclosed : type.getEnclosedElements()) {
+            if (enclosed.getKind() != ElementKind.CONSTRUCTOR) {
+                continue;
+            }
+            ExecutableElement ctor = (ExecutableElement) enclosed;
+            if (ctor.getParameters().isEmpty()) {
+                if (ctor.getModifiers().contains(Modifier.PRIVATE)) {
+                    error(type, label + " class must have a non-private no-argument constructor.");
+                    return false;
+                }
+                return true;
+            }
+            sawCtor = true;
+        }
+        if (sawCtor) {
+            error(type, label + " class must have a no-argument constructor.");
+            return false;
+        }
+        return true; // Only the implicit default constructor exists
+    }
+
+    private boolean isAssignableTo(TypeElement type, String superFqn) {
+        TypeElement superType = elements.getTypeElement(superFqn);
+        if (superType == null) {
+            return false;
+        }
+        TypeMirror erasedSuper = types.erasure(superType.asType());
+        return types.isAssignable(types.erasure(type.asType()), erasedSuper);
+    }
+
+    private void generate(TypeElement main, List<String> listeners,
+                          List<ClassTask> classTasks, List<MethodTask> methodTasks,
+                          List<CommandEntry> commands) {
+        String pkg = elements.getPackageOf(main).getQualifiedName().toString();
+        String bootstrapFqn = pkg.isEmpty() ? BOOTSTRAP_CLASS : pkg + "." + BOOTSTRAP_CLASS;
+        String mainBinary = elements.getBinaryName(main).toString();
+
+        writeBootstrap(main, pkg, bootstrapFqn, listeners, classTasks, methodTasks, commands);
+        writeDescriptor(main, mainBinary, bootstrapFqn);
+    }
+
+    private void writeBootstrap(TypeElement main, String pkg, String bootstrapFqn,
+                                List<String> listeners, List<ClassTask> classTasks,
+                                List<MethodTask> methodTasks, List<CommandEntry> commands) {
+        StringBuilder sb = new StringBuilder();
+        if (!pkg.isEmpty()) {
+            sb.append("package ").append(pkg).append(";\n\n");
+        }
+        sb.append("// AUTO-GENERATED by PNX-APT. Do not edit.\n");
+        sb.append("public final class ").append(BOOTSTRAP_CLASS).append(" {\n");
+        sb.append("    private ").append(BOOTSTRAP_CLASS).append("() {}\n\n");
+        sb.append("    public static void init(cn.nukkit.plugin.Plugin plugin) {\n");
+        if (!listeners.isEmpty()) {
+            sb.append("        cn.nukkit.plugin.PluginManager __pm = plugin.getServer().getPluginManager();\n");
+        }
+        if (!classTasks.isEmpty() || !methodTasks.isEmpty()) {
+            sb.append("        cn.nukkit.scheduler.ServerScheduler __sch = plugin.getServer().getScheduler();\n");
+        }
+        for (String listener : listeners) {
+            sb.append("        __pm.registerEvents(new ").append(listener).append("(), plugin);\n");
+        }
+        for (ClassTask task : classTasks) {
+            sb.append("        ").append(scheduleCall("new " + task.fqn + "()", task.cfg)).append('\n');
+        }
+        for (MethodTask task : methodTasks) {
+            sb.append("        ").append(scheduleCall("() -> " + task.owner + "." + task.method + "()", task.cfg))
+                    .append('\n');
+        }
+        if (!commands.isEmpty()) {
+            sb.append("        cn.nukkit.command.CommandMap __cmap = plugin.getServer().getCommandMap();\n");
+            sb.append("        String __prefix = plugin.getDescription().getName();\n");
+            for (CommandEntry cmd : commands) {
+                Command cfg = cmd.cfg;
+                sb.append("        {\n");
+                sb.append("            ").append(cmd.fqn).append(" __cmd = new ").append(cmd.fqn).append("();\n");
+                sb.append("            __cmd.setName(").append(javaString(cfg.name())).append(");\n");
+                if (cfg.aliases().length > 0) {
+                    sb.append("            __cmd.setAliases(").append(javaStringArray(cfg.aliases())).append(");\n");
+                }
+                if (!cfg.permission().isEmpty()) {
+                    sb.append("            __cmd.setPermission(").append(javaString(cfg.permission())).append(");\n");
+                }
+                if (!cfg.description().isEmpty()) {
+                    sb.append("            __cmd.setDescription(").append(javaString(cfg.description())).append(");\n");
+                }
+                if (!cfg.usage().isEmpty()) {
+                    sb.append("            __cmd.setUsage(").append(javaString(cfg.usage())).append(");\n");
+                }
+                if (cfg.enableParamTree()) {
+                    sb.append("            __cmd.enableParamTree();\n");
+                }
+                sb.append("            __cmap.register(__prefix, __cmd);\n");
+                sb.append("        }\n");
+            }
+        }
+        sb.append("    }\n");
+        sb.append("}\n");
+
+        try {
+            JavaFileObject src = filer.createSourceFile(bootstrapFqn, main);
+            try (Writer w = src.openWriter()) {
+                w.write(sb.toString());
+            }
+        } catch (IOException ex) {
+            error(main, "Failed to generate " + bootstrapFqn + ": " + ex.getMessage());
+        }
+    }
+
+    private static String scheduleCall(String runnableExpr, ScheduleTask cfg) {
+        if (cfg.period() > 0) {
+            return "__sch.scheduleDelayedRepeatingTask(plugin, " + runnableExpr + ", "
+                    + cfg.delay() + ", " + cfg.period() + ", " + cfg.async() + ");";
+        }
+        return "__sch.scheduleDelayedTask(plugin, " + runnableExpr + ", "
+                + cfg.delay() + ", " + cfg.async() + ");";
+    }
+
+    private void writeDescriptor(TypeElement main, String mainBinary, String bootstrapFqn) {
+        PluginMeta meta = main.getAnnotation(PluginMeta.class);
+        StringBuilder y = new StringBuilder();
+        scalar(y, "name", meta.name());
+        scalar(y, "main", mainBinary);
+        scalar(y, "version", meta.version());
+        list(y, "api", meta.api());
+        scalar(y, "bootstrap", bootstrapFqn);
+        if (meta.authors().length > 0) {
+            list(y, "authors", meta.authors());
+        }
+        if (!meta.description().isEmpty()) {
+            scalar(y, "description", meta.description());
+        }
+        if (!meta.website().isEmpty()) {
+            scalar(y, "website", meta.website());
+        }
+        if (!meta.prefix().isEmpty()) {
+            scalar(y, "prefix", meta.prefix());
+        }
+        // POSTWORLD is the default load order and is omitted from the descriptor.
+        if (meta.order() != PluginLoadOrder.POSTWORLD) {
+            y.append("load: ").append(meta.order().name()).append('\n');
+        }
+        if (meta.depend().length > 0) {
+            list(y, "depend", meta.depend());
+        }
+        if (meta.softDepend().length > 0) {
+            list(y, "softdepend", meta.softDepend());
+        }
+        if (meta.loadBefore().length > 0) {
+            list(y, "loadbefore", meta.loadBefore());
+        }
+        if (meta.features().length > 0) {
+            list(y, "features", meta.features());
+        }
+
+        try {
+            FileObject yml = filer.createResource(StandardLocation.CLASS_OUTPUT, "", "plugin.yml", main);
+            try (Writer w = yml.openWriter()) {
+                w.write(y.toString());
+            }
+        } catch (IOException ex) {
+            error(main, "Failed to generate plugin.yml: " + ex.getMessage());
+        }
+    }
+
+    private static void scalar(StringBuilder y, String key, String value) {
+        y.append(key).append(": ").append(quote(value)).append('\n');
+    }
+
+    private static void list(StringBuilder y, String key, String[] values) {
+        y.append(key).append(":\n");
+        for (String v : values) {
+            y.append("  - ").append(quote(v)).append('\n');
+        }
+    }
+
+    /** YAML double-quoted scalar; escapes backslash and double-quote. */
+    private static String quote(String s) {
+        return '"' + s.replace("\\", "\\\\").replace("\"", "\\\"") + '"';
+    }
+
+    /** Java source string literal; escapes backslash, double-quote and newlines. */
+    private static String javaString(String s) {
+        return '"' + s.replace("\\", "\\\\").replace("\"", "\\\"")
+                .replace("\n", "\\n").replace("\r", "\\r") + '"';
+    }
+
+    private static String javaStringArray(String[] values) {
+        StringBuilder sb = new StringBuilder("new String[]{");
+        for (int i = 0; i < values.length; i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(javaString(values[i]));
+        }
+        return sb.append('}').toString();
+    }
+
+    private void error(Element e, String message) {
+        messager.printMessage(Diagnostic.Kind.ERROR, message, e);
+    }
+
+    private record ClassTask(String fqn, ScheduleTask cfg) {
+    }
+
+    private record MethodTask(String owner, String method, ScheduleTask cfg) {
+    }
+
+    private record CommandEntry(String fqn, Command cfg) {
+    }
+}

--- a/src/main/java/cn/nukkit/plugin/annotation/PluginAnnotationProcessor.java
+++ b/src/main/java/cn/nukkit/plugin/annotation/PluginAnnotationProcessor.java
@@ -30,7 +30,7 @@ import java.util.Set;
 /**
  * Compile-time processor for the PNX plugin annotations.
  * <ol>
- *     <li>{@link PluginMeta} on the main class produces a {@code plugin.yml}
+ *     <li>{@link PluginMeta} on the main class produces a {@code powernukkitx.yml}
  *     descriptor in the plugin jar.</li>
  *     <li>{@link EventListener} types are registered with the plugin manager.</li>
  *     <li>{@link ScheduleTask} classes and methods are scheduled with the server
@@ -356,12 +356,12 @@ public class PluginAnnotationProcessor extends AbstractProcessor {
         }
 
         try {
-            FileObject yml = filer.createResource(StandardLocation.CLASS_OUTPUT, "", "plugin.yml", main);
+            FileObject yml = filer.createResource(StandardLocation.CLASS_OUTPUT, "", "powernukkitx.yml", main);
             try (Writer w = yml.openWriter()) {
                 w.write(y.toString());
             }
         } catch (IOException ex) {
-            error(main, "Failed to generate plugin.yml: " + ex.getMessage());
+            error(main, "Failed to generate powernukkitx.yml: " + ex.getMessage());
         }
     }
 

--- a/src/main/java/cn/nukkit/plugin/annotation/PluginMeta.java
+++ b/src/main/java/cn/nukkit/plugin/annotation/PluginMeta.java
@@ -1,0 +1,94 @@
+package cn.nukkit.plugin.annotation;
+
+import cn.nukkit.plugin.PluginLoadOrder;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares the metadata of a PowerNukkitX plugin.
+ * <p>
+ * Place this on the single main plugin class (the one that extends
+ * {@link cn.nukkit.plugin.PluginBase}). At compile time the PNX annotation
+ * processor reads it and emits a {@code plugin.yml} into the plugin jar, so the
+ * author never hand-writes one. The {@code main} entry of the generated
+ * descriptor is the fully qualified name of the annotated class.
+ * <p>
+ * Constraints (enforced by the processor, each violation is a compile error):
+ * <ul>
+ *     <li>The annotated type must extend {@link cn.nukkit.plugin.PluginBase}.</li>
+ *     <li>At most one type per project may carry this annotation.</li>
+ * </ul>
+ *
+ * @see EventListener
+ * @see ScheduleTask
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.SOURCE)
+public @interface PluginMeta {
+
+    /**
+     * The plugin name. Required.
+     */
+    String name();
+
+    /**
+     * The plugin version. Required.
+     */
+    String version();
+
+    /**
+     * The compatible PowerNukkitX API versions. Required, at least one.
+     */
+    String[] api();
+
+    /**
+     * The plugin authors. Optional.
+     */
+    String[] authors() default {};
+
+    /**
+     * A human-readable description of the plugin. Optional.
+     */
+    String description() default "";
+
+    /**
+     * The plugin website. Optional.
+     */
+    String website() default "";
+
+    /**
+     * The log prefix used by this plugin. Optional.
+     */
+    String prefix() default "";
+
+    /**
+     * Hard dependencies: plugins that must be present and loaded first. Optional.
+     */
+    String[] depend() default {};
+
+    /**
+     * Soft dependencies: plugins loaded first when present, but not required. Optional.
+     */
+    String[] softDepend() default {};
+
+    /**
+     * Plugins that must be loaded after this one. Optional.
+     */
+    String[] loadBefore() default {};
+
+    /**
+     * The load order. Defaults to {@link PluginLoadOrder#POSTWORLD}; the default
+     * is omitted from the generated descriptor.
+     */
+    PluginLoadOrder order() default PluginLoadOrder.POSTWORLD;
+
+    /**
+     * Declared feature flags. Optional.
+     */
+    String[] features() default {};
+}

--- a/src/main/java/cn/nukkit/plugin/annotation/ScheduleTask.java
+++ b/src/main/java/cn/nukkit/plugin/annotation/ScheduleTask.java
@@ -1,0 +1,53 @@
+package cn.nukkit.plugin.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Schedules a task automatically when the owning plugin is enabled.
+ * <p>
+ * May be placed on either:
+ * <ul>
+ *     <li>a <b>class</b> implementing {@link Runnable} (for example a subclass of
+ *     {@link cn.nukkit.scheduler.Task}) with an accessible no-argument
+ *     constructor — the processor schedules a fresh instance; or</li>
+ *     <li>a <b>public static method</b> taking no arguments — the processor
+ *     schedules a call to it.</li>
+ * </ul>
+ * The generated code schedules each as a delayed (optionally repeating) task via
+ * the server scheduler. When {@link #period()} is {@code 0} the task runs once
+ * after {@link #delay()} ticks; otherwise it repeats every {@code period} ticks.
+ * <p>
+ * Constraints (enforced by the processor, each violation is a compile error):
+ * <ul>
+ *     <li>On a class: must be a concrete {@link Runnable} with an accessible
+ *     no-argument constructor.</li>
+ *     <li>On a method: must be {@code public}, {@code static} and take no
+ *     parameters.</li>
+ * </ul>
+ *
+ * @see PluginMeta
+ */
+@Documented
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.SOURCE)
+public @interface ScheduleTask {
+
+    /**
+     * Delay in ticks before the first run. 20 ticks = 1 second.
+     */
+    int delay() default 0;
+
+    /**
+     * Repeat period in ticks. {@code 0} means run once (no repeat).
+     */
+    int period() default 0;
+
+    /**
+     * Whether the task runs on an asynchronous worker thread.
+     */
+    boolean async() default false;
+}

--- a/src/main/java/cn/nukkit/plugin/annotation/package-info.java
+++ b/src/main/java/cn/nukkit/plugin/annotation/package-info.java
@@ -1,0 +1,30 @@
+/**
+ * Compile-time annotations that remove plugin boilerplate.
+ * <p>
+ * A plugin author annotates their classes and the PNX annotation processor
+ * (shipped inside the server jar) does the rest at build time:
+ * <ul>
+ *     <li>{@link cn.nukkit.plugin.annotation.PluginMeta} on the main class emits
+ *     {@code plugin.yml} — no handwritten descriptor.</li>
+ *     <li>{@link cn.nukkit.plugin.annotation.EventListener} registers listeners
+ *     automatically.</li>
+ *     <li>{@link cn.nukkit.plugin.annotation.ScheduleTask} schedules tasks
+ *     automatically.</li>
+ *     <li>{@link cn.nukkit.plugin.annotation.Command} registers commands
+ *     automatically, with the name and metadata supplied on the annotation so the
+ *     command class needs no constructor.</li>
+ * </ul>
+ * The generated registrations live in a {@code PNXPluginBootstrap} class that the
+ * server invokes on enable, so there is nothing to call from {@code onEnable}.
+ * <p>
+ * The only build configuration a plugin needs is to put the server jar on the
+ * annotation processor path so the processor is discovered, e.g. with Gradle:
+ * <pre>
+ * dependencies {
+ *     compileOnly("org.powernukkitx:server:&lt;version&gt;")
+ *     annotationProcessor("org.powernukkitx:server:&lt;version&gt;")
+ * }
+ * </pre>
+ * After that, annotate and build — there is no other glue code.
+ */
+package cn.nukkit.plugin.annotation;

--- a/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+cn.nukkit.plugin.annotation.PluginAnnotationProcessor

--- a/src/test/java/cn/nukkit/plugin/annotation/PluginAnnotationProcessorTest.java
+++ b/src/test/java/cn/nukkit/plugin/annotation/PluginAnnotationProcessorTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.when;
 /**
  * Compiles real source through {@link PluginAnnotationProcessor} in-process (JDK
  * {@link JavaCompiler} + an in-memory file manager) and asserts on diagnostics
- * and on the generated {@code plugin.yml} / {@code PNXPluginBootstrap} sources.
+ * and on the generated {@code powernukkitx.yml} / {@code PNXPluginBootstrap} sources.
  * <p>
  * The compilation runs on the test classpath, so the real {@code cn.nukkit}
  * types ({@code PluginBase}, {@code Listener}, {@code Task}, {@code Command},
@@ -67,11 +67,11 @@ public class PluginAnnotationProcessorTest {
             """);
 
     // ------------------------------------------------------------------
-    // @PluginMeta -> plugin.yml
+    // @PluginMeta -> powernukkitx.yml
     // ------------------------------------------------------------------
 
     @Nested
-    @DisplayName("@PluginMeta / plugin.yml")
+    @DisplayName("@PluginMeta / powernukkitx.yml")
     class Meta {
 
         @Test
@@ -79,7 +79,7 @@ public class PluginAnnotationProcessorTest {
             Result r = compile(MAIN);
             r.assertSuccess();
             String yml = r.pluginYml();
-            assertNotNull(yml, "plugin.yml should be generated");
+            assertNotNull(yml, "powernukkitx.yml should be generated");
             assertContains(yml, "name: \"Demo\"");
             assertContains(yml, "main: \"demo.DemoPlugin\"");
             assertContains(yml, "version: \"1.0.0\"");
@@ -712,7 +712,7 @@ public class PluginAnnotationProcessorTest {
         }
 
         String pluginYml() {
-            MemoryFileObject o = fm.resources.get("plugin.yml");
+            MemoryFileObject o = fm.resources.get("powernukkitx.yml");
             return o == null ? null : o.content();
         }
 

--- a/src/test/java/cn/nukkit/plugin/annotation/PluginAnnotationProcessorTest.java
+++ b/src/test/java/cn/nukkit/plugin/annotation/PluginAnnotationProcessorTest.java
@@ -1,0 +1,845 @@
+package cn.nukkit.plugin.annotation;
+
+import cn.nukkit.Server;
+import cn.nukkit.command.SimpleCommandMap;
+import cn.nukkit.event.Listener;
+import cn.nukkit.plugin.Plugin;
+import cn.nukkit.plugin.PluginDescription;
+import cn.nukkit.plugin.PluginManager;
+import cn.nukkit.scheduler.ServerScheduler;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.ForwardingJavaFileManager;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Compiles real source through {@link PluginAnnotationProcessor} in-process (JDK
+ * {@link JavaCompiler} + an in-memory file manager) and asserts on diagnostics
+ * and on the generated {@code plugin.yml} / {@code PNXPluginBootstrap} sources.
+ * <p>
+ * The compilation runs on the test classpath, so the real {@code cn.nukkit}
+ * types ({@code PluginBase}, {@code Listener}, {@code Task}, {@code Command},
+ * ...) are resolved exactly as a plugin build would resolve them.
+ */
+public class PluginAnnotationProcessorTest {
+
+    // A valid, minimal main plugin class used by tests that only care about the
+    // other annotations.
+    private static final JavaSource MAIN = new JavaSource("demo.DemoPlugin", """
+            package demo;
+            import cn.nukkit.plugin.PluginBase;
+            import cn.nukkit.plugin.annotation.PluginMeta;
+            @PluginMeta(name = "Demo", version = "1.0.0", api = {"1.0.0"})
+            public class DemoPlugin extends PluginBase {}
+            """);
+
+    // ------------------------------------------------------------------
+    // @PluginMeta -> plugin.yml
+    // ------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("@PluginMeta / plugin.yml")
+    class Meta {
+
+        @Test
+        void minimalDescriptorHasRequiredKeysAndBootstrap() {
+            Result r = compile(MAIN);
+            r.assertSuccess();
+            String yml = r.pluginYml();
+            assertNotNull(yml, "plugin.yml should be generated");
+            assertContains(yml, "name: \"Demo\"");
+            assertContains(yml, "main: \"demo.DemoPlugin\"");
+            assertContains(yml, "version: \"1.0.0\"");
+            assertContains(yml, "api:\n  - \"1.0.0\"");
+            assertContains(yml, "bootstrap: \"demo.PNXPluginBootstrap\"");
+        }
+
+        @Test
+        void defaultLoadOrderIsOmitted() {
+            Result r = compile(MAIN);
+            r.assertSuccess();
+            assertFalse(r.pluginYml().contains("load:"), "POSTWORLD default must be omitted");
+        }
+
+        @Test
+        void optionalFieldsAreEmittedAndStartupOrderIsWritten() {
+            Result r = compile(new JavaSource("demo.DemoPlugin", """
+                    package demo;
+                    import cn.nukkit.plugin.PluginBase;
+                    import cn.nukkit.plugin.PluginLoadOrder;
+                    import cn.nukkit.plugin.annotation.PluginMeta;
+                    @PluginMeta(
+                        name = "Demo",
+                        version = "2.0",
+                        api = {"1.0.0", "1.1.0"},
+                        authors = {"Alice", "Bob"},
+                        description = "A demo",
+                        website = "https://example.com",
+                        prefix = "DEMO",
+                        order = PluginLoadOrder.STARTUP,
+                        depend = {"Core"},
+                        softDepend = {"Econ"},
+                        loadBefore = {"Other"},
+                        features = {"flagA", "flagB"}
+                    )
+                    public class DemoPlugin extends PluginBase {}
+                    """));
+            r.assertSuccess();
+            String yml = r.pluginYml();
+            assertContains(yml, "version: \"2.0\"");
+            assertContains(yml, "api:\n  - \"1.0.0\"\n  - \"1.1.0\"");
+            assertContains(yml, "authors:\n  - \"Alice\"\n  - \"Bob\"");
+            assertContains(yml, "description: \"A demo\"");
+            assertContains(yml, "website: \"https://example.com\"");
+            assertContains(yml, "prefix: \"DEMO\"");
+            assertContains(yml, "load: STARTUP");
+            assertContains(yml, "depend:\n  - \"Core\"");
+            assertContains(yml, "softdepend:\n  - \"Econ\"");
+            assertContains(yml, "loadbefore:\n  - \"Other\"");
+            assertContains(yml, "features:\n  - \"flagA\"\n  - \"flagB\"");
+        }
+
+        @Test
+        void emptyOptionalFieldsAreOmitted() {
+            Result r = compile(MAIN);
+            r.assertSuccess();
+            String yml = r.pluginYml();
+            assertFalse(yml.contains("authors:"), "empty authors omitted");
+            assertFalse(yml.contains("description:"), "empty description omitted");
+            assertFalse(yml.contains("website:"), "empty website omitted");
+            assertFalse(yml.contains("prefix:"), "empty prefix omitted");
+            assertFalse(yml.contains("depend:"), "empty depend omitted");
+            assertFalse(yml.contains("features:"), "empty features omitted");
+        }
+
+        @Test
+        void backslashInValueIsEscaped() {
+            // Annotation value is a\b (single backslash); yml must escape to a\\b.
+            Result r = compile(new JavaSource("demo.DemoPlugin", """
+                    package demo;
+                    import cn.nukkit.plugin.PluginBase;
+                    import cn.nukkit.plugin.annotation.PluginMeta;
+                    @PluginMeta(name = "Demo", version = "1", api = {"1"}, description = "a\\\\b")
+                    public class DemoPlugin extends PluginBase {}
+                    """));
+            r.assertSuccess();
+            assertContains(r.pluginYml(), "description: \"a\\\\b\"");
+        }
+
+        @Test
+        void mainNotExtendingPluginBaseIsAnError() {
+            Result r = compile(new JavaSource("demo.DemoPlugin", """
+                    package demo;
+                    import cn.nukkit.plugin.annotation.PluginMeta;
+                    @PluginMeta(name = "Demo", version = "1", api = {"1"})
+                    public class DemoPlugin {}
+                    """));
+            r.assertFailureContains("must extend cn.nukkit.plugin.PluginBase");
+            assertNull(r.pluginYml(), "no descriptor on validation failure");
+        }
+
+        @Test
+        void duplicatePluginMetaIsAnError() {
+            Result r = compile(
+                    new JavaSource("demo.A", """
+                            package demo;
+                            import cn.nukkit.plugin.PluginBase;
+                            import cn.nukkit.plugin.annotation.PluginMeta;
+                            @PluginMeta(name = "A", version = "1", api = {"1"})
+                            public class A extends PluginBase {}
+                            """),
+                    new JavaSource("demo.B", """
+                            package demo;
+                            import cn.nukkit.plugin.PluginBase;
+                            import cn.nukkit.plugin.annotation.PluginMeta;
+                            @PluginMeta(name = "B", version = "1", api = {"1"})
+                            public class B extends PluginBase {}
+                            """));
+            r.assertFailureContains("Only one type may be annotated with @PluginMeta");
+        }
+
+        @Test
+        void noPluginMetaSkipsGenerationWithoutError() {
+            // A lone valid listener and nothing else: no main, so nothing is
+            // generated, but it must not be an error (keeps incremental builds sane).
+            Result r = compile(new JavaSource("demo.L", """
+                    package demo;
+                    import cn.nukkit.event.Listener;
+                    import cn.nukkit.plugin.annotation.EventListener;
+                    @EventListener
+                    public class L implements Listener {}
+                    """));
+            r.assertSuccess();
+            assertNull(r.pluginYml());
+            assertNull(r.bootstrap());
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // @EventListener
+    // ------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("@EventListener")
+    class Listeners {
+
+        @Test
+        void validListenerIsRegistered() {
+            Result r = compile(MAIN, new JavaSource("demo.MyListener", """
+                    package demo;
+                    import cn.nukkit.event.Listener;
+                    import cn.nukkit.plugin.annotation.EventListener;
+                    @EventListener
+                    public class MyListener implements Listener {}
+                    """));
+            r.assertSuccess();
+            assertContains(r.bootstrap(), "__pm.registerEvents(new demo.MyListener(), plugin);");
+        }
+
+        @Test
+        void listenerThroughIndirectInterfaceIsAccepted() {
+            Result r = compile(MAIN, new JavaSource("demo.MyListener", """
+                    package demo;
+                    import cn.nukkit.event.Listener;
+                    import cn.nukkit.plugin.annotation.EventListener;
+                    interface Mid extends Listener {}
+                    @EventListener
+                    public class MyListener implements Mid {}
+                    """));
+            r.assertSuccess();
+            assertContains(r.bootstrap(), "new demo.MyListener()");
+        }
+
+        @Test
+        void notImplementingListenerIsAnError() {
+            Result r = compile(MAIN, new JavaSource("demo.MyListener", """
+                    package demo;
+                    import cn.nukkit.plugin.annotation.EventListener;
+                    @EventListener
+                    public class MyListener {}
+                    """));
+            r.assertFailureContains("must implement cn.nukkit.event.Listener");
+        }
+
+        @Test
+        void abstractListenerIsAnError() {
+            Result r = compile(MAIN, new JavaSource("demo.MyListener", """
+                    package demo;
+                    import cn.nukkit.event.Listener;
+                    import cn.nukkit.plugin.annotation.EventListener;
+                    @EventListener
+                    public abstract class MyListener implements Listener {}
+                    """));
+            r.assertFailureContains("must not be abstract");
+        }
+
+        @Test
+        void privateNoArgConstructorIsAnError() {
+            Result r = compile(MAIN, new JavaSource("demo.MyListener", """
+                    package demo;
+                    import cn.nukkit.event.Listener;
+                    import cn.nukkit.plugin.annotation.EventListener;
+                    @EventListener
+                    public class MyListener implements Listener {
+                        private MyListener() {}
+                    }
+                    """));
+            r.assertFailureContains("non-private no-argument constructor");
+        }
+
+        @Test
+        void onlyParameterizedConstructorIsAnError() {
+            Result r = compile(MAIN, new JavaSource("demo.MyListener", """
+                    package demo;
+                    import cn.nukkit.event.Listener;
+                    import cn.nukkit.plugin.annotation.EventListener;
+                    @EventListener
+                    public class MyListener implements Listener {
+                        public MyListener(int x) {}
+                    }
+                    """));
+            r.assertFailureContains("must have a no-argument constructor");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // @ScheduleTask
+    // ------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("@ScheduleTask")
+    class Tasks {
+
+        @Test
+        void repeatingClassTaskUsesRepeatingSchedule() {
+            Result r = compile(MAIN, new JavaSource("demo.MyTask", """
+                    package demo;
+                    import cn.nukkit.scheduler.Task;
+                    import cn.nukkit.plugin.annotation.ScheduleTask;
+                    @ScheduleTask(delay = 5, period = 20, async = true)
+                    public class MyTask extends Task {
+                        @Override public void onRun(int t) {}
+                    }
+                    """));
+            r.assertSuccess();
+            assertContains(r.bootstrap(),
+                    "__sch.scheduleDelayedRepeatingTask(plugin, new demo.MyTask(), 5, 20, true);");
+        }
+
+        @Test
+        void oneShotClassTaskUsesDelayedSchedule() {
+            Result r = compile(MAIN, new JavaSource("demo.MyTask", """
+                    package demo;
+                    import cn.nukkit.scheduler.Task;
+                    import cn.nukkit.plugin.annotation.ScheduleTask;
+                    @ScheduleTask(delay = 40)
+                    public class MyTask extends Task {
+                        @Override public void onRun(int t) {}
+                    }
+                    """));
+            r.assertSuccess();
+            assertContains(r.bootstrap(),
+                    "__sch.scheduleDelayedTask(plugin, new demo.MyTask(), 40, false);");
+        }
+
+        @Test
+        void plainRunnableClassIsAccepted() {
+            Result r = compile(MAIN, new JavaSource("demo.MyTask", """
+                    package demo;
+                    import cn.nukkit.plugin.annotation.ScheduleTask;
+                    @ScheduleTask(period = 10)
+                    public class MyTask implements Runnable {
+                        @Override public void run() {}
+                    }
+                    """));
+            r.assertSuccess();
+            assertContains(r.bootstrap(), "new demo.MyTask(), 0, 10, false);");
+        }
+
+        @Test
+        void staticMethodTaskSchedulesLambda() {
+            Result r = compile(MAIN, new JavaSource("demo.Jobs", """
+                    package demo;
+                    import cn.nukkit.plugin.annotation.ScheduleTask;
+                    public class Jobs {
+                        @ScheduleTask(delay = 100, period = 200, async = true)
+                        public static void tick() {}
+                    }
+                    """));
+            r.assertSuccess();
+            assertContains(r.bootstrap(),
+                    "__sch.scheduleDelayedRepeatingTask(plugin, () -> demo.Jobs.tick(), 100, 200, true);");
+        }
+
+        @Test
+        void nonRunnableClassIsAnError() {
+            Result r = compile(MAIN, new JavaSource("demo.MyTask", """
+                    package demo;
+                    import cn.nukkit.plugin.annotation.ScheduleTask;
+                    @ScheduleTask
+                    public class MyTask {}
+                    """));
+            r.assertFailureContains("must implement Runnable");
+        }
+
+        @Test
+        void nonStaticMethodIsAnError() {
+            Result r = compile(MAIN, new JavaSource("demo.Jobs", """
+                    package demo;
+                    import cn.nukkit.plugin.annotation.ScheduleTask;
+                    public class Jobs {
+                        @ScheduleTask
+                        public void tick() {}
+                    }
+                    """));
+            r.assertFailureContains("must be public and static");
+        }
+
+        @Test
+        void methodWithParametersIsAnError() {
+            Result r = compile(MAIN, new JavaSource("demo.Jobs", """
+                    package demo;
+                    import cn.nukkit.plugin.annotation.ScheduleTask;
+                    public class Jobs {
+                        @ScheduleTask
+                        public static void tick(int x) {}
+                    }
+                    """));
+            r.assertFailureContains("must take no parameters");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // @Command
+    // ------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("@Command")
+    class Commands {
+
+        @Test
+        void commandIsRegisteredWithAllMetadata() {
+            Result r = compile(MAIN, new JavaSource("demo.HealCommand", """
+                    package demo;
+                    import cn.nukkit.command.CommandSender;
+                    @cn.nukkit.plugin.annotation.Command(name = "heal", aliases = {"h", "hp"},
+                            permission = "demo.heal", description = "Heals", usage = "/heal <p>")
+                    public class HealCommand extends cn.nukkit.command.Command {
+                        @Override public boolean execute(CommandSender s, String l, String[] a) { return true; }
+                    }
+                    """));
+            r.assertSuccess();
+            String b = r.bootstrap();
+            assertContains(b, "demo.HealCommand __cmd = new demo.HealCommand();");
+            assertContains(b, "__cmd.setName(\"heal\");");
+            assertContains(b, "__cmd.setAliases(new String[]{\"h\", \"hp\"});");
+            assertContains(b, "__cmd.setPermission(\"demo.heal\");");
+            assertContains(b, "__cmd.setDescription(\"Heals\");");
+            assertContains(b, "__cmd.setUsage(\"/heal <p>\");");
+            assertContains(b, "__cmap.register(__prefix, __cmd);");
+        }
+
+        @Test
+        void optionalCommandMetadataIsOmitted() {
+            Result r = compile(MAIN, new JavaSource("demo.PingCommand", """
+                    package demo;
+                    import cn.nukkit.command.CommandSender;
+                    @cn.nukkit.plugin.annotation.Command(name = "ping")
+                    public class PingCommand extends cn.nukkit.command.Command {
+                        @Override public boolean execute(CommandSender s, String l, String[] a) { return true; }
+                    }
+                    """));
+            r.assertSuccess();
+            String b = r.bootstrap();
+            assertContains(b, "__cmd.setName(\"ping\");");
+            assertFalse(b.contains("setAliases"), "no aliases call when none given");
+            assertFalse(b.contains("setPermission"), "no permission call when empty");
+            assertFalse(b.contains("setDescription"), "no description call when empty");
+            assertFalse(b.contains("setUsage"), "no usage call when empty");
+        }
+
+        @Test
+        void paramTreeIsEnabledByDefault() {
+            Result r = compile(MAIN, new JavaSource("demo.PingCommand", """
+                    package demo;
+                    import cn.nukkit.command.CommandSender;
+                    @cn.nukkit.plugin.annotation.Command(name = "ping")
+                    public class PingCommand extends cn.nukkit.command.Command {
+                        @Override public boolean execute(CommandSender s, String l, String[] a) { return true; }
+                    }
+                    """));
+            r.assertSuccess();
+            assertContains(r.bootstrap(), "__cmd.enableParamTree();");
+        }
+
+        @Test
+        void paramTreeCanBeDisabled() {
+            Result r = compile(MAIN, new JavaSource("demo.PingCommand", """
+                    package demo;
+                    import cn.nukkit.command.CommandSender;
+                    @cn.nukkit.plugin.annotation.Command(name = "ping", enableParamTree = false)
+                    public class PingCommand extends cn.nukkit.command.Command {
+                        @Override public boolean execute(CommandSender s, String l, String[] a) { return true; }
+                    }
+                    """));
+            r.assertSuccess();
+            assertFalse(r.bootstrap().contains("enableParamTree"),
+                    "param tree call omitted when disabled");
+        }
+
+        @Test
+        void notExtendingCommandIsAnError() {
+            Result r = compile(MAIN, new JavaSource("demo.NotCmd", """
+                    package demo;
+                    @cn.nukkit.plugin.annotation.Command(name = "x")
+                    public class NotCmd {}
+                    """));
+            r.assertFailureContains("must extend cn.nukkit.command.Command");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Bootstrap structure / integration
+    // ------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("bootstrap")
+    class Bootstrap {
+
+        @Test
+        void emptyBootstrapStillHasInitAndNoRegistrations() {
+            Result r = compile(MAIN);
+            r.assertSuccess();
+            String b = r.bootstrap();
+            assertNotNull(b);
+            assertContains(b, "public static void init(cn.nukkit.plugin.Plugin plugin)");
+            assertFalse(b.contains("registerEvents"));
+            assertFalse(b.contains("scheduleDelayed"));
+            assertFalse(b.contains("__cmap"));
+        }
+
+        @Test
+        void everythingTogetherCompilesAndEmitsAllWiring() {
+            Result r = compile(
+                    MAIN,
+                    new JavaSource("demo.L1", """
+                            package demo;
+                            import cn.nukkit.event.Listener;
+                            import cn.nukkit.plugin.annotation.EventListener;
+                            @EventListener public class L1 implements Listener {}
+                            """),
+                    new JavaSource("demo.L2", """
+                            package demo;
+                            import cn.nukkit.event.Listener;
+                            import cn.nukkit.plugin.annotation.EventListener;
+                            @EventListener public class L2 implements Listener {}
+                            """),
+                    new JavaSource("demo.T1", """
+                            package demo;
+                            import cn.nukkit.scheduler.Task;
+                            import cn.nukkit.plugin.annotation.ScheduleTask;
+                            @ScheduleTask(period = 20) public class T1 extends Task {
+                                @Override public void onRun(int t) {}
+                            }
+                            """),
+                    new JavaSource("demo.Jobs", """
+                            package demo;
+                            import cn.nukkit.plugin.annotation.ScheduleTask;
+                            public class Jobs {
+                                @ScheduleTask(delay = 1) public static void run() {}
+                            }
+                            """),
+                    new JavaSource("demo.C1", """
+                            package demo;
+                            import cn.nukkit.command.CommandSender;
+                            @cn.nukkit.plugin.annotation.Command(name = "c1")
+                            public class C1 extends cn.nukkit.command.Command {
+                                @Override public boolean execute(CommandSender s, String l, String[] a) { return true; }
+                            }
+                            """));
+            r.assertSuccess();
+            String b = r.bootstrap();
+            assertContains(b, "new demo.L1()");
+            assertContains(b, "new demo.L2()");
+            assertContains(b, "new demo.T1()");
+            assertContains(b, "() -> demo.Jobs.run()");
+            assertContains(b, "new demo.C1()");
+            // The generated bootstrap must itself compile against the real API.
+            assertTrue(r.bootstrapCompiled(),
+                    "generated PNXPluginBootstrap should compile to a class file");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Runtime: load the generated bytecode and execute init(plugin)
+    // ------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("runtime wiring")
+    class RuntimeWiring {
+
+        @Test
+        void initRegistersListenerSchedulesTasksAndRegistersCommand() throws Exception {
+            Result r = compile(
+                    MAIN,
+                    new JavaSource("demo.RuntimeListener", """
+                            package demo;
+                            import cn.nukkit.event.Listener;
+                            import cn.nukkit.plugin.annotation.EventListener;
+                            @EventListener public class RuntimeListener implements Listener {}
+                            """),
+                    new JavaSource("demo.RuntimeTask", """
+                            package demo;
+                            import cn.nukkit.scheduler.Task;
+                            import cn.nukkit.plugin.annotation.ScheduleTask;
+                            @ScheduleTask(period = 20) public class RuntimeTask extends Task {
+                                @Override public void onRun(int t) {}
+                            }
+                            """),
+                    new JavaSource("demo.Jobs", """
+                            package demo;
+                            import cn.nukkit.plugin.annotation.ScheduleTask;
+                            public class Jobs {
+                                public static boolean ran = false;
+                                @ScheduleTask(delay = 1) public static void run() { ran = true; }
+                            }
+                            """),
+                    new JavaSource("demo.RtCommand", """
+                            package demo;
+                            import cn.nukkit.command.CommandSender;
+                            @cn.nukkit.plugin.annotation.Command(name = "rt", aliases = {"r"}, permission = "demo.rt")
+                            public class RtCommand extends cn.nukkit.command.Command {
+                                @Override public boolean execute(CommandSender s, String l, String[] a) { return true; }
+                            }
+                            """));
+            r.assertSuccess();
+
+            BytesClassLoader loader = new BytesClassLoader(r.classBytes(), getClass().getClassLoader());
+            Class<?> bootstrap = loader.loadClass("demo.PNXPluginBootstrap");
+
+            // Mocked server side; the listener/task/command instances are real.
+            Plugin plugin = mock(Plugin.class);
+            Server server = mock(Server.class);
+            PluginManager pm = mock(PluginManager.class);
+            ServerScheduler scheduler = mock(ServerScheduler.class);
+            SimpleCommandMap commandMap = mock(SimpleCommandMap.class);
+            PluginDescription description = mock(PluginDescription.class);
+            when(plugin.getServer()).thenReturn(server);
+            when(plugin.getDescription()).thenReturn(description);
+            when(description.getName()).thenReturn("Demo");
+            when(server.getPluginManager()).thenReturn(pm);
+            when(server.getScheduler()).thenReturn(scheduler);
+            when(server.getCommandMap()).thenReturn(commandMap);
+
+            bootstrap.getMethod("init", Plugin.class).invoke(null, plugin);
+
+            // Listener registered with this plugin.
+            ArgumentCaptor<Listener> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
+            verify(pm).registerEvents(listenerCaptor.capture(), eq(plugin));
+            assertEquals("demo.RuntimeListener", listenerCaptor.getValue().getClass().getName());
+
+            // Repeating class task scheduled with the right delay/period/async.
+            verify(scheduler).scheduleDelayedRepeatingTask(eq(plugin), any(Runnable.class), eq(0), eq(20), eq(false));
+
+            // One-shot method task scheduled; running its Runnable must call Jobs.run().
+            ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+            verify(scheduler).scheduleDelayedTask(eq(plugin), runnableCaptor.capture(), eq(1), eq(false));
+            runnableCaptor.getValue().run();
+            assertTrue(loader.loadClass("demo.Jobs").getField("ran").getBoolean(null),
+                    "scheduled method-task Runnable should invoke the annotated static method");
+
+            // Command registered under the plugin name, fully configured.
+            ArgumentCaptor<cn.nukkit.command.Command> commandCaptor =
+                    ArgumentCaptor.forClass(cn.nukkit.command.Command.class);
+            verify(commandMap).register(eq("Demo"), commandCaptor.capture());
+            cn.nukkit.command.Command command = commandCaptor.getValue();
+            assertInstanceOf(cn.nukkit.command.Command.class, command);
+            assertEquals("rt", command.getName());
+            assertTrue(java.util.Arrays.asList(command.getAliases()).contains("r"));
+            assertEquals("demo.rt", command.getPermission());
+            assertTrue(command.hasParamTree(), "enableParamTree() should have run by default");
+        }
+    }
+
+    // ==================================================================
+    // Compilation harness
+    // ==================================================================
+
+    private static Result compile(JavaSource... sources) {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        Assertions.assertNotNull(compiler, "JDK compiler required to run these tests");
+        DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+        StandardJavaFileManager std = compiler.getStandardFileManager(diagnostics, null, StandardCharsets.UTF_8);
+        MemoryFileManager fm = new MemoryFileManager(std);
+
+        List<JavaFileObject> units = new ArrayList<>();
+        for (JavaSource s : sources) {
+            units.add(s.toFileObject());
+        }
+
+        // Resolve cn.nukkit.* against this test JVM's classpath explicitly, so it
+        // does not depend on how the test runner seeds the default class path.
+        List<String> options = List.of("-classpath", System.getProperty("java.class.path"));
+        JavaCompiler.CompilationTask task =
+                compiler.getTask(null, fm, diagnostics, options, null, units);
+        task.setProcessors(List.of(new PluginAnnotationProcessor()));
+        boolean success = task.call();
+        return new Result(success, diagnostics, fm);
+    }
+
+    private static void assertContains(String haystack, String needle) {
+        assertNotNull(haystack, "expected generated output, got null");
+        assertTrue(haystack.contains(needle),
+                "expected to contain:\n" + needle + "\n--- actual ---\n" + haystack);
+    }
+
+    /** An in-memory Java source compilation unit. */
+    private record JavaSource(String fqn, String code) {
+        JavaFileObject toFileObject() {
+            URI uri = URI.create("string:///" + fqn.replace('.', '/') + ".java");
+            return new SimpleJavaFileObject(uri, JavaFileObject.Kind.SOURCE) {
+                @Override
+                public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+                    return code;
+                }
+            };
+        }
+    }
+
+    /** Result of a compilation: success flag, diagnostics and captured outputs. */
+    private static final class Result {
+        private final boolean success;
+        private final DiagnosticCollector<JavaFileObject> diagnostics;
+        private final MemoryFileManager fm;
+
+        Result(boolean success, DiagnosticCollector<JavaFileObject> diagnostics, MemoryFileManager fm) {
+            this.success = success;
+            this.diagnostics = diagnostics;
+            this.fm = fm;
+        }
+
+        String pluginYml() {
+            MemoryFileObject o = fm.resources.get("plugin.yml");
+            return o == null ? null : o.content();
+        }
+
+        String bootstrap() {
+            for (Map.Entry<String, MemoryFileObject> e : fm.sources.entrySet()) {
+                if (e.getKey().endsWith("PNXPluginBootstrap")) {
+                    return e.getValue().content();
+                }
+            }
+            return null;
+        }
+
+        boolean bootstrapCompiled() {
+            return fm.classes.keySet().stream().anyMatch(k -> k.endsWith("PNXPluginBootstrap"));
+        }
+
+        Map<String, byte[]> classBytes() {
+            Map<String, byte[]> out = new LinkedHashMap<>();
+            for (Map.Entry<String, MemoryFileObject> e : fm.classes.entrySet()) {
+                out.put(e.getKey(), e.getValue().bytes());
+            }
+            return out;
+        }
+
+        List<String> errors() {
+            List<String> out = new ArrayList<>();
+            for (Diagnostic<? extends JavaFileObject> d : diagnostics.getDiagnostics()) {
+                if (d.getKind() == Diagnostic.Kind.ERROR) {
+                    out.add(d.getMessage(Locale.ENGLISH));
+                }
+            }
+            return out;
+        }
+
+        void assertSuccess() {
+            assertTrue(success, "compilation should succeed, errors:\n" + String.join("\n", errors()));
+        }
+
+        void assertFailureContains(String fragment) {
+            assertFalse(success, "compilation should fail");
+            String all = String.join("\n", errors());
+            assertTrue(all.contains(fragment),
+                    "expected an error containing:\n" + fragment + "\n--- actual errors ---\n" + all);
+        }
+    }
+
+    /** Captures processor output (sources, classes, resources) in memory. */
+    private static final class MemoryFileManager extends ForwardingJavaFileManager<StandardJavaFileManager> {
+        final Map<String, MemoryFileObject> sources = new LinkedHashMap<>();
+        final Map<String, MemoryFileObject> classes = new LinkedHashMap<>();
+        final Map<String, MemoryFileObject> resources = new LinkedHashMap<>();
+
+        MemoryFileManager(StandardJavaFileManager delegate) {
+            super(delegate);
+        }
+
+        @Override
+        public JavaFileObject getJavaFileForOutput(Location location, String className,
+                                                   JavaFileObject.Kind kind, javax.tools.FileObject sibling) {
+            MemoryFileObject o = new MemoryFileObject(
+                    URI.create("mem:///" + className.replace('.', '/') + kind.extension), kind);
+            if (kind == JavaFileObject.Kind.SOURCE) {
+                sources.put(className, o);
+            } else {
+                classes.put(className, o);
+            }
+            return o;
+        }
+
+        @Override
+        public javax.tools.FileObject getFileForOutput(Location location, String packageName,
+                                                       String relativeName, javax.tools.FileObject sibling) {
+            MemoryFileObject o = new MemoryFileObject(
+                    URI.create("mem:///" + relativeName), JavaFileObject.Kind.OTHER);
+            resources.put(relativeName, o);
+            return o;
+        }
+    }
+
+    /** A writable in-memory file object whose written bytes are readable back. */
+    private static final class MemoryFileObject extends SimpleJavaFileObject {
+        private final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        MemoryFileObject(URI uri, Kind kind) {
+            super(uri, kind);
+        }
+
+        @Override
+        public OutputStream openOutputStream() {
+            return out;
+        }
+
+        @Override
+        public Writer openWriter() {
+            return new OutputStreamWriter(openOutputStream(), StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+            return content();
+        }
+
+        String content() {
+            return out.toString(StandardCharsets.UTF_8);
+        }
+
+        byte[] bytes() {
+            return out.toByteArray();
+        }
+    }
+
+    /** Loads classes from in-memory bytes (parent-first, so cn.nukkit resolves). */
+    private static final class BytesClassLoader extends ClassLoader {
+        private final Map<String, byte[]> byName;
+
+        BytesClassLoader(Map<String, byte[]> byName, ClassLoader parent) {
+            super(parent);
+            this.byName = byName;
+        }
+
+        @Override
+        protected Class<?> findClass(String name) throws ClassNotFoundException {
+            byte[] b = byName.get(name);
+            if (b == null) {
+                throw new ClassNotFoundException(name);
+            }
+            return defineClass(name, b, 0, b.length);
+        }
+    }
+}


### PR DESCRIPTION
# Annotation Processing Tool

Native implementation of [PNX-APT](https://github.com/PleaseInsertNameHere/PNX-APT) into the PowerNukkitX codebase.

This PR removes boilerplate from plugin development by generating code at compile time. Instead of manually registering listeners, commands, schedulers and more, classes and methods can simply be annotated - the processor handles the rest.

## Features

### `@PluginMeta`
— generates a `powernukkitx.yml` from code

```java
package com.example;

import cn.nukkit.plugin.PluginBase;
import cn.nukkit.plugin.PluginLoadOrder;
import cn.nukkit.plugin.annotation.PluginMeta;

@PluginMeta(
    name = "ExamplePlugin",
    version = "1.0.0",
    api = {"3.0.0"},
    authors = {"You"},
    description = "Example plugin",
    website = "https://example.com",
    prefix = "EXAMPLE",
    depend = {},
    softDepend = {},
    loadBefore = {},
    order = PluginLoadOrder.POSTWORLD,
    features = {}
)
public class ExamplePlugin extends PluginBase {
    @Override
    public void onEnable() {
        getLogger().info("enabled");
    }
}
```

### `@EventListener`
— automatically registers all event listeners within a class implementing `Listener`

```java
package com.example;

import cn.nukkit.event.EventHandler;
import cn.nukkit.event.Listener;
import cn.nukkit.event.player.PlayerJoinEvent;
import cn.nukkit.plugin.annotation.EventListener;

@EventListener
public class JoinListener implements Listener {

    @EventHandler
    public void onJoin(PlayerJoinEvent event) {
        event.getPlayer().sendMessage("Welcome to the server!");
    }
}
```

### `@ScheduleTask`
— auto-registers and schedules tasks

```java
package com.example;

import cn.nukkit.scheduler.Task;
import cn.nukkit.plugin.annotation.ScheduleTask;

@ScheduleTask(delay = 20, period = 40, async = false)
public class HeartbeatTask extends Task {
    @Override
    public void onRun(int currentTick) {
        // Run code
    }
}

// Also works for public static methods
```

### `@Command`
— auto-registers commands and handles name, aliases, permission, description, usage message and the param tree

> [!NOTE]  
> Using `@Command` enables the param tree by default. If you don't want to use it, set `enableParamTree = false` in the annotation.
> Registration of command parameters still need a constructor.

```java
package com.example;

import cn.nukkit.command.CommandSender;
import cn.nukkit.command.tree.ParamList;
import cn.nukkit.command.utils.CommandLogger;
import cn.nukkit.plugin.annotation.Command;
import java.util.Map;

@Command(name = "ping", aliases = {"p"}, permission = "example.ping", description = "Pong")
public class PingCommand extends cn.nukkit.command.Command {

    @Override
    public int execute(CommandSender sender, String label,
                       Map.Entry<String, ParamList> result, CommandLogger log) {
        sender.sendMessage("pong");
        return 1;
    }
}
```

## How to use

PNX has to be added as annotation processor in the build file.

> [!IMPORTANT]
> The annotation processor needs further documentation once the website is running.

```kotlin
dependencies {
    compileOnly("org.powernukkitx:server:<version>")
    annotationProcessor("org.powernukkitx:server:<version>")
}
```

## AI Usage
Claude Code was used for parts of this PR:
- Comments
- Unit Tests
- Smoke Tests (locally - not committed)