### PR TITLE
feat: add `disconnectScreenMessage` to `Player.kick` and `Player.close`

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -3146,7 +3146,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
     /**
      * reason=empty string
      *
-     * @see #kick(PlayerKickEvent.Reason, String, boolean)
+     * @see #kick(PlayerKickEvent.Reason, String, String, boolean)
      */
     public boolean kick() {
         return this.kick("");
@@ -3155,7 +3155,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
     /**
      * {@link PlayerKickEvent.Reason} = {@link PlayerKickEvent.Reason#UNKNOWN}
      *
-     * @see #kick(PlayerKickEvent.Reason, String, boolean)
+     * @see #kick(PlayerKickEvent.Reason, String, String, boolean)
      */
     public boolean kick(String reason, boolean isAdmin) {
         return this.kick(PlayerKickEvent.Reason.UNKNOWN, reason, isAdmin);
@@ -3164,61 +3164,98 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
     /**
      * {@link PlayerKickEvent.Reason} = {@link PlayerKickEvent.Reason#UNKNOWN}
      *
-     * @see #kick(PlayerKickEvent.Reason, String, boolean)
+     * @see #kick(PlayerKickEvent.Reason, String, String, boolean)
      */
     public boolean kick(String reason) {
         return kick(PlayerKickEvent.Reason.UNKNOWN, reason);
     }
 
     /**
-     * @see #kick(PlayerKickEvent.Reason, String, boolean)
+     * {@link PlayerKickEvent.Reason} = {@link PlayerKickEvent.Reason#UNKNOWN}
+     *
+     * @see #kick(PlayerKickEvent.Reason, String, String, boolean)
+     */
+    public boolean kick(String reason, String disconnectScreenMessage) {
+        return kick(PlayerKickEvent.Reason.UNKNOWN, reason, disconnectScreenMessage);
+    }
+
+    /**
+     * {@link PlayerKickEvent.Reason} = {@link PlayerKickEvent.Reason#UNKNOWN}
+     *
+     * @see #kick(PlayerKickEvent.Reason, String, String, boolean)
+     */
+    public boolean kick(String reason, String disconnectScreenMessage, boolean isAdmin) {
+        return kick(PlayerKickEvent.Reason.UNKNOWN, reason, disconnectScreenMessage, isAdmin);
+    }
+
+    /**
+     * @see #kick(PlayerKickEvent.Reason, String, String, boolean)
      */
     public boolean kick(PlayerKickEvent.Reason reason) {
         return this.kick(reason, true);
     }
 
     /**
-     * @see #kick(PlayerKickEvent.Reason, String, boolean)
+     * @see #kick(PlayerKickEvent.Reason, String, String, boolean)
      */
     public boolean kick(PlayerKickEvent.Reason reason, String reasonString) {
         return this.kick(reason, reasonString, true);
     }
 
     /**
-     * @see #kick(PlayerKickEvent.Reason, String, boolean)
+     * @see #kick(PlayerKickEvent.Reason, String, String, boolean)
+     */
+    public boolean kick(PlayerKickEvent.Reason reason, String reasonString, String disconnectScreenMessage) {
+        return this.kick(reason, reasonString, disconnectScreenMessage, true);
+    }
+
+    /**
+     * @see #kick(PlayerKickEvent.Reason, String, String, boolean)
      */
     public boolean kick(PlayerKickEvent.Reason reason, boolean isAdmin) {
         return this.kick(reason, reason.toString(), isAdmin);
     }
 
     /**
-     * Kicks the player
-     *
-     * @param reason       Reason enum
-     * @param reasonString Reason String
-     * @param isAdmin      Whether from the administrator kicked out
-     * @return boolean
+     * @see #kick(PlayerKickEvent.Reason, String, String, boolean)
      */
     public boolean kick(PlayerKickEvent.Reason reason, String reasonString, boolean isAdmin) {
+        return this.kick(reason, reasonString, reasonString, isAdmin);
+    }
+
+    /**
+     * Kicks the player.
+     *
+     * @param reason                  Reason enum
+     * @param reasonString            Reason String shown inside the console
+     * @param disconnectScreenMessage Reason String shown on the player's screen
+     * @param isAdmin                 Whether from the administrator kicked out
+     * @return boolean
+     */
+    public boolean kick(PlayerKickEvent.Reason reason, String reasonString, String disconnectScreenMessage, boolean isAdmin) {
         PlayerKickEvent ev;
-        this.server.getPluginManager().callEvent(ev = new PlayerKickEvent(this, reason, this.getLeaveMessage()));
+        this.server.getPluginManager().callEvent(ev = new PlayerKickEvent(this, reason, reasonString, disconnectScreenMessage, this.getLeaveMessage()));
         if (!ev.isCancelled()) {
+            String finalReason;
             String message;
             if (isAdmin) {
                 if (!Server.getInstance().getNameBans().isBanned(getName())) {
-                    message = "Kicked by admin." + (!reasonString.isEmpty() ? " Reason: " + reasonString : "");
+                    finalReason = "Kicked by admin." + (!reasonString.isEmpty() ? " Reason: " + reasonString : "");
+                    message = "Kicked by admin." + (!disconnectScreenMessage.isEmpty() ? " Reason: " + disconnectScreenMessage : (!reasonString.isEmpty() ? " Reason: " + reasonString : ""));
                 } else {
-                    message = reasonString;
+                    finalReason = reasonString;
+                    message = disconnectScreenMessage;
                 }
             } else {
-                if (reasonString.isEmpty()) {
+                finalReason = reasonString.isEmpty() ? "disconnectionScreen.noReason" : reasonString;
+                if (disconnectScreenMessage.isEmpty()) {
                     message = "disconnectionScreen.noReason";
                 } else {
-                    message = reasonString;
+                    message = disconnectScreenMessage;
                 }
             }
 
-            this.close(ev.getQuitMessage(), message);
+            this.close(ev.getQuitMessage(), finalReason, message);
 
             return true;
         }
@@ -3613,7 +3650,6 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         this.sendPacket(pk);
     }
 
-
     @Override
     public void close() {
         this.close("");
@@ -3622,41 +3658,48 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
     /**
      * {@code notify=true}
      *
-     * @see #close(TextContainer, String)
+     * @see #close(TextContainer, String, String)
      */
     public void close(String reason) {
-        this.close(this.getLeaveMessage(), reason);
+        this.close(this.getLeaveMessage(), reason, reason);
     }
 
-    public void close(String message, String reason) {
-        this.close(new TextContainer(message), reason);
+    public void close(String reason, String disconnectScreenMessage) {
+        this.close(this.getLeaveMessage(), reason, disconnectScreenMessage);
+    }
+
+    public void close(String message, String reason, String disconnectScreenMessage) {
+        this.close(new TextContainer(message), reason, disconnectScreenMessage);
     }
 
     /**
      * {@code reason="generic",notify=true}
      *
-     * @see #close(TextContainer, String)
+     * @see #close(TextContainer, String, String)
      */
     public void close(TextContainer message) {
         this.close(message, "generic");
     }
 
     /**
-     * Closing the player's connection and all its activities are almost as function as {@link #kick}, the difference is that {@link #kick} is implemented based on {@code close}.
-     *
-     * @param message PlayerQuitEvent message
-     * @param reason  Reason for logout
+     * @see #close(TextContainer, String, String)
      */
     public void close(TextContainer message, String reason) {
+        this.close(message, reason, reason);
+    }
+
+    public void close(TextContainer message, String reason, String disconnectScreenMessage) {
         if (this.closed || !this.connected.compareAndSet(true, false)) {
             return;
         }
         //output logout information
         log.info(this.getServer().getLanguage().tr("nukkit.player.logOut",
-                TextFormat.AQUA + this.getName() + TextFormat.WHITE,
-                this.getAddress(),
-                String.valueOf(this.getPort()),
-                this.getServer().getLanguage().tr(reason)));
+            TextFormat.AQUA + this.getName() + TextFormat.WHITE,
+            this.getAddress(),
+            String.valueOf(this.getPort()),
+            this.getServer().getLanguage().tr(reason)));
+
+        if (disconnectScreenMessage == null) disconnectScreenMessage = reason;
 
         resetInventory();
         for (var inv : this.windows.keySet()) {
@@ -3744,7 +3787,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         log.debug(reason);
         // true when the server closes the client connection
         if (this.session.isConnected()) {
-            this.session.disconnect(reason, false);
+            this.session.disconnect(disconnectScreenMessage, false);
         }
     }
 

--- a/src/main/java/org/powernukkitx/event/player/PlayerKickEvent.java
+++ b/src/main/java/org/powernukkitx/event/player/PlayerKickEvent.java
@@ -36,24 +36,30 @@ public class PlayerKickEvent extends PlayerEvent implements Cancellable {
 
     protected final Reason reason;
     protected final String reasonString;
+    protected final String disconnectScreenMessage;
 
     public PlayerKickEvent(Player player, Reason reason, TextContainer quitMessage) {
-        this(player, reason, reason.toString(), quitMessage);
+        this(player, reason, reason.toString(), reason.toString(), quitMessage);
     }
 
     public PlayerKickEvent(Player player, Reason reason, String quitMessage) {
         this(player, reason, new TextContainer(quitMessage));
     }
 
-    public PlayerKickEvent(Player player, Reason reason, String reasonString, TextContainer quitMessage) {
+    public PlayerKickEvent(Player player, Reason reason, String reasonString, String disconnectScreenMessage, TextContainer quitMessage) {
         this.player = player;
         this.quitMessage = quitMessage;
         this.reason = reason;
+        this.disconnectScreenMessage = disconnectScreenMessage;
         this.reasonString = reasonString;
     }
 
     public String getReason() {
         return reasonString;
+    }
+
+    public String getDisconnectScreenMessage() {
+        return disconnectScreenMessage;
     }
 
     public Reason getReasonEnum() {


### PR DESCRIPTION
The `reasonString` and `disconnectScreenMessage` now serve different purposes.

While `reasonString` acts as a fallback for ´disconnectScreenMessage`, `disconnectScreenMessage` is **not** a fallback for ´reasonString`.
- `reasonString`: The reason shown inside the server console. It is meant to describe the kick in a few short words.
- `disconnectScreenMessage`: The detailed message shown directly to the player on their disconnect screen.

For example, 
player.kick("Player is banned", "You have been banned from the network..."); 
> This would add a "Kicked by admin. Reason:" infront of both Strings, since `isAdmin` is true by default.

player.kick("Player is banned", "You have been banned from the network...", false); 
> This would **not** add a "Kicked by admin. Reason:" infront of both Strings, since `isAdmin` is false this time.

The console would only say that the player has disconnected because "Player is banned", while the player sees the `disconnectScreenMessage`, being "You have been banned from the network..."

If `disconnectScreenMessage` would be left out, the `reasonString` becomes the `disconnectScreenMessage`, which is the previous behavior.

This feature seems small, but can actually make a huge difference when it comes to logging and debugging.