### PR TITLE
fix: make BlockEntity.getCleanedNBT return a non-destructive copy

### DIFF
--- a/src/main/java/org/powernukkitx/blockentity/BlockEntity.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntity.java
@@ -152,11 +152,24 @@ public abstract class BlockEntity extends Position implements BlockEntityID {
         return id;
     }
 
+    /**
+     * Returns a position-independent snapshot of this block entity's NBT, suitable for copying
+     * the block entity elsewhere (item block data, block picking, structure saving, equality checks).
+     * <p>
+     * The returned tag is a defensive deep copy: the live {@link #nbt} is never modified, and callers
+     * are free to mutate the result. The {@code id}, {@code x}, {@code y} and {@code z} tags are
+     * stripped since they only describe this block entity's current identity/location. Subclasses may
+     * override to additionally strip location-bound data (e.g. {@link BlockEntityChest} removes its
+     * {@code pairx}/{@code pairz} pairing coordinates).
+     *
+     * @return a cleaned copy of the NBT, or {@code null} if nothing meaningful remains after cleaning
+     */
     public CompoundTag getCleanedNBT() {
         this.saveNBT();
-        this.nbt.remove("id", "x", "y", "z");
-        if (!this.nbt.isEmpty()) {
-            return getNbt();
+        final CompoundTag cleaned = this.nbt.copy();
+        cleaned.remove("id", "x", "y", "z");
+        if (!cleaned.isEmpty()) {
+            return cleaned;
         } else {
             return null;
         }


### PR DESCRIPTION
`getCleanedNBT()` stripped id/x/y/z from the live nbt and returned that same reference, so callers were mutating the real block entity. Most visibly, saving a structure or block-picking a double chest ran `BlockEntityChest.getCleanedNBT()`, which removed the live pairx/pairz pairing data and permanently disconnected the chest.

Clean a copy instead, leaving the live nbt untouched. This also fixes block equality checks and block-clone-on-break, which previously aliased or mutated live block entity data.

AI usage: Javadoc by Claude