### PR TITLE
perf: Optimize EntityItem and Hopper alloc / GC

### DIFF
--- a/src/main/java/org/powernukkitx/block/BlockHopper.java
+++ b/src/main/java/org/powernukkitx/block/BlockHopper.java
@@ -5,7 +5,6 @@ import org.powernukkitx.Server;
 import org.powernukkitx.block.property.CommonBlockProperties;
 import org.powernukkitx.blockentity.BlockEntity;
 import org.powernukkitx.blockentity.BlockEntityHopper;
-import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.item.EntityItem;
 import org.powernukkitx.event.inventory.InventoryMoveItemEvent;
 import org.powernukkitx.inventory.ContainerInventory;
@@ -276,10 +275,7 @@ public class BlockHopper extends BlockTransparent implements RedstoneComponent, 
 
             boolean pickedUpItem = false;
 
-            for (Entity entity : hopperPos.level.getCollidingEntities(pickupArea)) {
-                if (entity == null || entity.isClosed() || !(entity instanceof EntityItem itemEntity))
-                    continue;
-
+            for (EntityItem itemEntity : hopperPos.level.getCollidingItemEntities(pickupArea)) {
                 if (itemEntity.isDisplayOnly())
                     continue;
 
@@ -296,7 +292,7 @@ public class BlockHopper extends BlockTransparent implements RedstoneComponent, 
                 Item[] items = hopperInv.addItem(item);
 
                 if (items.length == 0) {
-                    entity.close();
+                    itemEntity.close();
                     pickedUpItem = true;
                     continue;
                 }

--- a/src/main/java/org/powernukkitx/entity/item/EntityItem.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityItem.java
@@ -183,13 +183,13 @@ public class EntityItem extends Entity {
 
         if (this.mergeItems && this.age % 60 == 0 && this.onGround && this.getItem() != null && this.isAlive()) {
             if (this.getItem().getCount() < this.getItem().getMaxStackSize()) {
-                for (Entity entity : this.getLevel().getNearbyEntities(getBoundingBox().grow(1, 1, 1), this, false)) {
-                    if (entity instanceof EntityItem) {
+                for (EntityItem entity : this.getLevel().getCollidingItemEntities(getBoundingBox().grow(1, 1, 1))) {
+                    if (entity != this) {
                         if (!entity.isAlive()) {
                             continue;
                         }
-                        if (!((EntityItem) entity).mergeItems) continue;
-                        Item closeItem = ((EntityItem) entity).getItem();
+                        if (!entity.mergeItems) continue;
+                        Item closeItem = entity.getItem();
                         if (!closeItem.equals(getItem(), true, true)) {
                             continue;
                         }

--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -3636,6 +3636,44 @@ public class Level implements Metadatable {
         return getEntitiesFromBuffer(index, overflow);
     }
 
+    /**
+     * Returns only the {@link EntityItem} instances whose bounding box intersects {@code bb}.
+     * <p>
+     * Same chunk range and intersection test as {@link #getCollidingEntities(AxisAlignedBB)}, but skips every
+     * non-item entity and allocates nothing when there is no item to return.
+     *
+     * @param bb the area to search
+     * @return matching item entities, or an empty list (never null)
+     */
+    public List<EntityItem> getCollidingItemEntities(AxisAlignedBB bb) {
+        int minX = NukkitMath.floorDouble((bb.getMinX() - 2) / 16);
+        int maxX = NukkitMath.ceilDouble((bb.getMaxX() + 2) / 16);
+        int minZ = NukkitMath.floorDouble((bb.getMinZ() - 2) / 16);
+        int maxZ = NukkitMath.ceilDouble((bb.getMaxZ() + 2) / 16);
+
+        List<EntityItem> result = null;
+
+        for (int x = minX; x <= maxX; ++x) {
+            for (int z = minZ; z <= maxZ; ++z) {
+                IChunk chunk = this.getChunkIfLoaded(x, z);
+                if (chunk == null) {
+                    continue;
+                }
+                for (Entity ent : chunk.getEntities().values()) {
+                    if (ent instanceof EntityItem item && !item.isClosed()
+                            && item.boundingBox.intersectsWith(bb)) {
+                        if (result == null) {
+                            result = new ArrayList<>();
+                        }
+                        result.add(item);
+                    }
+                }
+            }
+        }
+
+        return result == null ? Collections.emptyList() : result;
+    }
+
     public List<Entity> fastCollidingEntities(AxisAlignedBB bb) {
         return this.fastCollidingEntities(bb, null);
     }


### PR DESCRIPTION
Under high pressure (e.g. from farms), the server is having trouble with collision. This PR reduces the allocation amount by introducing a new method only collecting EntityItem.

# AI Usage
Comment by Claude