### PR TITLE
fix: Placement of some blocks

### DIFF
--- a/src/main/java/cn/nukkit/item/Item.java
+++ b/src/main/java/cn/nukkit/item/Item.java
@@ -2752,7 +2752,10 @@ public abstract class Item implements Cloneable, ItemID {
             item.setCanDestroyOn(canDestroyOn);
         }
         if (itemData.getBlockDefinition() != null) {
-            item.setBlockUnsafe(Block.get(Registries.BLOCKSTATE.get(itemData.getBlockDefinition().getRuntimeId())));
+            int runtimeId = itemData.getBlockDefinition().getRuntimeId();
+            if(runtimeId != 0) {
+                item.setBlockUnsafe(Block.get(Registries.BLOCKSTATE.get(runtimeId)));
+            }
         }
         item.setNetId(itemData.getNetId());
         item.identifier = Identifier.tryParse(itemData.getDefinition().getIdentifier());


### PR DESCRIPTION
For some blocks, the client sends the runtimeId 0, which does not exist. That overwrite the already correct block