### PR TITLE
fix: dead mobs fly into the sky during death animation

### DIFF
--- a/src/main/java/cn/nukkit/entity/EntityPhysical.java
+++ b/src/main/java/cn/nukkit/entity/EntityPhysical.java
@@ -166,6 +166,11 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
         if (this.hasGravity() && isFalling()) {
             this.fallingTick++;
         }
+        if (!this.isAlive() && !this.isImmobile()) {
+            handleGravity();
+            handleGroundFrictionMovement();
+            handlePassableBlockFrictionMovement();
+        }
         super.updateMovement();
         this.move(this.motionX, this.motionY, this.motionZ);
     }


### PR DESCRIPTION
When you killed a mob with a melee hit, the hit applies knockback, which pushes the mob slightly upward (a positive motionY). Normally gravity would immediately start cancelling that upward push and friction would bleed it off, so the mob just does a tiny hop and falls. But because the dead mob no longer gets gravity or friction, that upward velocity never decays.

We need dead mobs to still feel gravity and friction so their leftover motion dies down. Since `asyncPrepare(int)` is never called for dead entities, we add those calculations into the one method that does still run for corpses: `updateMovement()`.