### PR TITLE
fix: Regression in synced entity property indexes

### DIFF
--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -6142,7 +6142,6 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         int schemaIndex = 0;
         for (EntityProperty prop : propertyDefs) {
             if (!prop.isClientSync()) {
-                schemaIndex++;
                 continue;
             }
 


### PR DESCRIPTION
Fixes a regression from the recent entity property sync changes where non-client-sync properties were still counted in runtime schema indexes, causing later synced properties to be applied incorrectly by clients.