### PR TITLE
fix: Some blocks can be lit but not consumed by fire

### DIFF
--- a/src/main/java/cn/nukkit/block/BlockGlowstone.java
+++ b/src/main/java/cn/nukkit/block/BlockGlowstone.java
@@ -43,6 +43,16 @@ public class BlockGlowstone extends BlockTransparent {
     }
 
     @Override
+    public int getBurnChance() {
+        return 0;
+    }
+
+    @Override
+    public int getBurnAbility() {
+        return 0;
+    }
+
+    @Override
     public int getLightLevel() {
         return 15;
     }

--- a/src/main/java/cn/nukkit/block/BlockStem.java
+++ b/src/main/java/cn/nukkit/block/BlockStem.java
@@ -18,7 +18,7 @@ public abstract class BlockStem extends BlockLog {
 
     @Override
     public int getBurnChance() {
-        return -1;
+        return 0;
     }
 
     @Override


### PR DESCRIPTION
Some blocks can be lit but not consumed by fire