### PR TITLE
fix: derive player UUID from XUID instead of deprecated identity claim

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -412,7 +412,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         this.creationTime = System.currentTimeMillis();
         this.displayName = info.getIdentityClaims().extraData.displayName;
         this.clientChainData = info.getClientChainData();
-        this.uuid = UUID.nameUUIDFromBytes(("pocket-auth-1-xuid:" + this.getXUID()).getBytes(StandardCharsets.UTF_8));
+        this.uuid = Server.uuidFromXUID(this.getXUID());
         final ByteBuffer buffer = ByteBuffer.allocate(16);
         buffer.putLong(this.uuid.getMostSignificantBits());
         buffer.putLong(this.uuid.getLeastSignificantBits());

--- a/src/main/java/cn/nukkit/Server.java
+++ b/src/main/java/cn/nukkit/Server.java
@@ -1868,7 +1868,7 @@ public class Server {
      * @param info the player info
      */
     void updateName(Player.PlayerInfo info) {
-        var uniqueId = info.getIdentityClaims().extraData.identity;
+        var uniqueId = uuidFromXUID(info.getIdentityClaims().extraData.xuid);
         var name = info.getIdentityClaims().extraData.displayName;
 
         byte[] nameBytes = name.toLowerCase(Locale.ENGLISH).getBytes(StandardCharsets.UTF_8);
@@ -1885,6 +1885,21 @@ public class Server {
         if (!xboxAuthEnabled) {
             playerDataDB.put(nameBytes, array);
         }
+    }
+
+    /**
+     * Derives a stable {@link UUID} from a player's XUID (Xbox User ID).
+     * <p>
+     * The XUID is namespaced with the {@code "pocket-auth-1-xuid:"} prefix and hashed
+     * using {@link UUID#nameUUIDFromBytes(byte[])} (a type 3, name-based UUID). Because
+     * the derivation is deterministic, the same XUID always yields the same UUID, while
+     * different XUIDs yield different UUIDs.
+     *
+     * @param xuid the player's XUID, as provided by Xbox Live authentication
+     * @return a deterministic, name-based {@link UUID} derived from the given XUID
+     */
+    public static UUID uuidFromXUID(String xuid) {
+        return UUID.nameUUIDFromBytes(("pocket-auth-1-xuid:" + xuid).getBytes(StandardCharsets.UTF_8));
     }
 
     public IPlayer getOfflinePlayer(final String name) {


### PR DESCRIPTION
This PR replaces the deprecated identity claim usage with the same UUID deriving method that's already used in the Player creation. Introcoduces a new helper method `Server#uuidFromXUID(String)`

### Compatibility / existing data

`Player.uuid` is unchanged by this PR (XUID-derived before and after), so player data are not re-keyed and nothing is lost.

Servers that previously ran a build where the deprecated `identity` was used as the data key may have leftover name->UUID index entries pointing at `identity`-derived UUIDs. Those UUIDs hold no data (`hasOfflinePlayerData` returns false for them), but I'm not 100% if they get removed automatically already.

### AI usage

Claude has been used to generate Javadoc for the new helper method.