### PR TITLE
fix: send block break particles under server-authoritative block brea…

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -80,7 +80,7 @@ import org.powernukkitx.level.PlayerChunkManager;
 import org.powernukkitx.level.Position;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
-import org.powernukkitx.level.particle.CrackBlockParticle;
+import org.powernukkitx.level.particle.BreakBlockParticle;
 import org.powernukkitx.level.vibration.VibrationEvent;
 import org.powernukkitx.level.vibration.VibrationType;
 import org.powernukkitx.math.AxisAlignedBB;
@@ -451,7 +451,6 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
     protected void onBlockBreakContinue(Vector3 pos, BlockFace face) {
         if (this.isBreakingBlock()) {
             var time = System.currentTimeMillis();
-            Block block = this.level.getBlock(pos, false);
             double miningTimeRequired;
 
             if (this.breakingBlock instanceof CustomBlock customBlock) {
@@ -471,7 +470,10 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
                     pk.setPosition(Vector3f.from(this.breakingBlock.x, this.breakingBlock.y, this.breakingBlock.z));
                     pk.setData(65535 / breakTick);
                     this.getLevel().addChunkPacket(this.breakingBlock.getFloorX() >> 4, this.breakingBlock.getFloorZ() >> 4, pk);
-                    this.level.addParticle(new CrackBlockParticle(pos, block));
+                }
+
+                if (face != null && this.server.isServerAuthoritativeBlockBreaking()) {
+                    this.level.addParticle(new BreakBlockParticle(pos.add(0.5, 0.5, 0.5), this.breakingBlock, face));
                 }
 
                 long timeDiff = time - breakingBlockTime;
@@ -2976,7 +2978,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
                 this.timeSinceRest++;
             }
 
-            if (this.server.getServerAuthoritativeMovement() > 0 && !this.server.getSettings().miscSettings().overrideServerAuthBlockBreaking()) { // For server-side use only, as client-side continue break is normal.
+            if (this.server.isServerAuthoritativeBlockBreaking()) { // For server-side use only, as client-side continue break is normal.
                 onBlockBreakContinue(breakingBlock, breakingBlockFace);
             }
 

--- a/src/main/java/org/powernukkitx/Server.java
+++ b/src/main/java/org/powernukkitx/Server.java
@@ -3118,6 +3118,10 @@ public class Server {
     public int getServerAuthoritativeMovement() {
         return serverAuthoritativeMovementMode;
     }
+
+    public boolean isServerAuthoritativeBlockBreaking() {
+        return this.serverAuthoritativeMovementMode > 0 && !this.settings.miscSettings().overrideServerAuthBlockBreaking();
+    }
     // endregion
 
     // region threading

--- a/src/main/java/org/powernukkitx/level/particle/BreakBlockParticle.java
+++ b/src/main/java/org/powernukkitx/level/particle/BreakBlockParticle.java
@@ -1,0 +1,25 @@
+package org.powernukkitx.level.particle;
+
+import org.powernukkitx.block.Block;
+import org.powernukkitx.math.BlockFace;
+import org.powernukkitx.math.Vector3;
+import org.cloudburstmc.protocol.bedrock.data.LevelEvent;
+import org.cloudburstmc.protocol.bedrock.data.LevelEventType;
+
+public class BreakBlockParticle extends GenericParticle {
+
+    public BreakBlockParticle(Vector3 pos, Block block, BlockFace face) {
+        super(pos, typeFromFace(face), block.getRuntimeId());
+    }
+
+    private static LevelEventType typeFromFace(BlockFace face) {
+        return switch (face) {
+            case DOWN -> LevelEvent.PARTICLE_BREAK_BLOCK_DOWN;
+            case UP -> LevelEvent.PARTICLE_BREAK_BLOCK_UP;
+            case NORTH -> LevelEvent.PARTICLE_BREAK_BLOCK_NORTH;
+            case SOUTH -> LevelEvent.PARTICLE_BREAK_BLOCK_SOUTH;
+            case WEST -> LevelEvent.PARTICLE_BREAK_BLOCK_WEST;
+            case EAST -> LevelEvent.PARTICLE_BREAK_BLOCK_EAST;
+        };
+    }
+}

--- a/src/main/java/org/powernukkitx/network/process/PlayerSessionHolder.java
+++ b/src/main/java/org/powernukkitx/network/process/PlayerSessionHolder.java
@@ -311,7 +311,7 @@ public class PlayerSessionHolder {
         packet.setMovementSettings(new SyncedPlayerMovementSettings(
                         ServerAuthMovementMode.SERVER_AUTHORITATIVE_V3,
                         0,
-                        true
+                        server.isServerAuthoritativeBlockBreaking()
                 )
         );
         packet.getBlockProperties().addAll(


### PR DESCRIPTION
…king

The six LevelEvent.PARTICLE_BREAK_BLOCK_{DOWN,UP,NORTH,SOUTH,WEST,EAST} events were never sent, so no mining particles appeared while breaking a block.

PARTICLE_CRACK_BLOCK expects the face packed into the data field as `id | (face << 24)`. That encoding is unusable here because the server sets blockNetworkIdsAreHashes(true), so the field carries a state hash whose top byte the client reads back as a bogus face. The six per-face events exist precisely to solve this: the face travels in the event id and the data field carries the plain block network id. Only custom blocks and `minecraft:digger` items emitted the old particle at all, so ordinary blocks produced none.

Add BreakBlockParticle, which picks the event from the face, and emit it for every block from Player#onBlockBreakContinue. The face is the one the client already sends in PlayerBlockActionData, so no raycast is performed.

Also make the serverAuthoritativeBlockBreaking flag in StartGamePacket derive from the config instead of being hardcoded true. It previously disagreed with the server-side break handling, which is gated on the config: with client-authoritative movement or overrideServerAuthBlockBreaking set, the client was told the server owned block breaking and drew no particles, while the server-side emitter was gated off and drew none either.