### PR TITLE
fix: register client-side multi recipes

### DIFF
--- a/src/main/java/cn/nukkit/inventory/request/CraftRecipeActionProcessor.java
+++ b/src/main/java/cn/nukkit/inventory/request/CraftRecipeActionProcessor.java
@@ -15,6 +15,7 @@ import cn.nukkit.item.enchantment.EnchantmentHelper;
 import cn.nukkit.nbt.tag.CompoundTag;
 import cn.nukkit.network.protocol.types.TrimData;
 import cn.nukkit.recipe.Input;
+import cn.nukkit.recipe.MultiRecipe;
 import cn.nukkit.recipe.Recipe;
 import cn.nukkit.recipe.SmithingTransformRecipe;
 import cn.nukkit.recipe.UserDataShapelessRecipe;
@@ -211,7 +212,9 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
                 log.warn("Mismatched consume action count! Expected: {}, Actual: {} on inventory {}", consumeActionCountNeeded, consumeActions.size(), craft.getClass().getSimpleName());
                 return context.error();
             }
-            if (recipe.getResults().size() == 1) {
+            if (recipe instanceof MultiRecipe && recipe.getResults().isEmpty()) {
+                context.put(RECIPE_DATA_KEY, recipe);
+            } else if (recipe.getResults().size() == 1) {
                 // If the recipe has a single output item, the client will not send a CreateAction; in this case, we will output the item directly to CREATED_OUTPUT in CraftRecipeAction
                 // If the recipe has multiple output items, the client will send a CreateAction; in this case, we will output the items to CREATED_OUTPUT within the CreateActionProcessor
                 var output = recipe.getResults().getFirst().clone();

--- a/src/main/java/cn/nukkit/registry/RecipeRegistry.java
+++ b/src/main/java/cn/nukkit/registry/RecipeRegistry.java
@@ -530,6 +530,10 @@ public class RecipeRegistry implements IRegistry<String, Recipe, Recipe> {
         // https://github.com/Kaooot/bedrock-network-data
         // We can use the original reader again, once endstone generates data again
 
+        // Register special recipes first so their (potentially reused) UUIDs are known while
+        // loading the vanilla recipe data below and can be skipped there to avoid duplicates.
+        this.registerSpecial();
+
         var recipeConfig = new Config(Config.JSON);
         try (var r = Server.class.getClassLoader().getResourceAsStream("gamedata/kaooot/recipes.json")) {
             recipeConfig.load(r);
@@ -581,8 +585,22 @@ public class RecipeRegistry implements IRegistry<String, Recipe, Recipe> {
 
                 String block = (String) recipe.get("block");
 
-                if (block == null)
+                if (block == null) {
+                    // Multi recipes (type 4) have no crafting block. They are client-side
+                    // special recipes such as applying a banner pattern to a shield, cloning
+                    // maps, crafting fireworks, etc. They must still be registered so the client
+                    // is told about them and so the server can resolve them by network id
+                    Object typeObj = recipe.get("type");
+                    if (typeObj != null && ((Number) typeObj).intValue() == RecipeType.MULTI.networkType) {
+                        UUID uuid = UUID.fromString((String) recipe.get("uuid"));
+                        int netId = (int) ((double) recipe.get("netId"));
+                        // Skip already handled implementations, registered via registerSpecial()
+                        if (!allRecipeMaps.containsKey(uuid.toString())) {
+                            this.register(new MultiRecipe(uuid, netId));
+                        }
+                    }
                     continue;
+                }
 
                 switch (block) {     // the block defines the type of recipe
                     case "smithing_table" -> {
@@ -838,9 +856,6 @@ public class RecipeRegistry implements IRegistry<String, Recipe, Recipe> {
         register(new CartographyRecipe(Item.get(ItemID.FILLED_MAP, 5, 1, EmptyArrays.EMPTY_BYTES, false),
                 10007,
                 Collections.singletonList(Item.get(ItemID.FILLED_MAP, 5, 1, EmptyArrays.EMPTY_BYTES, false))));
-
-        //Registering special recipes
-        this.registerSpecial();
     }
 
     private void registerFurnaceRecipe(String block, Item outputItem, List<ItemDescriptor> ingredients, Config furnaceXpConfig) {


### PR DESCRIPTION
Allows crafting of shield banners, map cloning, fireworks etc.

If a recipe has no crafting block, it's a multi recipe (type 4). These are resolved client-side, but only once the server registers them and includes them in the crafting packet, previously they were skipped entirely. We now register them and on craft pass the recipe through the request context so the result the client sends is applied.

Claude Opus 4.8 was used to identify the cause and suggest a fix. The suggested fix has been applied with some minor changes.