### PR TITLE
Fix loading of images into ItemFilledMap.

### DIFF
--- a/src/main/java/cn/nukkit/item/ItemFilledMap.java
+++ b/src/main/java/cn/nukkit/item/ItemFilledMap.java
@@ -141,7 +141,6 @@ public class ItemFilledMap extends Item {
         packet.setPixels(pixels.stream().mapToInt(Integer::intValue).toArray());
 
         player.sendPacketImmediately(packet);
-        player.getLevel().getScheduler().scheduleDelayedTask(InternalPlugin.INSTANCE, () -> player.sendPacketImmediately(packet), 20);
     }
 
     public boolean trySendImage(Player p) {

--- a/src/main/java/cn/nukkit/item/ItemFilledMap.java
+++ b/src/main/java/cn/nukkit/item/ItemFilledMap.java
@@ -135,7 +135,7 @@ public class ItemFilledMap extends Item {
         final List<Integer> pixels = new IntArrayList();
         for (int x = 0; x < image.getWidth(); x++) {
             for (int y = 0; y < image.getHeight(); y++) {
-                pixels.add((int) Utils.toABGR(this.image.getRGB(x, y)));
+                pixels.add((int) Utils.toABGR(this.image.getRGB(y, x)));
             }
         }
         packet.setPixels(pixels.stream().mapToInt(Integer::intValue).toArray());


### PR DESCRIPTION
This fixes the loading of images into ItemFilledMaps. Previously, they were axis-swapped.
The second change fixes a piece of commit acddcea. There's no obvious reason given for why the retransmit was originally added. It sent the map a second time, after a delay of one second. Clients apparently have never complained until iOS 26.3x.