### PR TITLE
enhancement: Expose PlayerInfo in PlayerCreationEvent

### DIFF
--- a/src/main/java/cn/nukkit/event/player/PlayerCreationEvent.java
+++ b/src/main/java/cn/nukkit/event/player/PlayerCreationEvent.java
@@ -3,29 +3,32 @@ package cn.nukkit.event.player;
 import cn.nukkit.Player;
 import cn.nukkit.event.Event;
 import cn.nukkit.event.HandlerList;
+import lombok.Getter;
+import lombok.Setter;
+import org.jetbrains.annotations.Nullable;
 
-/**
- * @author MagicDroidX (Nukkit Project)
- */
 public class PlayerCreationEvent extends Event {
 
     private static final HandlerList handlers = new HandlerList();
 
-    public static HandlerList getHandlers() {
-        return handlers;
-    }
-
+    @Getter
+    @Setter
     private Class<? extends Player> playerClass;
 
+    @Getter
+    @Nullable
+    private final Player.PlayerInfo playerInfo;
+
     public PlayerCreationEvent(Class<? extends Player> playerClass) {
-        this.playerClass = playerClass;
+        this(playerClass, null);
     }
 
-    public Class<? extends Player> getPlayerClass() {
-        return playerClass;
+    public PlayerCreationEvent(Class<? extends Player> playerClass, @Nullable Player.PlayerInfo playerInfo) {
+        this.playerClass = playerClass;
+        this.playerInfo = playerInfo;
     }
 
-    public void setPlayerClass(Class<? extends Player> playerClass) {
-        this.playerClass = playerClass;
+    public static HandlerList getHandlers() {
+        return handlers;
     }
 }

--- a/src/main/java/cn/nukkit/network/process/PlayerSessionHolder.java
+++ b/src/main/java/cn/nukkit/network/process/PlayerSessionHolder.java
@@ -385,7 +385,7 @@ public class PlayerSessionHolder {
 
     private @Nullable Player createPlayer(Player.PlayerInfo playerInfo) {
         try {
-            PlayerCreationEvent event = new PlayerCreationEvent(Player.class);
+            PlayerCreationEvent event = new PlayerCreationEvent(Player.class, playerInfo);
             Server.getInstance().getPluginManager().callEvent(event);
             Constructor<? extends Player> constructor = event.getPlayerClass().getConstructor(BedrockServerSession.class, Player.PlayerInfo.class);
             return constructor.newInstance(this.session, playerInfo);


### PR DESCRIPTION
Adds a PlayerInfo-aware PlayerCreationEvent constructor while preserving the existing constructor for compatibility.

This allows plugins to select different Player subclasses during login based on identity data such as XUID, gamertag, or client chain information, enabling multiple custom player classes without hardcoding the decision in core.