### PR TITLE
lOptimize villager AI performance via POI system

### DIFF
--- a/src/main/java/org/powernukkitx/entity/passive/EntityVillagerV2.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityVillagerV2.java
@@ -52,10 +52,11 @@ import org.powernukkitx.inventory.InventorySlice;
 import org.powernukkitx.inventory.TradeInventory;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.level.Level;
-import org.powernukkitx.level.Location;
 import org.powernukkitx.level.ParticleEffect;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
+import org.powernukkitx.level.poi.PoiManager;
+import org.powernukkitx.level.poi.PoiTypeRegistry;
 import org.powernukkitx.math.BlockVector3;
 import org.powernukkitx.math.Vector3;
 import org.powernukkitx.nbt.tag.CompoundTag;
@@ -241,25 +242,19 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
                         entity -> {
                             if (getLevel().getTick() % 120 == 0) {
                                 if (getMemoryStorage().isEmpty(CoreMemoryTypes.OCCUPIED_BED)) {
-                                    int range = 48;
-                                    int lookY = 5;
-                                    BlockBed block = null;
-                                    for (int x = -range; x <= range; x++) {
-                                        for (int z = -range; z <= range; z++) {
-                                            for (int y = -lookY; y <= lookY; y++) {
-                                                Location lookLocation = entity.add(x, y, z);
-                                                Block lookBlock = lookLocation.getLevelBlock();
-                                                if (lookBlock instanceof BlockBed bed
-                                                        && !bed.isHeadPiece() && Arrays.stream(getLevel().getEntities()).noneMatch(entity1 -> entity1 instanceof EntityVillagerV2 v && v.getMemoryStorage().notEmpty(CoreMemoryTypes.OCCUPIED_BED) && v.getBed().equals(bed))) {
-                                                    block = bed.getFootPart();
+                                    getLevel().getPoiManager().findClosest(type -> type == PoiTypeRegistry.HOME, this, 48, PoiManager.Occupancy.HAS_SPACE)
+                                            .ifPresent(record -> {
+                                                BlockVector3 pos = record.getPos();
+                                                if (getLevel().getBlock(pos.x, pos.y, pos.z) instanceof BlockBed bed && !bed.isOccupied()) {
+                                                    setBed(bed.getFootPart());
                                                 }
-                                            }
-                                        }
-                                    }
-                                    if (block != null && !block.isOccupied()) setBed(block);
+                                            });
                                 } else if (!getMemoryStorage().get(CoreMemoryTypes.OCCUPIED_BED).isBedValid()) {
+                                    getLevel().getPoiManager().release(getMemoryStorage().get(CoreMemoryTypes.OCCUPIED_BED).asBlockVector3());
                                     this.nbt.remove("bed");
                                     getMemoryStorage().clear(CoreMemoryTypes.OCCUPIED_BED);
+                                } else {
+                                    getLevel().getPoiManager().ensureTicket(getMemoryStorage().get(CoreMemoryTypes.OCCUPIED_BED).asBlockVector3());
                                 }
                             }
                         },
@@ -295,19 +290,27 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
                             if (getLevel().getTick() % 30 == 0 && !isBaby()) {
                                 Block siteBlock = getMemoryStorage().get(CoreMemoryTypes.SITE_BLOCK);
                                 if (siteBlock != null && !siteBlock.getLevelBlock().getId().equals(siteBlock.getId())) {
+                                    getLevel().getPoiManager().release(siteBlock.asBlockVector3());
                                     getMemoryStorage().clear(CoreMemoryTypes.SITE_BLOCK);
                                     if (getTradeExp() == 0) {
                                         setTradeSeed(new NukkitRandom().nextInt(Integer.MAX_VALUE - 1));
                                     }
+                                } else if (siteBlock != null) {
+                                    getLevel().getPoiManager().ensureTicket(siteBlock.asBlockVector3());
                                 }
 
                                 if (getMemoryStorage().isEmpty(CoreMemoryTypes.SITE_BLOCK)) {
-                                    for (Block block : getLevel().getCollisionBlocks(this.getBoundingBox().grow(16, 4, 16))) {
-                                        if (Arrays.stream(getLevel().getEntities()).noneMatch(entity1 -> entity1 instanceof EntityVillagerV2 v && v.getMemoryStorage().notEmpty(CoreMemoryTypes.SITE_BLOCK) && v.getSite().equals(block))
-                                                && setProfessionBlock(block))
-                                            return;
+                                    Profession currentProfession = Profession.getProfession(getProfession());
+                                    String requiredBlockId = getTradeExp() != 0 && currentProfession != null ? currentProfession.getBlockID() : null;
+                                    var poi = getLevel().getPoiManager().findClosest(
+                                            type -> type.isJobSite() && (requiredBlockId == null || requiredBlockId.equals(type.jobSiteBlockId())),
+                                            this, 16, PoiManager.Occupancy.HAS_SPACE);
+                                    boolean acquired = false;
+                                    if (poi.isPresent()) {
+                                        BlockVector3 pos = poi.get().getPos();
+                                        acquired = setProfessionBlock(getLevel().getBlock(pos.x, pos.y, pos.z));
                                     }
-                                    if (getTradeExp() == 0) setProfession(0, true);
+                                    if (!acquired && getTradeExp() == 0) setProfession(0, true);
                                 }
                             }
                         },
@@ -375,7 +378,7 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
     }
 
     public void setBed(BlockBed bed) {
-        if (bed.isBedValid()) {
+        if (bed.isBedValid() && getLevel().getPoiManager().takeAt(bed.getFootPart().asBlockVector3())) {
             getMemoryStorage().put(CoreMemoryTypes.OCCUPIED_BED, bed);
             for (int i = 0; i < 5; i++) {
                 float randX = Utils.rand(0f, 0.5f);
@@ -744,6 +747,7 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
         for (Profession profession : Profession.getProfessions().values()) {
             if (getTradeExp() != 0 && profession.getIndex() != getProfession()) continue;
             if (block.getId().equals(profession.getBlockID())) {
+                if (!getLevel().getPoiManager().takeAt(block.asBlockVector3())) return false;
                 getMemoryStorage().put(CoreMemoryTypes.SITE_BLOCK, block);
                 setProfession(profession.getIndex(), true);
                 return true;
@@ -868,6 +872,12 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
 
     @Override
     public void close() {
+        if (getLevel() != null && getMemoryStorage() != null) {
+            BlockBed bed = getMemoryStorage().get(CoreMemoryTypes.OCCUPIED_BED);
+            if (bed != null) getLevel().getPoiManager().release(bed.asBlockVector3());
+            Block site = getMemoryStorage().get(CoreMemoryTypes.SITE_BLOCK);
+            if (site != null) getLevel().getPoiManager().release(site.asBlockVector3());
+        }
         this.getTradeNetIds().forEach(TradeRecipeBuildUtils.RECIPE_MAP::remove);
         super.close();
     }

--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -46,6 +46,7 @@ import org.powernukkitx.level.format.ChunkState;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.level.format.LevelConfig;
 import org.powernukkitx.level.format.LevelProvider;
+import org.powernukkitx.level.poi.PoiManager;
 import org.powernukkitx.level.format.UnsafeChunk;
 import org.powernukkitx.level.format.leveldb.LevelDBProvider;
 import org.powernukkitx.level.generator.BiomedGenerator;
@@ -311,6 +312,7 @@ public class Level implements Metadatable {
     public static final AtomicLong GENERATED_CHUNK_COUNT = new AtomicLong();
     private final Server server;
     private final int levelId;
+    private final PoiManager poiManager = new PoiManager(this);
     // Loaders still remain single-threaded
     private final Int2ObjectOpenHashMap<ChunkLoader> loaders = new Int2ObjectOpenHashMap<>();
     private final Int2IntMap loaderCounter = new Int2IntOpenHashMap();
@@ -2734,6 +2736,10 @@ public class Level implements Metadatable {
         BlockChangeEvent blockChangeEvent = new BlockChangeEvent(block, blockPrevious);
         this.server.getPluginManager().callEvent(blockChangeEvent);
 
+        if (layer == 0) {
+            this.poiManager.onBlockChange(x, y, z, statePrevious, state);
+        }
+
         int cx = x >> 4;
         int cz = z >> 4;
         long index = Level.chunkHash(cx, cz);
@@ -3971,6 +3977,10 @@ public class Level implements Metadatable {
         return this.requireProvider().getLoadedChunk(index);
     }
 
+    public PoiManager getPoiManager() {
+        return this.poiManager;
+    }
+
     /**
      * Set chunk to the level provider
      */
@@ -4555,6 +4565,8 @@ public class Level implements Metadatable {
         } catch (Exception e) {
             log.error(this.server.getLanguage().tr("nukkit.level.chunkUnloadError", e.toString()), e);
         }
+
+        this.poiManager.onChunkUnload(x, z);
 
         return true;
     }

--- a/src/main/java/org/powernukkitx/level/format/leveldb/LevelDBChunkSerializer.java
+++ b/src/main/java/org/powernukkitx/level/format/leveldb/LevelDBChunkSerializer.java
@@ -74,6 +74,10 @@ public class LevelDBChunkSerializer {
             serializeHeightAndBiome(writeBatch, unsafeChunk);
             serializeLight(writeBatch, unsafeChunk);
             serializeBlockTicks(unsafeChunk);
+            if (unsafeChunk.getProvider() != null && unsafeChunk.getProvider().getLevel() != null) {
+                unsafeChunk.getProvider().getLevel().getPoiManager()
+                        .flushToChunk(unsafeChunk.getX(), unsafeChunk.getZ(), unsafeChunk.getExtraData());
+            }
             writeBatch.put(LevelDBKeyUtil.PNX_EXTRA_DATA.getKey(unsafeChunk.getX(), unsafeChunk.getZ(), unsafeChunk.getDimensionData()), this.writeBigEndian(unsafeChunk.getExtraData()));
         });
 

--- a/src/main/java/org/powernukkitx/level/format/palette/Palette.java
+++ b/src/main/java/org/powernukkitx/level/format/palette/Palette.java
@@ -57,6 +57,15 @@ public class Palette<V> {
         this.addToPalette(first);
     }
 
+    public boolean anyMatch(java.util.function.Predicate<V> predicate) {
+        for (int i = 0, size = this.palette.size(); i < size; i++) {
+            if (predicate.test(this.palette.get(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     protected void addToPalette(V value) {
         if (this.paletteIndex != null) {
             if (!this.paletteIndex.containsKey(value)) {

--- a/src/main/java/org/powernukkitx/level/poi/PoiManager.java
+++ b/src/main/java/org/powernukkitx/level/poi/PoiManager.java
@@ -1,0 +1,300 @@
+package org.powernukkitx.level.poi;
+
+import org.powernukkitx.block.BlockState;
+import org.powernukkitx.level.DimensionData;
+import org.powernukkitx.level.Level;
+import org.powernukkitx.level.format.ChunkSection;
+import org.powernukkitx.level.format.IChunk;
+import org.powernukkitx.math.BlockVector3;
+import org.powernukkitx.math.Vector3;
+import org.powernukkitx.nbt.tag.CompoundTag;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
+
+/**
+ * Per-level point-of-interest index (vanilla {@code PoiManager} transposed).
+ * <p>
+ * The world is never scanned on demand: {@link Level#setBlock} reports every block
+ * change through {@link #onBlockChange}, and a chunk section is scanned at most once,
+ * lazily, the first time a query touches it (with a palette pre-check so sections
+ * without any POI block are skipped for free). Sections are dropped on chunk unload.
+ * <p>
+ * The index is in-memory only: after a chunk reload, tickets are re-acquired by the
+ * entities when their memories are validated.
+ */
+public class PoiManager {
+
+    public enum Occupancy {
+        HAS_SPACE(PoiRecord::hasSpace),
+        IS_OCCUPIED(PoiRecord::isOccupied),
+        ANY(record -> true);
+
+        private final Predicate<PoiRecord> test;
+
+        Occupancy(Predicate<PoiRecord> test) {
+            this.test = test;
+        }
+
+        public Predicate<PoiRecord> getTest() {
+            return test;
+        }
+    }
+
+    private static final String EXTRA_DATA_KEY = "PNXPoi";
+
+    private final Level level;
+    private final ConcurrentHashMap<Long, PoiSection> sections = new ConcurrentHashMap<>();
+
+    public PoiManager(Level level) {
+        this.level = level;
+    }
+
+    private static long sectionKey(int chunkX, int sectionY, int chunkZ) {
+        return ((chunkX & 0xFFFFFFFL) << 36) | ((chunkZ & 0xFFFFFFFL) << 8) | (sectionY & 0xFFL);
+    }
+
+    /**
+     * Called by {@link Level#setBlock} for every layer-0 block change. Only sections
+     * already indexed are patched; unindexed sections will see the new state when
+     * they are lazily scanned.
+     */
+    public void onBlockChange(int x, int y, int z, BlockState oldState, BlockState newState) {
+        PoiType oldType = PoiTypeRegistry.forState(oldState);
+        PoiType newType = PoiTypeRegistry.forState(newState);
+        if (oldType == newType) {
+            return;
+        }
+        PoiSection section = sections.get(sectionKey(x >> 4, y >> 4, z >> 4));
+        if (section == null) {
+            return;
+        }
+        if (oldType != null) {
+            section.remove(x & 0xF, y & 0xF, z & 0xF);
+        }
+        if (newType != null) {
+            section.add(new BlockVector3(x, y, z), newType);
+        }
+    }
+
+    public void onChunkUnload(int chunkX, int chunkZ) {
+        DimensionData dimension = level.getDimensionData();
+        for (int sectionY = dimension.getMinSectionY(); sectionY <= dimension.getMaxSectionY(); sectionY++) {
+            sections.remove(sectionKey(chunkX, sectionY, chunkZ));
+        }
+    }
+
+    public Optional<PoiRecord> findClosest(Predicate<PoiType> typePredicate, Vector3 center, int radius, Occupancy occupancy) {
+        return getInRange(typePredicate, center, radius, occupancy).stream()
+                .min(Comparator.comparingDouble(record -> distanceSquared(record.getPos(), center)));
+    }
+
+    public List<PoiRecord> getInRange(Predicate<PoiType> typePredicate, Vector3 center, int radius, Occupancy occupancy) {
+        List<PoiRecord> result = new ArrayList<>();
+        DimensionData dimension = level.getDimensionData();
+        int centerX = center.getFloorX();
+        int centerY = center.getFloorY();
+        int centerZ = center.getFloorZ();
+        int chunkRadius = (radius >> 4) + 1;
+        int centerChunkX = centerX >> 4;
+        int centerChunkZ = centerZ >> 4;
+        int minSectionY = Math.max(dimension.getMinSectionY(), (centerY - radius) >> 4);
+        int maxSectionY = Math.min(dimension.getMaxSectionY(), (centerY + radius) >> 4);
+
+        List<PoiRecord> candidates = new ArrayList<>();
+        for (int chunkX = centerChunkX - chunkRadius; chunkX <= centerChunkX + chunkRadius; chunkX++) {
+            for (int chunkZ = centerChunkZ - chunkRadius; chunkZ <= centerChunkZ + chunkRadius; chunkZ++) {
+                for (int sectionY = minSectionY; sectionY <= maxSectionY; sectionY++) {
+                    PoiSection section = getOrScan(chunkX, sectionY, chunkZ);
+                    if (section == null || section.isEmpty()) {
+                        continue;
+                    }
+                    section.collect(typePredicate, occupancy.getTest(), candidates);
+                }
+            }
+        }
+        for (PoiRecord record : candidates) {
+            BlockVector3 pos = record.getPos();
+            if (Math.abs(pos.x - centerX) <= radius && Math.abs(pos.y - centerY) <= radius && Math.abs(pos.z - centerZ) <= radius) {
+                result.add(record);
+            }
+        }
+        return result;
+    }
+
+    public Optional<PoiType> getType(BlockVector3 pos) {
+        PoiRecord record = getRecord(pos);
+        return record == null ? Optional.empty() : Optional.of(record.getType());
+    }
+
+    /**
+     * Claims a ticket on the POI at the given position. Returns true when the ticket
+     * was acquired, or when the position is not indexed (unloaded chunk / index lag) so
+     * callers never get blocked by a stale index.
+     */
+    public boolean takeAt(BlockVector3 pos) {
+        PoiSection section = getOrScan(pos.x >> 4, pos.y >> 4, pos.z >> 4);
+        if (section == null) {
+            return true;
+        }
+        PoiRecord record = section.get(pos.x & 0xF, pos.y & 0xF, pos.z & 0xF);
+        if (record == null) {
+            return true;
+        }
+        return record.acquireTicket();
+    }
+
+    public void release(BlockVector3 pos) {
+        PoiSection section = sections.get(sectionKey(pos.x >> 4, pos.y >> 4, pos.z >> 4));
+        if (section != null) {
+            PoiRecord record = section.get(pos.x & 0xF, pos.y & 0xF, pos.z & 0xF);
+            if (record != null) {
+                record.releaseTicket();
+            }
+        }
+    }
+
+    private @Nullable PoiRecord getRecord(BlockVector3 pos) {
+        PoiSection section = getOrScan(pos.x >> 4, pos.y >> 4, pos.z >> 4);
+        return section == null ? null : section.get(pos.x & 0xF, pos.y & 0xF, pos.z & 0xF);
+    }
+
+    /**
+     * Writes the dirty sections of a chunk into its extra data compound so they are
+     * persisted with the chunk (called from the chunk serializer). Sections never
+     * loaded into the manager keep their previously stored data untouched.
+     */
+    public void flushToChunk(int chunkX, int chunkZ, @Nullable CompoundTag extraData) {
+        if (extraData == null) {
+            return;
+        }
+        DimensionData dimension = level.getDimensionData();
+        CompoundTag poiTag = extraData.contains(EXTRA_DATA_KEY) ? extraData.getCompound(EXTRA_DATA_KEY) : new CompoundTag();
+        boolean changed = false;
+        for (int sectionY = dimension.getMinSectionY(); sectionY <= dimension.getMaxSectionY(); sectionY++) {
+            PoiSection section = sections.get(sectionKey(chunkX, sectionY, chunkZ));
+            if (section == null || !section.isDirty()) {
+                continue;
+            }
+            section.clearDirty();
+            String key = "s" + sectionY;
+            if (section.isEmpty()) {
+                poiTag.remove(key);
+            } else {
+                poiTag.putCompound(key, section.pack());
+            }
+            changed = true;
+        }
+        if (changed) {
+            if (poiTag.getTags().isEmpty()) {
+                extraData.remove(EXTRA_DATA_KEY);
+            } else {
+                extraData.putCompound(EXTRA_DATA_KEY, poiTag);
+            }
+        }
+    }
+
+    /**
+     * Idempotent claim used to re-validate an entity memory (e.g. after a chunk reload).
+     */
+    public boolean ensureTicket(BlockVector3 pos) {
+        PoiRecord record = getRecord(pos);
+        return record == null || record.ensureTicket();
+    }
+
+    private @Nullable PoiSection getOrScan(int chunkX, int sectionY, int chunkZ) {
+        long key = sectionKey(chunkX, sectionY, chunkZ);
+        PoiSection existing = sections.get(key);
+        if (existing != null) {
+            return existing;
+        }
+        IChunk chunk = level.getChunkIfLoaded(chunkX, chunkZ);
+        if (chunk == null) {
+            return null;
+        }
+        return sections.computeIfAbsent(key, k -> loadSection(chunk, chunkX, sectionY, chunkZ));
+    }
+
+    private PoiSection loadSection(IChunk chunk, int chunkX, int sectionY, int chunkZ) {
+        CompoundTag extraData = chunk.getExtraData();
+        if (extraData != null && extraData.contains(EXTRA_DATA_KEY)) {
+            CompoundTag poiTag = extraData.getCompound(EXTRA_DATA_KEY);
+            String key = "s" + sectionY;
+            if (poiTag.contains(key)) {
+                PoiSection section = PoiSection.unpack(poiTag.getCompound(key));
+                if (!section.isValid()) {
+                    refresh(chunk, chunkX, sectionY, chunkZ, section);
+                }
+                return section;
+            }
+        }
+        return scan(chunk, chunkX, sectionY, chunkZ);
+    }
+
+    /**
+     * Rebuilds an untrusted section from the actual blocks, carrying over the ticket
+     * counts of records that still match (vanilla {@code PoiSection.refresh}).
+     */
+    private void refresh(IChunk chunk, int chunkX, int sectionY, int chunkZ, PoiSection section) {
+        Map<BlockVector3, PoiRecord> old = new HashMap<>();
+        for (PoiRecord record : section.allRecords()) {
+            old.put(record.getPos(), record);
+        }
+        section.clearRecords();
+        PoiSection scanned = scan(chunk, chunkX, sectionY, chunkZ);
+        for (PoiRecord record : scanned.allRecords()) {
+            PoiRecord previous = old.get(record.getPos());
+            if (previous != null && previous.getType() == record.getType()) {
+                section.addLoaded(record.getPos(), record.getType(), previous.getFreeTickets());
+            } else {
+                section.add(record.getPos(), record.getType());
+            }
+        }
+        section.setValid(true);
+    }
+
+    private PoiSection scan(IChunk chunk, int chunkX, int sectionY, int chunkZ) {
+        PoiSection section = new PoiSection();
+        try {
+            ChunkSection chunkSection = chunk.getSection(sectionY);
+            if (chunkSection == null || chunkSection.isEmpty()) {
+                return section;
+            }
+            if (!chunkSection.blockLayer()[0].anyMatch(state -> PoiTypeRegistry.isPoiBlock(state.getIdentifier()))) {
+                return section;
+            }
+            int baseX = chunkX << 4;
+            int baseY = sectionY << 4;
+            int baseZ = chunkZ << 4;
+            for (int x = 0; x < 16; x++) {
+                for (int z = 0; z < 16; z++) {
+                    for (int y = 0; y < 16; y++) {
+                        BlockState state = chunkSection.getBlockState(x, y, z, 0);
+                        PoiType type = PoiTypeRegistry.forState(state);
+                        if (type != null) {
+                            section.add(new BlockVector3(baseX + x, baseY + y, baseZ + z), type);
+                        }
+                    }
+                }
+            }
+        } catch (Exception ignored) {
+            // concurrent palette mutation during the scan: keep what was indexed so far,
+            // onBlockChange keeps the section consistent from here on
+        }
+        return section;
+    }
+
+    private static double distanceSquared(BlockVector3 pos, Vector3 center) {
+        double dx = pos.x + 0.5 - center.x;
+        double dy = pos.y + 0.5 - center.y;
+        double dz = pos.z + 0.5 - center.z;
+        return dx * dx + dy * dy + dz * dz;
+    }
+}

--- a/src/main/java/org/powernukkitx/level/poi/PoiRecord.java
+++ b/src/main/java/org/powernukkitx/level/poi/PoiRecord.java
@@ -1,0 +1,78 @@
+package org.powernukkitx.level.poi;
+
+import org.powernukkitx.math.BlockVector3;
+
+/**
+ * One indexed POI block. Tickets model occupancy without scanning entities:
+ * an entity claiming the POI acquires a ticket and releases it when it lets go.
+ * Ticket changes notify the owning section so it gets persisted with the chunk.
+ */
+public final class PoiRecord {
+
+    private final BlockVector3 pos;
+    private final PoiType type;
+    private final Runnable setDirty;
+    private int freeTickets;
+
+    public PoiRecord(BlockVector3 pos, PoiType type, Runnable setDirty) {
+        this(pos, type, type.maxTickets(), setDirty);
+    }
+
+    public PoiRecord(BlockVector3 pos, PoiType type, int freeTickets, Runnable setDirty) {
+        this.pos = pos;
+        this.type = type;
+        this.setDirty = setDirty;
+        this.freeTickets = Math.max(0, Math.min(freeTickets, type.maxTickets()));
+    }
+
+    public BlockVector3 getPos() {
+        return pos;
+    }
+
+    public PoiType getType() {
+        return type;
+    }
+
+    public synchronized int getFreeTickets() {
+        return freeTickets;
+    }
+
+    public synchronized boolean acquireTicket() {
+        if (freeTickets <= 0) {
+            return false;
+        }
+        freeTickets--;
+        setDirty.run();
+        return true;
+    }
+
+    /**
+     * Idempotent claim used to re-validate a memory after a chunk reload: acquires a
+     * ticket only when the POI is completely free, and always reports success so a
+     * holder whose ticket survived persistence is not evicted.
+     */
+    public synchronized boolean ensureTicket() {
+        if (freeTickets == type.maxTickets()) {
+            freeTickets--;
+            setDirty.run();
+        }
+        return true;
+    }
+
+    public synchronized boolean releaseTicket() {
+        if (freeTickets >= type.maxTickets()) {
+            return false;
+        }
+        freeTickets++;
+        setDirty.run();
+        return true;
+    }
+
+    public synchronized boolean hasSpace() {
+        return freeTickets > 0;
+    }
+
+    public synchronized boolean isOccupied() {
+        return freeTickets != type.maxTickets();
+    }
+}

--- a/src/main/java/org/powernukkitx/level/poi/PoiSection.java
+++ b/src/main/java/org/powernukkitx/level/poi/PoiSection.java
@@ -1,0 +1,174 @@
+package org.powernukkitx.level.poi;
+
+import org.powernukkitx.math.BlockVector3;
+import org.powernukkitx.nbt.tag.CompoundTag;
+import org.powernukkitx.nbt.tag.ListTag;
+import it.unimi.dsi.fastutil.shorts.Short2ObjectOpenHashMap;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * POI index of one 16x16x16 chunk section. Keyed by section-relative position,
+ * with a per-type inverted index for fast type queries. Instances are read from
+ * AI worker threads and written from the main thread, hence the coarse lock.
+ * <p>
+ * Sections serialize to NBT ({@link #pack()} / {@link #unpack(CompoundTag)}) and are
+ * persisted inside the chunk's extra data. {@code dirty} tracks unsaved changes
+ * (including ticket moves); {@code valid} is false when the stored data cannot be
+ * trusted (format change) and the section must be rebuilt from the blocks.
+ */
+public final class PoiSection {
+
+    private static final int FORMAT_VERSION = 1;
+
+    private final Short2ObjectOpenHashMap<PoiRecord> records = new Short2ObjectOpenHashMap<>();
+    private final Map<PoiType, Set<PoiRecord>> byType = new HashMap<>();
+    private final Runnable markDirty = () -> this.dirty = true;
+    private volatile boolean dirty;
+    private volatile boolean valid;
+
+    public PoiSection() {
+        this(true);
+    }
+
+    private PoiSection(boolean valid) {
+        this.valid = valid;
+    }
+
+    private static short key(int localX, int localY, int localZ) {
+        return (short) ((localX << 8) | (localZ << 4) | localY);
+    }
+
+    public synchronized void add(BlockVector3 pos, PoiType type) {
+        short key = key(pos.x & 0xF, pos.y & 0xF, pos.z & 0xF);
+        PoiRecord previous = records.get(key);
+        if (previous != null) {
+            if (previous.getType() == type) {
+                return;
+            }
+            removeRecord(key, previous);
+        }
+        putRecord(key, new PoiRecord(pos, type, markDirty));
+        this.dirty = true;
+    }
+
+    /**
+     * Inserts a record with a known ticket count (deserialization / consistency refresh).
+     */
+    public synchronized void addLoaded(BlockVector3 pos, PoiType type, int freeTickets) {
+        putRecord(key(pos.x & 0xF, pos.y & 0xF, pos.z & 0xF), new PoiRecord(pos, type, freeTickets, markDirty));
+    }
+
+    private void putRecord(short key, PoiRecord record) {
+        records.put(key, record);
+        byType.computeIfAbsent(record.getType(), t -> new HashSet<>()).add(record);
+    }
+
+    public synchronized void remove(int localX, int localY, int localZ) {
+        short key = key(localX, localY, localZ);
+        PoiRecord record = records.get(key);
+        if (record != null) {
+            removeRecord(key, record);
+            this.dirty = true;
+        }
+    }
+
+    private void removeRecord(short key, PoiRecord record) {
+        records.remove(key);
+        Set<PoiRecord> ofType = byType.get(record.getType());
+        if (ofType != null) {
+            ofType.remove(record);
+            if (ofType.isEmpty()) {
+                byType.remove(record.getType());
+            }
+        }
+    }
+
+    public synchronized @Nullable PoiRecord get(int localX, int localY, int localZ) {
+        return records.get(key(localX, localY, localZ));
+    }
+
+    public synchronized void collect(Predicate<PoiType> typePredicate, Predicate<PoiRecord> occupancy, List<PoiRecord> out) {
+        for (Map.Entry<PoiType, Set<PoiRecord>> entry : byType.entrySet()) {
+            if (typePredicate.test(entry.getKey())) {
+                for (PoiRecord record : entry.getValue()) {
+                    if (occupancy.test(record)) {
+                        out.add(record);
+                    }
+                }
+            }
+        }
+    }
+
+    public synchronized List<PoiRecord> allRecords() {
+        return new ArrayList<>(records.values());
+    }
+
+    public synchronized void clearRecords() {
+        records.clear();
+        byType.clear();
+        this.dirty = true;
+    }
+
+    public synchronized boolean isEmpty() {
+        return records.isEmpty();
+    }
+
+    public boolean isDirty() {
+        return dirty;
+    }
+
+    public void clearDirty() {
+        this.dirty = false;
+    }
+
+    public boolean isValid() {
+        return valid;
+    }
+
+    public void setValid(boolean valid) {
+        this.valid = valid;
+    }
+
+    public synchronized CompoundTag pack() {
+        CompoundTag tag = new CompoundTag();
+        tag.putByte("Version", FORMAT_VERSION);
+        tag.putBoolean("Valid", valid);
+        ListTag<CompoundTag> list = new ListTag<>();
+        for (PoiRecord record : records.values()) {
+            list.add(new CompoundTag()
+                    .putInt("x", record.getPos().x)
+                    .putInt("y", record.getPos().y)
+                    .putInt("z", record.getPos().z)
+                    .putString("type", record.getType().name())
+                    .putInt("freeTickets", record.getFreeTickets()));
+        }
+        tag.putList("Records", list);
+        return tag;
+    }
+
+    /**
+     * Records whose type is unknown (removed profession/plugin) are dropped; a format
+     * version mismatch yields an invalid section that will be rebuilt from the blocks.
+     */
+    public static PoiSection unpack(CompoundTag tag) {
+        boolean sameVersion = tag.getByte("Version") == FORMAT_VERSION;
+        PoiSection section = new PoiSection(sameVersion && tag.getBoolean("Valid"));
+        for (CompoundTag recordTag : tag.getList("Records", CompoundTag.class).getAll()) {
+            PoiType type = PoiTypeRegistry.byName(recordTag.getString("type"));
+            if (type == null) {
+                continue;
+            }
+            BlockVector3 pos = new BlockVector3(recordTag.getInt("x"), recordTag.getInt("y"), recordTag.getInt("z"));
+            section.addLoaded(pos, type, recordTag.getInt("freeTickets"));
+        }
+        return section;
+    }
+}

--- a/src/main/java/org/powernukkitx/level/poi/PoiType.java
+++ b/src/main/java/org/powernukkitx/level/poi/PoiType.java
@@ -1,0 +1,33 @@
+package org.powernukkitx.level.poi;
+
+import org.powernukkitx.block.BlockState;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * A point-of-interest category (job site block, bed, bell...).
+ * <p>
+ * A block state belongs to this type when its identifier is in {@link #blockIds()}
+ * and it passes {@link #stateFilter()} (e.g. only bed foot pieces are indexed).
+ * {@code maxTickets} is the number of entities that can claim a POI of this type
+ * at the same time (1 for beds and job sites, more for meeting points).
+ *
+ * @param jobSiteBlockId the block id of the profession work station, or null if this type is not a job site
+ */
+public record PoiType(String name, Set<String> blockIds, Predicate<BlockState> stateFilter, int maxTickets,
+                      @Nullable String jobSiteBlockId) {
+
+    public boolean matches(BlockState state) {
+        return blockIds.contains(state.getIdentifier()) && stateFilter.test(state);
+    }
+
+    public boolean mayMatch(String blockId) {
+        return blockIds.contains(blockId);
+    }
+
+    public boolean isJobSite() {
+        return jobSiteBlockId != null;
+    }
+}

--- a/src/main/java/org/powernukkitx/level/poi/PoiTypeRegistry.java
+++ b/src/main/java/org/powernukkitx/level/poi/PoiTypeRegistry.java
@@ -1,0 +1,92 @@
+package org.powernukkitx.level.poi;
+
+import org.powernukkitx.block.BlockID;
+import org.powernukkitx.block.BlockState;
+import org.powernukkitx.block.property.CommonBlockProperties;
+import org.powernukkitx.entity.data.profession.Profession;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Maps block identifiers to {@link PoiType}s. Job-site types are derived from the
+ * registered {@link Profession}s; call {@link #refresh()} after registering a
+ * profession at runtime so its work station becomes a POI.
+ */
+public final class PoiTypeRegistry {
+
+    public static final PoiType HOME = new PoiType("minecraft:home", Set.of(BlockID.BED),
+            state -> !((Boolean) state.getPropertyValue(CommonBlockProperties.HEAD_PIECE_BIT)), 1, null);
+
+    public static final PoiType MEETING = new PoiType("minecraft:meeting", Set.of(BlockID.BELL),
+            state -> true, 32, null);
+
+    private static volatile Map<String, PoiType> byBlockId;
+    private static volatile Map<String, PoiType> byName;
+
+    private PoiTypeRegistry() {
+    }
+
+    public static @Nullable PoiType forState(BlockState state) {
+        PoiType type = byBlockId().get(state.getIdentifier());
+        return type != null && type.matches(state) ? type : null;
+    }
+
+    public static boolean isPoiBlock(String blockId) {
+        return byBlockId().containsKey(blockId);
+    }
+
+    /**
+     * Resolves a persisted type name back to its {@link PoiType}, or null if it no longer exists.
+     */
+    public static @Nullable PoiType byName(String name) {
+        byBlockId();
+        return byName.get(name);
+    }
+
+    /**
+     * Drops the cached indexes so they are rebuilt from the current professions on next access.
+     */
+    public static void refresh() {
+        synchronized (PoiTypeRegistry.class) {
+            byBlockId = null;
+            byName = null;
+        }
+    }
+
+    private static Map<String, PoiType> byBlockId() {
+        Map<String, PoiType> map = byBlockId;
+        if (map == null) {
+            synchronized (PoiTypeRegistry.class) {
+                map = byBlockId;
+                if (map == null) {
+                    map = build();
+                    byBlockId = map;
+                }
+            }
+        }
+        return map;
+    }
+
+    private static Map<String, PoiType> build() {
+        Map<String, PoiType> map = new HashMap<>();
+        for (String id : HOME.blockIds()) {
+            map.put(id, HOME);
+        }
+        for (String id : MEETING.blockIds()) {
+            map.put(id, MEETING);
+        }
+        for (Profession profession : Profession.getProfessions().values()) {
+            String blockId = profession.getBlockID();
+            map.putIfAbsent(blockId, new PoiType("job_site:" + blockId, Set.of(blockId), state -> true, 1, blockId));
+        }
+        Map<String, PoiType> names = new HashMap<>();
+        for (PoiType type : map.values()) {
+            names.put(type.name(), type);
+        }
+        byName = names;
+        return map;
+    }
+}


### PR DESCRIPTION
## Description
Implemented an initial version of a POI (Point of Interest) system for villagers, aimed at improving AI performance.

## Problem
Currently, once more than 15 villagers are present at the same time, server TPS drops significantly due to the computational cost of villager AI (pathfinding, interactions, etc.).

## Solution
Introduced a POI system that:
- Reduces the computational load related to villager behaviors
- Prevents TPS drops even with a high number of villagers
- Lays a scalable foundation for future AI optimizations

## Current status
This is an initial implementation (WIP). Only a base version of the POI system has been added for now.

## Future work
- Implement additional POI types to further refine and expand villager AI behaviors
- Continue optimizing performance based on testing results

## Testing done
https://youtu.be/DMt2bIcNBlA?is=jLDvw7AeWN8Wgen0