### PR TITLE
fix: preserve unknown block identity in chunk palette and improve logging

### DIFF
--- a/src/main/java/org/powernukkitx/level/format/leveldb/LevelDBChunkSerializer.java
+++ b/src/main/java/org/powernukkitx/level/format/leveldb/LevelDBChunkSerializer.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Supplier;
 
 /**
  * Allay Project 8/23/2023
@@ -212,14 +213,22 @@ public class LevelDBChunkSerializer {
                                 Arrays.fill(palettes, new BlockPalette(BlockAir.STATE, new ReferenceArrayList<>(16), BitArrayVersion.V2));
                                 section = new ChunkSection((byte) ySection, palettes);
                             }
+                            final int sectionY = ySection;
                             for (int layer = 0; layer < layers; layer++) {
+                                final int currentLayer = layer;
+                                final Supplier<String> locationHint = log.isDebugEnabled()
+                                        ? () -> "level=" + builder.getLevelProvider().getName()
+                                                + " dim=" + dimensionInfo.getDimensionName()
+                                                + " chunk=(" + builder.getChunkX() + "," + builder.getChunkZ() + ")"
+                                                + " sectionY=" + sectionY + " layer=" + currentLayer
+                                        : null;
                                 section.blockLayer()[layer].readFromStoragePersistent(byteBuf, hash -> {
                                     BlockState blockState = Registries.BLOCKSTATE.get(hash);
                                     if (blockState == null) {
                                         return BlockUnknown.PROPERTIES.getDefaultState();
                                     }
                                     return blockState;
-                                });
+                                }, locationHint);
                             }
                             sections[ySection - minSectionY] = section;
                     }

--- a/src/main/java/org/powernukkitx/level/format/palette/Palette.java
+++ b/src/main/java/org/powernukkitx/level/format/palette/Palette.java
@@ -15,7 +15,6 @@ import org.powernukkitx.utils.SemVersion;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
-import it.unimi.dsi.fastutil.Pair;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import lombok.extern.slf4j.Slf4j;
 import org.cloudburstmc.nbt.NBTInputStream;
@@ -31,6 +30,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.TreeMap;
+import java.util.function.Supplier;
 
 @Slf4j
 public class Palette<V> {
@@ -171,19 +171,23 @@ public class Palette<V> {
     }
 
     public void readFromStoragePersistent(ByteBuf byteBuf, RuntimeDataDeserializer<V> deserializer) {
+        readFromStoragePersistent(byteBuf, deserializer, null);
+    }
+
+    public void readFromStoragePersistent(ByteBuf byteBuf, RuntimeDataDeserializer<V> deserializer, Supplier<String> locationHint) {
         try (final ByteBufInputStream bufInputStream = new ByteBufInputStream(byteBuf)) {
             final BitArrayVersion bversion = readBitArrayVersion(byteBuf);
             if (bversion == BitArrayVersion.V0) {
                 this.bitArray = bversion.createArray(ChunkSection.SIZE, null);
                 this.clearPalette();
-                addBlockPalette(byteBuf, deserializer);
+                addBlockPalette(byteBuf, deserializer, locationHint);
                 this.onResize(BitArrayVersion.V2);
                 return;
             }
             readWords(byteBuf, bversion);
             final int paletteSize = byteBuf.readIntLE();
             for (int i = 0; i < paletteSize; i++) {
-                addBlockPalette(byteBuf, deserializer);
+                addBlockPalette(byteBuf, deserializer, locationHint);
             }
         } catch (IOException e) {
             log.error("Failed to read palette from storage", e);
@@ -256,7 +260,8 @@ public class Palette<V> {
     }
 
     @SuppressWarnings("unchecked")
-    protected void addBlockPalette(ByteBuf byteBuf, RuntimeDataDeserializer<V> deserializer) throws IOException {
+    protected void addBlockPalette(ByteBuf byteBuf, RuntimeDataDeserializer<V> deserializer, Supplier<String> locationHint) throws IOException {
+        byteBuf.markReaderIndex();
         try (final ByteBufInputStream inputStream = new ByteBufInputStream(byteBuf);
              final NBTInputStream nbtInputStream = NbtUtils.createReaderLE(inputStream)) {
             NbtMap blockTag = (NbtMap) nbtInputStream.readTag();
@@ -265,14 +270,8 @@ public class Palette<V> {
             builder.remove("version");
             blockTag = builder.build();
             final int blockRuntimeId = HashUtils.fnv1a_32_nbt(blockTag);
-            final Pair<Integer, SemVersion> p = Pair.of(blockRuntimeId, null);
 
             final V unknownState = (V) BlockUnknown.PROPERTIES.getDefaultState();
-
-            if (p == null) {
-                this.addToPalette(unknownState);
-                return;
-            }
 
             V resultingBlockState = unknownState;
 
@@ -286,16 +285,12 @@ public class Palette<V> {
 
             boolean isBlockOutdated = false;
 
-            if (p.left() == null) {     // is blockStateHash null
+            V currentState = deserializer.deserialize(blockRuntimeId);
+            if (blockRuntimeId != -2 && Objects.equals(currentState, unknownState)) {
+                byteBuf.resetReaderIndex();
                 isBlockOutdated = true;
             } else {
-                V currentState = deserializer.deserialize(blockRuntimeId);
-                if (blockRuntimeId != -2 && Objects.equals(currentState, unknownState)) {
-                    byteBuf.resetReaderIndex();
-                    isBlockOutdated = true;
-                } else {
-                    resultingBlockState = currentState;
-                }
+                resultingBlockState = currentState;
             }
 
             if (isBlockOutdated) {
@@ -313,16 +308,25 @@ public class Palette<V> {
 
                     resultingBlockState = deserializer.deserialize(hash);
 
-                    // we send a warning if the resultingBlockState is null or unknown after updating it.
-                    // this way the only possibility is that the block hash is not represented in block_palette.nbt
                     if (resultingBlockState == null || Objects.equals(resultingBlockState, unknownState)) {
-                        resultingBlockState = unknownState;
-                        log.debug("Block State updating failed, blockHash: {}, oldBlockState: {}, newBlockState: {}, blockTag: {}", HashUtils.fnv1a_32_nbt(oldBlockNbt), oldBlockNbt, newBlockNbt, blockTag);
+                        final NbtMap preservedTag = newBlockNbt.toBuilder()
+                                .putInt("version", version)
+                                .build();
+                        resultingBlockState = (V) BlockState.makeUnknownBlockState(hash, preservedTag);
+
+                        if (log.isDebugEnabled()) {
+                            final String name = newBlockNbt.getString("name");
+                            if (!name.isEmpty()) {
+                                final String location = locationHint != null ? locationHint.get() : "<unknown>";
+                                log.debug("Block state did not resolve after updating; preserved as unknown. name: '{}', hash: {}, location: {}, originalState: {}, updatedState: {}",
+                                    name, hash, location, oldBlockNbt, newBlockNbt);
+                            }
+                        }
                     }
                 }
             }
 
-            if (Objects.equals(resultingBlockState, unknownState)) {
+            if (resultingBlockState instanceof BlockState bs && bs.getIdentifier().equals(BlockID.UNKNOWN)) {
                 boolean replaceWithUnknown = Server.getInstance().getSettings().baseSettings().saveUnknownBlock();
                 if (replaceWithUnknown) {
                     this.addToPalette(resultingBlockState);

--- a/src/test/java/org/powernukkitx/level/LevelStorageTest.java
+++ b/src/test/java/org/powernukkitx/level/LevelStorageTest.java
@@ -1,16 +1,22 @@
 package org.powernukkitx.level;
 
+import org.powernukkitx.Server;
 import org.powernukkitx.block.BlockAir;
+import org.powernukkitx.block.BlockID;
 import org.powernukkitx.block.BlockOakLog;
 import org.powernukkitx.block.BlockState;
+import org.powernukkitx.block.BlockUnknown;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.level.format.leveldb.LevelDBProvider;
 import org.powernukkitx.level.format.palette.Palette;
+import org.powernukkitx.network.NetworkConstants;
 import org.powernukkitx.registry.Registries;
+import org.powernukkitx.utils.HashUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import lombok.SneakyThrows;
 import org.apache.commons.io.FileUtils;
+import org.cloudburstmc.nbt.NbtMap;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -18,6 +24,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -82,7 +89,58 @@ public class LevelStorageTest {
         Assertions.assertNotNull(levelDBProvider.getLevelData());
         Assertions.assertEquals("Bedrock level", levelDBProvider.getLevelData().getName());
     }
-    
+
+
+    @Order(4)
+    @Test
+    void testUnknownBlockIdentityPreservedOnRoundTrip() {
+        // Simulate a custom/removed block that has no implementation: a real name + states
+        final String customName = "powernukkitx:test_unknown_block";
+        final NbtMap identity = NbtMap.builder()
+                .putString("name", customName)
+                .putCompound("states", NbtMap.builder().putInt("test_state", 3).build())
+                .build();
+        final int hash = HashUtils.fnv1a_32_nbt(identity);
+        final NbtMap blockTag = identity.toBuilder()
+                .putInt("version", NetworkConstants.BLOCK_STATE_VERSION_NO_REVISION)
+                .build();
+        final BlockState unknown = BlockState.makeUnknownBlockState(hash, blockTag);
+
+        // In memory, the unknown state carries the original identity under the "Block" compound
+        Assertions.assertEquals(customName, unknown.getBlockStateTag().getCompound("Block").getString("name"));
+
+        // Write a single-entry palette containing that unknown block to storage...
+        final Palette<BlockState> palette = new Palette<>(unknown);
+        final ByteBuf buf = ByteBufAllocator.DEFAULT.ioBuffer();
+        palette.writeToStoragePersistent(buf, BlockState::getBlockStateTag);
+
+        // ...and read it back with the same deserializer the chunk loader uses:
+        // an unresolved hash maps to the generic unknown default, which is what triggers
+        // the preserve-or-lose branch in addBlockPalette. The unknown-block path consults
+        // Server settings (saveUnknownBlock), so stub the singleton for this unit test
+        final Server server = Mockito.mock(Server.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(server.getSettings().baseSettings().saveUnknownBlock()).thenReturn(true);
+        final Palette<BlockState> reloaded = new Palette<>(BlockAir.STATE);
+        try (MockedStatic<Server> mocked = Mockito.mockStatic(Server.class)) {
+            mocked.when(Server::getInstance).thenReturn(server);
+            reloaded.readFromStoragePersistent(buf, hashKey -> {
+                BlockState bs = Registries.BLOCKSTATE.get(hashKey);
+                return bs == null ? BlockUnknown.PROPERTIES.getDefaultState() : bs;
+            });
+        }
+        buf.release();
+
+        final BlockState result = reloaded.get(0);
+        Assertions.assertEquals(BlockID.UNKNOWN, result.getIdentifier());
+
+        // The critical assertion: the block's original identity survived the round-trip
+        // instead of being destroyed into an empty tag.
+        final NbtMap preserved = result.getBlockStateTag().getCompound("Block");
+        Assertions.assertEquals(customName, preserved.getString("name"),
+                "Unknown block lost its name on the save/load round-trip");
+        Assertions.assertEquals(3, preserved.getCompound("states").getInt("test_state"),
+                "Unknown block lost its states on the save/load round-trip");
+    }
 
     @Order(8)
     @Test


### PR DESCRIPTION
This PR fixes the block state updater so Unknown blocks no longer loose the "Block" identity when saved to disk.
Additionally, it improves logging by adding position, changing the wording a bit, and dropping empty blocks without recoverable identity to prevent log spam.
Finally, it also adds a test to verify that the block state updater is able to recover blocks.

To test this in-game, install a plugin implementing a custom block, place it on a world, restart the server without the plugin, force the chunk to get saved to disk, restart the server with the plugin again. If the block recovers, the changes work. `saveUnknownBlock` must be enabled in `pnx.yml` for this to work. Also set your log level to DEBUG if you want to verify them too.

AI usage: [Test](https://github.com/PowerNukkitX/PowerNukkitX/commit/7e48092c4ec3094c1eef83d0efd27775b66e690b) by Claude Opus 4.8