### PR TITLE
fix: NPE when a player kicks themselves during tick

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -2899,6 +2899,13 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         if (this.spawned) {
             this.drainInboundPackets();
 
+            // Draining packets can execute a command (e.g. kicking yourself) that closes this
+            // player synchronously, nulling the inventory. Bail out before touching any further
+            // player state in this tick, otherwise getInventory() below throws an NPE.
+            if (!this.loggedIn) {
+                return true;
+            }
+
             if (this.pendingClose != null) {
                 final String closeReason = this.pendingClose;
                 this.pendingClose = null;

--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -2899,9 +2899,8 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         if (this.spawned) {
             this.drainInboundPackets();
 
-            // Draining packets can execute a command (e.g. kicking yourself) that closes this
-            // player synchronously, nulling the inventory. Bail out before touching any further
-            // player state in this tick, otherwise getInventory() below throws an NPE.
+            // Draining may close the player synchronously (e.g. self-kick), nulling the
+            // inventory; bail out before the getInventory() access below throws an NPE.
             if (!this.loggedIn) {
                 return true;
             }


### PR DESCRIPTION
Draining inbound packets can execute a command that closes the player synchronously (e.g. kicking yourself), nulling the inventory while the tick is still inside the spawned branch. onUpdate then called getInventory().getItemInMainHand() on a null inventory. Bail out of the tick right after draining packets when the player is no longer logged in.