### PR TITLE
chore: remove unused nbt max depth config field

### DIFF
--- a/src/main/java/cn/nukkit/config/category/PerformanceSettings.java
+++ b/src/main/java/cn/nukkit/config/category/PerformanceSettings.java
@@ -31,7 +31,4 @@ public class PerformanceSettings extends OkaeriConfig {
     int melting = 16;
     int singleOperation = 1;
     int batchOperation = 32;
-    @Comment("Maximum allowed recursion depth for NBT reading and writing. Increase if loading worlds with deeply nested containers.")
-    @CustomKey("nbt-max-depth")
-    private int nbtMaxDepth = 16;
 }

--- a/src/main/resources/language/eng/lang.json
+++ b/src/main/resources/language/eng/lang.json
@@ -180,7 +180,6 @@
   "pnx.settings.performance.asyncworkers": "Number of threads used by the server scheduler, 'auto' means automatic allocation",
   "pnx.settings.performance.basetps": "How many ticks per second should be targeted",
   "pnx.settings.performance.freezearray.enable": "Whether to enable the freeze array",
-  "pnx.settings.performance.maxNbtDepth": "Maximum allowed recursion depth for NBT reading and writing. Increase if loading worlds with deeply nested containers.",
   "chat.type.achievement": "{%0} has just earned the achievement {%1}",
   "chat.type.admin": "[{%0}: {%1}]",
   "chat.type.announcement": "[{%0}] {%1}",


### PR DESCRIPTION
Removing leftover of nbt max depth config (originally introduced with #2365) which has been removed with protocol migration. After testing, I found out that this setting was not useful and resulted in many errors. We should preserve the hard-coded default of 16 levels for safety. It is not supported anyway.