### PR TITLE
Fix memory leaks, stability bugs and hot path performance

### DIFF
--- a/src/main/java/org/powernukkitx/block/BlockProperties.java
+++ b/src/main/java/org/powernukkitx/block/BlockProperties.java
@@ -142,7 +142,9 @@ public final class BlockProperties {
     }
 
     public boolean containBlockState(BlockState blockState) {
-        return this.specialValueMap.containsValue(blockState);
+        if (blockState == null) return false;
+        BlockState canonical = this.specialValueMap.get(blockState.specialValue());
+        return canonical != null && canonical.equals(blockState);
     }
 
     public boolean containBlockState(short specialValue) {

--- a/src/main/java/org/powernukkitx/blockentity/BlockEntityChest.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntityChest.java
@@ -1,5 +1,6 @@
 package org.powernukkitx.blockentity;
 
+import org.powernukkitx.Player;
 import org.powernukkitx.block.BlockChest;
 import org.powernukkitx.block.copper.chest.BlockCopperChest;
 import org.powernukkitx.inventory.BaseInventory;
@@ -10,6 +11,7 @@ import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.math.Vector3;
 import org.powernukkitx.nbt.tag.CompoundTag;
 
+import java.util.HashSet;
 import java.util.Objects;
 
 /**
@@ -33,10 +35,15 @@ public class BlockEntityChest extends BlockEntitySpawnableContainer {
         if (!closed) {
             DoubleChestInventory dblInv = this.doubleInventory;
             if (dblInv != null) {
-                dblInv.getViewers().forEach(p -> p.removeWindow(dblInv));
+                for (Player player : new HashSet<>(dblInv.getViewers())) {
+                    player.removeWindow(dblInv);
+                }
                 this.doubleInventory = null;
             }
-            this.getRealInventory().getViewers().forEach(p -> p.removeWindow(this.getRealInventory()));
+            ChestInventory realInv = this.getRealInventory();
+            for (Player player : new HashSet<>(realInv.getViewers())) {
+                player.removeWindow(realInv);
+            }
 
             this.closed = true;
             if (this.chunk != null) {

--- a/src/main/java/org/powernukkitx/blockentity/BlockEntitySpawnableContainer.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntitySpawnableContainer.java
@@ -1,5 +1,6 @@
 package org.powernukkitx.blockentity;
 
+import org.powernukkitx.Player;
 import org.powernukkitx.block.BlockAir;
 import org.powernukkitx.inventory.ContainerInventory;
 import org.powernukkitx.item.Item;
@@ -9,6 +10,8 @@ import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.nbt.tag.ListTag;
 import org.powernukkitx.nbt.tag.Tag;
 import org.powernukkitx.utils.ItemHelper;
+
+import java.util.HashSet;
 public abstract class BlockEntitySpawnableContainer extends BlockEntitySpawnable implements BlockEntityInventoryHolder {
     protected ContainerInventory inventory;
 
@@ -35,7 +38,9 @@ public abstract class BlockEntitySpawnableContainer extends BlockEntitySpawnable
     @Override
     public void close() {
         if (!closed) {
-            this.getInventory().getViewers().forEach(p -> p.removeWindow(this.getInventory()));
+            for (Player player : new HashSet<>(this.getInventory().getViewers())) {
+                player.removeWindow(this.getInventory());
+            }
             super.close();
         }
     }

--- a/src/main/java/org/powernukkitx/entity/EntityPhysical.java
+++ b/src/main/java/org/powernukkitx/entity/EntityPhysical.java
@@ -22,7 +22,6 @@ import org.powernukkitx.math.Vector2;
 import org.powernukkitx.math.Vector2f;
 import org.powernukkitx.math.Vector3;
 import org.powernukkitx.nbt.tag.CompoundTag;
-import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import lombok.extern.slf4j.Slf4j;
 import org.cloudburstmc.protocol.bedrock.data.PlayerAuthInputData;
 import org.cloudburstmc.protocol.bedrock.data.actor.ActorFlags;
@@ -376,24 +375,19 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
             }
         }
 
-        var dxPositives = new DoubleArrayList(size);
-        var dxNegatives = new DoubleArrayList(size);
-        var dzPositives = new DoubleArrayList(size);
-        var dzNegatives = new DoubleArrayList(size);
+        double dxPosMax = Double.NEGATIVE_INFINITY;
+        double dxNegMax = Double.NEGATIVE_INFINITY;
+        double dzPosMax = Double.NEGATIVE_INFINITY;
+        double dzNegMax = Double.NEGATIVE_INFINITY;
 
-        var stream = collidingEntities.stream();
-        if (size > 4) {
-            stream = stream.parallel();
-        }
-
-        stream.forEach(each -> {
+        for (Entity each : collidingEntities) {
             AxisAlignedBB targetAABB;
             if (each instanceof EntityPhysical entityPhysical) {
                 targetAABB = entityPhysical.getOffsetBoundingBox();
             } else if (each instanceof Player player) {
                 targetAABB = player.reCalcOffsetBoundingBox();
             } else {
-                return;
+                continue;
             }
 
             double centerXWidth = (targetAABB.getMaxX() + targetAABB.getMinX() - selfAABB.getMaxX() - selfAABB.getMinX()) * 0.5;
@@ -401,26 +395,32 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
 
             if (centerXWidth > 0) {
                 double value = (targetAABB.getMaxX() - targetAABB.getMinX()) + (selfAABB.getMaxX() - selfAABB.getMinX()) * 0.5 - centerXWidth;
-                dxPositives.add(value);
+                if (value > dxPosMax) dxPosMax = value;
             } else {
                 double value = (targetAABB.getMaxX() - targetAABB.getMinX()) + (selfAABB.getMaxX() - selfAABB.getMinX()) * 0.5 + centerXWidth;
-                dxNegatives.add(value);
+                if (value > dxNegMax) dxNegMax = value;
             }
 
             if (centerZWidth > 0) {
                 double value = (targetAABB.getMaxZ() - targetAABB.getMinZ()) + (selfAABB.getMaxZ() - selfAABB.getMinZ()) * 0.5 - centerZWidth;
-                dzPositives.add(value);
+                if (value > dzPosMax) dzPosMax = value;
             } else {
                 double value = (targetAABB.getMaxZ() - targetAABB.getMinZ()) + (selfAABB.getMaxZ() - selfAABB.getMinZ()) * 0.5 + centerZWidth;
-                dzNegatives.add(value);
+                if (value > dzNegMax) dzNegMax = value;
             }
-        });
+        }
 
-        double resultX = (size > 4 ? dxPositives.doubleParallelStream() : dxPositives.doubleStream()).max().orElse(0)
-                - (size > 4 ? dxNegatives.doubleParallelStream() : dxNegatives.doubleStream()).max().orElse(0);
-        double resultZ = (size > 4 ? dzPositives.doubleParallelStream() : dzPositives.doubleStream()).max().orElse(0)
-                - (size > 4 ? dzNegatives.doubleParallelStream() : dzNegatives.doubleStream()).max().orElse(0);
+        double resultX = (dxPosMax == Double.NEGATIVE_INFINITY ? 0 : dxPosMax)
+                - (dxNegMax == Double.NEGATIVE_INFINITY ? 0 : dxNegMax);
+        double resultZ = (dzPosMax == Double.NEGATIVE_INFINITY ? 0 : dzPosMax)
+                - (dzNegMax == Double.NEGATIVE_INFINITY ? 0 : dzNegMax);
         double len = Math.sqrt(resultX * resultX + resultZ * resultZ);
+
+        if (Double.isNaN(len) || len <= 0) {
+            this.previousCollideMotion.setX(0);
+            this.previousCollideMotion.setZ(0);
+            return;
+        }
 
         double finalX = -(resultX / len * 0.2 * 0.32);
         double finalZ = -(resultZ / len * 0.2 * 0.32);

--- a/src/main/java/org/powernukkitx/entity/ai/sensor/NearestEntitySensor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/sensor/NearestEntitySensor.java
@@ -3,6 +3,8 @@ package org.powernukkitx.entity.ai.sensor;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityIntelligent;
 import org.powernukkitx.entity.ai.memory.MemoryType;
+import org.powernukkitx.level.Level;
+import org.powernukkitx.math.NukkitMath;
 import lombok.Getter;
 
 //Memory that stores the nearest player
@@ -36,17 +38,25 @@ public class NearestEntitySensor implements ISensor {
     @Override
     public void sense(EntityIntelligent entity) {
         Entity ent = null;
+        double nearestSquared = 0;
         double rangeSquared = this.range * this.range;
         double minRangeSquared = this.minRange * this.minRange;
+        Level level = entity.getLevel();
+        int minChunkX = NukkitMath.floorDouble((entity.x - this.range - 2) * 0.0625);
+        int maxChunkX = NukkitMath.ceilDouble((entity.x + this.range + 2) * 0.0625);
+        int minChunkZ = NukkitMath.floorDouble((entity.z - this.range - 2) * 0.0625);
+        int maxChunkZ = NukkitMath.ceilDouble((entity.z + this.range + 2) * 0.0625);
         //Find the nearest player within range
-        for (Entity e : entity.getLevel().getEntities()) {
-            if(entityClass.isAssignableFrom(e.getClass())) {
-                if (entity.distanceSquared(e) <= rangeSquared && entity.distanceSquared(e) >= minRangeSquared) {
-                    if (ent == null) {
-                        ent = e;
-                    } else {
-                        if (entity.distanceSquared(e) < entity.distanceSquared(ent)) {
-                            ent = e;
+        for (int chunkX = minChunkX; chunkX <= maxChunkX; ++chunkX) {
+            for (int chunkZ = minChunkZ; chunkZ <= maxChunkZ; ++chunkZ) {
+                for (Entity e : level.getChunkEntities(chunkX, chunkZ, false).values()) {
+                    if(entityClass.isAssignableFrom(e.getClass())) {
+                        double distanceSquared = entity.distanceSquared(e);
+                        if (distanceSquared <= rangeSquared && distanceSquared >= minRangeSquared) {
+                            if (ent == null || distanceSquared < nearestSquared) {
+                                ent = e;
+                                nearestSquared = distanceSquared;
+                            }
                         }
                     }
                 }

--- a/src/main/java/org/powernukkitx/entity/ai/sensor/NearestItemSensor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/sensor/NearestItemSensor.java
@@ -6,6 +6,8 @@ import org.powernukkitx.entity.EntityIntelligent;
 import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
 import org.powernukkitx.entity.item.EntityItem;
 import org.powernukkitx.item.Item;
+import org.powernukkitx.level.Level;
+import org.powernukkitx.math.NukkitMath;
 import lombok.Getter;
 
 //Memory that stores the nearest player
@@ -37,18 +39,26 @@ public class NearestItemSensor implements ISensor {
         if(itemClass == null) return;
 
         EntityItem item = null;
+        double nearestSquared = 0;
         double rangeSquared = this.range * this.range;
         double minRangeSquared = this.minRange * this.minRange;
+        Level level = entity.getLevel();
+        int minChunkX = NukkitMath.floorDouble((entity.x - this.range - 2) * 0.0625);
+        int maxChunkX = NukkitMath.ceilDouble((entity.x + this.range + 2) * 0.0625);
+        int minChunkZ = NukkitMath.floorDouble((entity.z - this.range - 2) * 0.0625);
+        int maxChunkZ = NukkitMath.ceilDouble((entity.z + this.range + 2) * 0.0625);
         //Find the nearest player within range
-        for (Entity e : entity.getLevel().getEntities()) {
-            if(e instanceof EntityItem entityItem) {
-                if(itemClass.isAssignableFrom(entityItem.getItem().getClass())) {
-                    if (entity.distanceSquared(e) <= rangeSquared && entity.distanceSquared(e) >= minRangeSquared) {
-                        if (item == null) {
-                            item = entityItem;
-                        } else {
-                            if (entity.distanceSquared(entityItem) < entity.distanceSquared(item)) {
-                                 item = entityItem;
+        for (int chunkX = minChunkX; chunkX <= maxChunkX; ++chunkX) {
+            for (int chunkZ = minChunkZ; chunkZ <= maxChunkZ; ++chunkZ) {
+                for (Entity e : level.getChunkEntities(chunkX, chunkZ, false).values()) {
+                    if(e instanceof EntityItem entityItem) {
+                        if(itemClass.isAssignableFrom(entityItem.getItem().getClass())) {
+                            double distanceSquared = entity.distanceSquared(e);
+                            if (distanceSquared <= rangeSquared && distanceSquared >= minRangeSquared) {
+                                if (item == null || distanceSquared < nearestSquared) {
+                                    item = entityItem;
+                                    nearestSquared = distanceSquared;
+                                }
                             }
                         }
                     }

--- a/src/main/java/org/powernukkitx/entity/ai/sensor/NearestTargetEntitySensor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/sensor/NearestTargetEntitySensor.java
@@ -3,6 +3,8 @@ package org.powernukkitx.entity.ai.sensor;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityIntelligent;
 import org.powernukkitx.entity.ai.memory.MemoryType;
+import org.powernukkitx.level.Level;
+import org.powernukkitx.math.NukkitMath;
 import org.powernukkitx.utils.SortedList;
 
 import java.util.ArrayList;
@@ -63,6 +65,11 @@ public class NearestTargetEntitySensor<T extends Entity> implements ISensor {
     public void sense(EntityIntelligent entity) {
         double minRangeSquared = this.minRange * this.minRange;
         double maxRangeSquared = this.maxRange * this.maxRange;
+        Level level = entity.getLevel();
+        int minChunkX = NukkitMath.floorDouble((entity.x - this.maxRange - 2) * 0.0625);
+        int maxChunkX = NukkitMath.ceilDouble((entity.x + this.maxRange + 2) * 0.0625);
+        int minChunkZ = NukkitMath.floorDouble((entity.z - this.maxRange - 2) * 0.0625);
+        int maxChunkZ = NukkitMath.ceilDouble((entity.z + this.maxRange + 2) * 0.0625);
 
         if (allTargetFunction == null && memories.size() == 1) {
             var currentMemory = memories.get(0);
@@ -71,9 +78,14 @@ public class NearestTargetEntitySensor<T extends Entity> implements ISensor {
 
             //Find the nearest entity within range
             var entities = Collections.synchronizedList(new SortedList<>(Comparator.comparingDouble((Entity e) -> e.distanceSquared(entity))));
-            for (Entity p : entity.getLevel().getEntities()) {
-                if (entity.distanceSquared(p) <= maxRangeSquared && entity.distanceSquared(p) >= minRangeSquared && !p.equals(entity)) {
-                    entities.add(p);
+            for (int chunkX = minChunkX; chunkX <= maxChunkX; ++chunkX) {
+                for (int chunkZ = minChunkZ; chunkZ <= maxChunkZ; ++chunkZ) {
+                    for (Entity p : level.getChunkEntities(chunkX, chunkZ, false).values()) {
+                        double distanceSquared = entity.distanceSquared(p);
+                        if (distanceSquared <= maxRangeSquared && distanceSquared >= minRangeSquared && !p.equals(entity)) {
+                            entities.add(p);
+                        }
+                    }
                 }
             }
 
@@ -89,16 +101,21 @@ public class NearestTargetEntitySensor<T extends Entity> implements ISensor {
                 sortEntities.add(new SortedList<>(Comparator.comparingDouble((Entity e) -> e.distanceSquared(entity))));
             }
 
-            for (Entity p : entity.getLevel().getEntities()) {
-                if (entity.distanceSquared(p) <= maxRangeSquared && entity.distanceSquared(p) >= minRangeSquared && !p.equals(entity)) {
-                    int i = 0;
-                    for (var targetFunction : allTargetFunction) {
-                        @SuppressWarnings("unchecked")
-                        T castedP = (T) p;
-                        if (targetFunction.apply(castedP)) {
-                            sortEntities.get(i).add(p);
+            for (int chunkX = minChunkX; chunkX <= maxChunkX; ++chunkX) {
+                for (int chunkZ = minChunkZ; chunkZ <= maxChunkZ; ++chunkZ) {
+                    for (Entity p : level.getChunkEntities(chunkX, chunkZ, false).values()) {
+                        double distanceSquared = entity.distanceSquared(p);
+                        if (distanceSquared <= maxRangeSquared && distanceSquared >= minRangeSquared && !p.equals(entity)) {
+                            int i = 0;
+                            for (var targetFunction : allTargetFunction) {
+                                @SuppressWarnings("unchecked")
+                                T castedP = (T) p;
+                                if (targetFunction.apply(castedP)) {
+                                    sortEntities.get(i).add(p);
+                                }
+                                ++i;
+                            }
                         }
-                        ++i;
                     }
                 }
             }

--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -123,6 +123,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -733,10 +734,11 @@ public class Level implements Metadatable {
         this.scheduler.mainThreadHeartbeat(this.getTick() + 10000);
         this.server.getLevels().remove(this.levelId);
         LevelProvider levelProvider = this.provider.get();
+        if (levelProvider != null && this.getAutoSave()) {
+            this.save(true);
+        }
+        this.scheduler.close();
         if (levelProvider != null) {
-            if (this.getAutoSave()) {
-                this.save(true);
-            }
             levelProvider.close();
         }
         this.provider.set(null);
@@ -1077,21 +1079,21 @@ public class Level implements Metadatable {
         if (chunkLoadersIndex != null) {
             ChunkLoader oldLoader = chunkLoadersIndex.remove(loaderId);
             if (oldLoader != null) {
-                if (chunkLoadersIndex.isEmpty()) {
+                boolean becameEmpty = chunkLoadersIndex.isEmpty();
+                if (becameEmpty) {
                     this.chunkLoaders.remove(chunkHash);
-                    return this.unloadChunkRequest(chunkX, chunkZ, isSafeUnload);
                 }
 
                 synchronized (this.loaders) {
                     int count = this.loaderCounter.get(loaderId);
-                    if (--count == 0) {
+                    if (--count <= 0) {
                         this.loaderCounter.remove(loaderId);
                         this.loaders.remove(loaderId);
                     } else {
                         this.loaderCounter.put(loaderId, count);
                     }
                 }
-                return true;
+                return becameEmpty ? this.unloadChunkRequest(chunkX, chunkZ, isSafeUnload) : true;
             }
             return false;
         }
@@ -1137,8 +1139,14 @@ public class Level implements Metadatable {
             return;
         }
         synchronized (this.tickCachedBlocks) {
-            for (var each : tickCachedBlocks.values()) {
-                each.clearCachedStore();
+            var iterator = tickCachedBlocks.values().iterator();
+            while (iterator.hasNext()) {
+                var each = iterator.next();
+                if (each.isCachedStoreEmpty()) {
+                    iterator.remove();
+                } else {
+                    each.clearCachedStore();
+                }
             }
         }
     }
@@ -1943,11 +1951,9 @@ public class Level implements Metadatable {
     /** Per-chunk tick work: entity update scheduling, scheduled block updates, random ticks. */
     private void tickChunk(IChunk chunk, int tickSpeed) {
         if (chunk.hasEntities()) {
-            CompletableFuture.runAsync(() -> {
-                for (Entity entity : chunk.getEntities().values()) {
-                    entity.scheduleUpdate();
-                }
-            });
+            for (Entity entity : chunk.getEntities().values()) {
+                entity.scheduleUpdate();
+            }
         }
 
         chunk.getBlockUpdateScheduler().tick(this.getCurrentTick());
@@ -2671,20 +2677,34 @@ public class Level implements Metadatable {
 
         int minY = getDimensionData().getMinHeight();
         int maxY = getDimensionData().getMaxHeight();
+        int lcx = x & 0xF;
+        int lcz = z & 0xF;
+        UnsafeChunk unsafeChunk = chunk.isFinished() ? null : new UnsafeChunk((Chunk) chunk);
         int level = 15;
 
-        for (int _y = maxY; _y >= minY; _y--) {
-            Block block = getBlock(x, _y, z);
-            if (!block.isTransparent()) {
+        int _y = maxY;
+        for (; _y >= minY; _y--) {
+            BlockState state = unsafeChunk == null
+                    ? chunk.getBlockState(lcx, _y, lcz, 0)
+                    : unsafeChunk.getBlockState(lcx, _y, lcz, 0);
+            int packed = BlockLightProperties.packed(state);
+            if (!BlockLightProperties.isTransparent(packed)) {
                 level = 0;
-            } else if (block.diffusesSkyLight()) {
+            } else if (BlockLightProperties.diffusesSkyLight(packed)) {
                 level--;
             } else {
-                level -= block.getLightLevel();
+                level -= BlockLightProperties.lightLevel(packed);
             }
-            if (level <= 0) level = 0;
             //if(_y != height && !block.canPassThrough() && block.up().canPassThrough()) addSkyLightUpdate(x, _y+1, z); ToDo: Light Spread
-            setBlockSkyLightAt(x, _y, z, level);
+            if (level <= 0) {
+                level = 0;
+                break;
+            }
+            chunk.setBlockSkyLight(lcx, _y, lcz, level);
+        }
+
+        for (; _y >= minY; _y--) {
+            chunk.setBlockSkyLight(lcx, _y, lcz, 0);
         }
     }
 
@@ -4614,8 +4634,15 @@ public class Level implements Metadatable {
 
 
     public CompletableFuture<IChunk> getChunkAsync(int chunkX, int chunkZ, boolean create) {
+        long index = Level.chunkHash(chunkX, chunkZ);
+        LevelProvider levelProvider = this.provider.get();
+        if (levelProvider != null) {
+            IChunk loaded = levelProvider.getLoadedChunk(index);
+            if (loaded != null) {
+                return CompletableFuture.completedFuture(loaded);
+            }
+        }
         return CompletableFuture.supplyAsync(() -> {
-            long index = Level.chunkHash(chunkX, chunkZ);
             IChunk chunk = this.requireProvider().getLoadedChunk(index);
             if (chunk == null) {
                 chunk = this.forceLoadChunk(index, chunkX, chunkZ, create);
@@ -5024,37 +5051,83 @@ public class Level implements Metadatable {
         }
         long index = Level.chunkHash(x, z);
         if (this.chunkGenerationQueue.putIfAbsent(index, Boolean.TRUE) == null) {
-            final IChunk chunk = this.getChunk(x, z, true);
-            if (chunk != null && chunk.getChunkState().canSend()) {
-                this.chunkGenerationQueue.remove(index);
-                log.warn("generateChunk called on already-sendable chunk ({}, {}) in level '{}' with state {}. This is a bug - please report it ASAP!",
-                        x, z, getFolderName(), chunk.getChunkState(), new RuntimeException("generateChunk guard triggered"));
-                return;
+            final AtomicBoolean released = new AtomicBoolean(false);
+            boolean scheduled = false;
+            try {
+                final IChunk chunk = this.getChunk(x, z, true);
+                if (chunk == null) {
+                    return;
+                }
+                if (chunk.getChunkState().canSend()) {
+                    log.warn("generateChunk called on already-sendable chunk ({}, {}) in level '{}' with state {}. This is a bug - please report it ASAP!",
+                            x, z, getFolderName(), chunk.getChunkState(), new RuntimeException("generateChunk guard triggered"));
+                    return;
+                }
+                this.generator.asyncGenerate(chunk, (c) -> {
+                    if (released.compareAndSet(false, true)) {
+                        GENERATED_CHUNK_COUNT.incrementAndGet();
+                        chunkGenerationQueue.remove(c.getChunk().getIndex());
+                    }
+                });
+                scheduled = true;
+            } finally {
+                if (!scheduled && released.compareAndSet(false, true)) {
+                    this.chunkGenerationQueue.remove(index);
+                }
             }
-            this.generator.asyncGenerate(chunk, (c) -> {
-                GENERATED_CHUNK_COUNT.incrementAndGet();
-                chunkGenerationQueue.remove(c.getChunk().getIndex());
-            });
         }
     }
 
     public void syncGenerateChunk(int x, int z) {
         long index = Level.chunkHash(x, z);
-        if (isChunkGenerating(x, z) && getChunk(x, z, false).getChunkState() == ChunkState.NEW)
-            removeFromGenerateList(x, z);
-        if (this.chunkGenerationQueue.putIfAbsent(index, Boolean.TRUE) == null) {
-            IChunk chunk = this.getChunk(x, z, true);
-            if (chunk != null && chunk.getChunkState().canSend()) {
-                this.chunkGenerationQueue.remove(index);
-                log.warn("syncGenerateChunk called on already-sendable chunk ({}, {}) in level '{}' with state {}. This is a bug - please report it ASAP!",
-                        x, z, getFolderName(), chunk.getChunkState(), new RuntimeException("syncGenerateChunk guard triggered"));
-                return;
-            }
-            this.generator.syncGenerate(chunk);
-            GENERATED_CHUNK_COUNT.incrementAndGet();
-            chunkGenerationQueue.remove(index);
+        if (isChunkGenerating(x, z)) {
+            IChunk generating = this.getChunk(x, z, false);
+            if (generating != null && generating.getChunkState() == ChunkState.NEW)
+                removeFromGenerateList(x, z);
         }
-        while (isChunkGenerating(x, z));
+        if (this.chunkGenerationQueue.putIfAbsent(index, Boolean.TRUE) == null) {
+            try {
+                IChunk chunk = this.getChunk(x, z, true);
+                if (chunk == null) {
+                    return;
+                }
+                if (chunk.getChunkState().canSend()) {
+                    log.warn("syncGenerateChunk called on already-sendable chunk ({}, {}) in level '{}' with state {}. This is a bug - please report it ASAP!",
+                            x, z, getFolderName(), chunk.getChunkState(), new RuntimeException("syncGenerateChunk guard triggered"));
+                    return;
+                }
+                this.generator.syncGenerate(chunk);
+                GENERATED_CHUNK_COUNT.incrementAndGet();
+            } finally {
+                chunkGenerationQueue.remove(index);
+            }
+            return;
+        }
+        awaitChunkGeneration(x, z);
+    }
+
+    private void awaitChunkGeneration(int x, int z) {
+        final long deadline = System.currentTimeMillis() + 30000L;
+        try {
+            ForkJoinPool.managedBlock(new ForkJoinPool.ManagedBlocker() {
+                @Override
+                public boolean block() throws InterruptedException {
+                    Thread.sleep(1);
+                    return isReleasable();
+                }
+
+                @Override
+                public boolean isReleasable() {
+                    return !isChunkGenerating(x, z) || System.currentTimeMillis() >= deadline;
+                }
+            });
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return;
+        }
+        if (isChunkGenerating(x, z)) {
+            log.warn("Timed out after 30s waiting for the generation of chunk ({}, {}) in level '{}'", x, z, getFolderName());
+        }
     }
 
     private void removeFromGenerateList(int x, int z) {
@@ -5073,12 +5146,16 @@ public class Level implements Metadatable {
             //gcBlockInventoryMetaData
             for (var entry : new HashMap<>(this.getBlockMetadata().getBlockMetadataMap()).entrySet()) {
                 String key = entry.getKey();
-                String[] split = key.split(":");
+                String[] split = key.split(":", 4);
+                if (split.length < 4) {
+                    continue;
+                }
+                String metadataKey = split[3];
                 Map<Plugin, MetadataValue> value = entry.getValue();
-                if (split[3].equals(BlockInventoryHolder.KEY) && value.containsKey(InternalPlugin.INSTANCE)) {
-                    Block block = getBlock(Integer.parseInt(split[0]), Integer.parseInt(split[1]), Integer.parseInt(split[2]));
+                if (metadataKey.equals(BlockInventoryHolder.KEY) && value.containsKey(InternalPlugin.INSTANCE)) {
+                    Block block = getBlock(Integer.parseInt(split[0]), Integer.parseInt(split[1]), Integer.parseInt(split[2]), false);
                     if (!(block instanceof BlockInventoryHolder)) {
-                        this.getBlockMetadata().removeMetadata(block, key, InternalPlugin.INSTANCE);
+                        this.getBlockMetadata().removeMetadata(block, metadataKey, InternalPlugin.INSTANCE);
                     }
                 }
             }

--- a/src/main/java/org/powernukkitx/level/PlayerChunkManager.java
+++ b/src/main/java/org/powernukkitx/level/PlayerChunkManager.java
@@ -39,50 +39,50 @@ public final class PlayerChunkManager {
      */
     private static final long CHUNK_LOAD_TIMEOUT_MICROS = 10L;
 
+    private static final double MIN_FOV_CHECK_DISTANCE_SQUARED = MIN_FOV_CHECK_DISTANCE * MIN_FOV_CHECK_DISTANCE;
+
+    private int comparatorLoaderChunkX;
+    private int comparatorLoaderChunkZ;
+    private double comparatorDirX;
+    private double comparatorDirZ;
+    private double comparatorCosFov;
+
     private final LongComparator chunkDistanceAndFovComparator = new LongComparator() {
         @Override
         public int compare(long chunkHash1, long chunkHash2) {
-            BlockVector3 floor = player.getPosition().asBlockVector3();
-            int loaderChunkX = floor.x >> 4;
-            int loaderChunkZ = floor.z >> 4;
-
             int chunkX1 = Level.getHashX(chunkHash1);
             int chunkZ1 = Level.getHashZ(chunkHash1);
             int chunkX2 = Level.getHashX(chunkHash2);
             int chunkZ2 = Level.getHashZ(chunkHash2);
 
-            int dx1 = chunkX1 - loaderChunkX;
-            int dz1 = chunkZ1 - loaderChunkZ;
-            int dx2 = chunkX2 - loaderChunkX;
-            int dz2 = chunkZ2 - loaderChunkZ;
+            int dx1 = chunkX1 - comparatorLoaderChunkX;
+            int dz1 = chunkZ1 - comparatorLoaderChunkZ;
+            int dx2 = chunkX2 - comparatorLoaderChunkX;
+            int dz2 = chunkZ2 - comparatorLoaderChunkZ;
 
-            double dist1 = Math.hypot(dx1, dz1);
-            double dist2 = Math.hypot(dx2, dz2);
+            long squaredDist1 = (long) dx1 * dx1 + (long) dz1 * dz1;
+            long squaredDist2 = (long) dx2 * dx2 + (long) dz2 * dz2;
 
-            boolean inFov1 = isInPlayerFov(dx1, dz1);
-            boolean inFov2 = isInPlayerFov(dx2, dz2);
+            boolean inFov1 = isInPlayerFov(dx1, dz1, squaredDist1);
+            boolean inFov2 = isInPlayerFov(dx2, dz2, squaredDist2);
 
             if (inFov1 && !inFov2) return -1;
             if (!inFov1 && inFov2) return 1;
 
-            return Double.compare(dist1, dist2);
+            return Long.compare(squaredDist1, squaredDist2);
         }
 
-        private boolean isInPlayerFov(int dx, int dz) {
-            double yaw = player.getYaw();
-            double dirX = -Math.sin(Math.toRadians(yaw));
-            double dirZ = Math.cos(Math.toRadians(yaw));
+        private boolean isInPlayerFov(int dx, int dz, long squaredDistance) {
+            if (squaredDistance < MIN_FOV_CHECK_DISTANCE_SQUARED) return true;
 
-            double len = Math.sqrt(dx * dx + dz * dz);
-            if (len < MIN_FOV_CHECK_DISTANCE) return true;
+            double len = Math.sqrt(squaredDistance);
 
             double toChunkX = dx / len;
             double toChunkZ = dz / len;
 
-            double dot = dirX * toChunkX + dirZ * toChunkZ;
+            double dot = comparatorDirX * toChunkX + comparatorDirZ * toChunkZ;
 
-            double cosFov = Math.cos(Math.toRadians(player.getServer().getSettings().levelSettings().fieldOfView()));
-            return dot >= cosFov;
+            return dot >= comparatorCosFov;
         }
     };
 
@@ -112,6 +112,7 @@ public final class PlayerChunkManager {
      */
     public synchronized void handleTeleport() {
         if (!player.isConnected()) return;
+        refreshComparatorContext();
         BlockVector3 floor = player.asBlockVector3();
         updateInRadiusChunks(1, floor);
         removeOutOfRadiusChunks();
@@ -123,6 +124,7 @@ public final class PlayerChunkManager {
 
     public synchronized void tick() {
         if (!player.isConnected()) return;
+        refreshComparatorContext();
         long currentLoaderChunkPosHashed;
         BlockVector3 floor = player.asBlockVector3();
         if ((currentLoaderChunkPosHashed = Level.chunkHash(floor.x >> 4, floor.z >> 4)) != lastLoaderChunkPosHashed) {
@@ -137,6 +139,7 @@ public final class PlayerChunkManager {
 
     public synchronized void handleViewDistanceChange() {
         if (!player.isConnected()) return;
+        refreshComparatorContext();
         BlockVector3 floor = player.asBlockVector3();
         updateInRadiusChunks(player.getViewDistance(), floor);
         removeOutOfRadiusChunks();
@@ -158,6 +161,7 @@ public final class PlayerChunkManager {
 
     @ApiStatus.Internal
     public synchronized void addSendChunk(int x, int z) {
+        refreshComparatorContext();
         chunkSendQueue.enqueue(Level.chunkHash(x, z));
     }
 
@@ -292,6 +296,17 @@ public final class PlayerChunkManager {
                 iterator.remove();
             }
         }
+    }
+
+    private void refreshComparatorContext() {
+        BlockVector3 floor = player.getPosition().asBlockVector3();
+        this.comparatorLoaderChunkX = floor.x >> 4;
+        this.comparatorLoaderChunkZ = floor.z >> 4;
+
+        double yawRadians = Math.toRadians(player.getYaw());
+        this.comparatorDirX = -Math.sin(yawRadians);
+        this.comparatorDirZ = Math.cos(yawRadians);
+        this.comparatorCosFov = Math.cos(Math.toRadians(player.getServer().getSettings().levelSettings().fieldOfView()));
     }
 
     private void unloadChunkForPlayer(long hash) {

--- a/src/main/java/org/powernukkitx/level/generator/Generator.java
+++ b/src/main/java/org/powernukkitx/level/generator/Generator.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 /**
@@ -106,7 +107,12 @@ public abstract class Generator implements BlockID {
         if (chunk.getChunkState().ordinal() < ChunkState.STARTED.ordinal()) {
             chunk.setChunkState(ChunkState.STARTED);
         }
-        asyncGenerate0(context, start, to, () -> callback.accept(context));
+        final AtomicBoolean called = new AtomicBoolean(false);
+        asyncGenerate0(context, start, to, () -> {
+            if (called.compareAndSet(false, true)) {
+                callback.accept(context);
+            }
+        });
     }
 
 
@@ -117,14 +123,24 @@ public abstract class Generator implements BlockID {
         }
         if (to.equals(start.name())) {
             start.getExecutor().execute(() -> {
-                start.apply(context);
-                callback.run();
+                try {
+                    start.apply(context);
+                } catch (Throwable t) {
+                    log.error("Error while applying the generate stage {} of the chunk ({}, {})", start.name(), context.getChunk().getX(), context.getChunk().getZ(), t);
+                } finally {
+                    callback.run();
+                }
             });
             return;
         }
         start.getExecutor().execute(() -> {
-            start.apply(context);
-            asyncGenerate0(context, start.getNextStage(), to, callback);
+            try {
+                start.apply(context);
+                asyncGenerate0(context, start.getNextStage(), to, callback);
+            } catch (Throwable t) {
+                log.error("Error while applying the generate stage {} of the chunk ({}, {})", start.name(), context.getChunk().getX(), context.getChunk().getZ(), t);
+                callback.run();
+            }
         });
 
     }

--- a/src/main/java/org/powernukkitx/level/util/SimpleTickCachedBlockStore.java
+++ b/src/main/java/org/powernukkitx/level/util/SimpleTickCachedBlockStore.java
@@ -17,7 +17,14 @@ public final class SimpleTickCachedBlockStore implements TickCachedBlockStore {
 
     @Override
     public void clearCachedStore() {
-        this.tickCachedBlockStore.clear();
+        if (!this.tickCachedBlockStore.isEmpty()) {
+            this.tickCachedBlockStore.clear();
+        }
+    }
+
+    @Override
+    public boolean isCachedStoreEmpty() {
+        return this.tickCachedBlockStore.isEmpty();
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/level/util/TickCachedBlockStore.java
+++ b/src/main/java/org/powernukkitx/level/util/TickCachedBlockStore.java
@@ -8,6 +8,10 @@ import org.powernukkitx.block.Block;
 public interface TickCachedBlockStore {
     void clearCachedStore();
 
+    default boolean isCachedStoreEmpty() {
+        return false;
+    }
+
     void saveIntoCachedStore(Block block, int x, int y, int z, int layer);
 
     Block getFromCachedStore(int x, int y, int z, int layer);

--- a/src/main/java/org/powernukkitx/network/Network.java
+++ b/src/main/java/org/powernukkitx/network/Network.java
@@ -156,7 +156,6 @@ public class Network implements NetworkInterface {
                         }
                         if (isAddressBlocked(address)) {
                             session.close("Your IP address has been blocked by this server!");
-                            onSessionDisconnect(address);
                         } else {
                             session.setCodec(NetworkConstants.CODEC);
                             session.setPacketHandler(new NetworkPacketHandler(server,
@@ -165,7 +164,13 @@ public class Network implements NetworkInterface {
                                             Network.this.server.getSettings().networkSettings().rateLimitSettings()
                                     )
                             ));
+                            final Channel sessionChannel = session.getPeer().getChannel();
                             Network.this.sessionMap.put(address, session);
+                            sessionChannel.closeFuture().addListener(future -> {
+                                if (!Network.this.sessionMap.remove(address, session)) {
+                                    Network.this.sessionMap.values().remove(session);
+                                }
+                            });
                         }
                     }
                 })

--- a/src/main/java/org/powernukkitx/scheduler/AsyncPool.java
+++ b/src/main/java/org/powernukkitx/scheduler/AsyncPool.java
@@ -3,6 +3,7 @@ package org.powernukkitx.scheduler;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -12,12 +13,17 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class AsyncPool extends ThreadPoolExecutor {
 
+    private static final AtomicInteger THREAD_COUNTER = new AtomicInteger();
+
     public AsyncPool(int size) {
-        super(size, Integer.MAX_VALUE, 60, TimeUnit.MILLISECONDS, new SynchronousQueue<>());
-        this.setThreadFactory(runnable -> new Thread(runnable) {{
-            setDaemon(true);
-            setName(String.format("Nukkit Asynchronous Task Handler #%s", getPoolSize()));
-        }});
+        super(size, Integer.MAX_VALUE, 30, TimeUnit.SECONDS, new SynchronousQueue<>());
+        this.setThreadFactory(runnable -> {
+            Thread thread = new Thread(runnable);
+            thread.setDaemon(true);
+            thread.setName(String.format("Nukkit Asynchronous Task Handler #%s", THREAD_COUNTER.incrementAndGet()));
+            return thread;
+        });
+        this.allowCoreThreadTimeOut(true);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/scheduler/ServerScheduler.java
+++ b/src/main/java/org/powernukkitx/scheduler/ServerScheduler.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -491,7 +492,16 @@ public class ServerScheduler {
     }
 
     public void close() {
-        this.asyncPool.shutdownNow();
+        this.asyncPool.shutdown();
+        try {
+            if (!this.asyncPool.awaitTermination(10, TimeUnit.SECONDS)) {
+                log.warn("Timed out while waiting for the asynchronous task pool to terminate");
+                this.asyncPool.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            this.asyncPool.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
     }
 
     @ApiStatus.Internal


### PR DESCRIPTION
Bugs:
- EntityPhysical.handleCollideMovement: unsynchronized writes to a non-thread-safe DoubleArrayList from a parallel stream (data race). Replaced with a sequential loop tracking four running maxima instead of four lists. Added a NaN guard for the len == 0 case where symmetric pushers cancel out.
- BlockEntityChest / BlockEntitySpawnableContainer.close: ConcurrentModificationException while iterating viewers aborted close() and left windows open. Use a defensive copy, matching the existing pattern in ShulkerBox and Hopper.
- Level.syncGenerateChunk: a bare spin loop and a leaked generation queue entry could permanently stall all chunk generation. Bounded 30s wait via ForkJoinPool.ManagedBlocker, try/finally entry release, and a null guard on the recovery path. Generator.asyncGenerate0 now always invokes the callback, including on stage failure and rejected execution.

Leaks:
- Level.unregisterChunkLoader: an early return skipped the loaders/loaderCounter cleanup, retaining Player instances for the lifetime of the server.
- Network.initSession: sessionMap entries were never removed on disconnect. Added a closeFuture listener with conditional removal so a stale session cannot evict a newer one bound to the same address.
- Level.doLevelGarbageCollection: the metadata key was disambiguated twice, so the lookup never matched and block metadata was never collected.
- Level.remove now closes the per-level scheduler; ServerScheduler.close performs a graceful shutdown so in-flight tasks drain before the provider closes.
- Level.releaseTickCachedBlocks: drop tick cache entries that went unused.

Hot paths:
- Nearest{Entity,Item,TargetEntity}Sensor: scan a chunk window instead of copying and walking the level-wide entity array on every tick.
- Level.getChunkAsync: return a completed future directly when the chunk is already resident instead of dispatching to the async pool.
- Level.updateBlockSkyLight: resolve the chunk once and read block states directly, removing 384 Block allocations per call, and break once the light level clamps.
- BlockProperties.containBlockState: replace the O(n) containsValue scan with an O(1) key lookup.
- Level.tickChunk: run the entity update loop synchronously instead of submitting a task to the common pool every tick.
- PlayerChunkManager: hoist loop-invariant position and FOV computations out of the chunk queue comparator.
- AsyncPool: raise keepAlive from 60ms to 30s so workers survive between ticks, and enable allowCoreThreadTimeOut.

## AI usage

This PR was produced with AI assistance for the analysis and the initial patches.
Every change was reviewed before submitting, and the build was verified and
runtime-tested on a local server.