### PR TITLE
perf: build block-light table at startup instead of on first tick

### DIFF
--- a/src/main/java/org/powernukkitx/Server.java
+++ b/src/main/java/org/powernukkitx/Server.java
@@ -28,6 +28,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.powernukkitx.block.BlockComposter;
+import org.powernukkitx.block.BlockLightProperties;
 import org.powernukkitx.block.dispenser.DispenseBehaviorRegister;
 import org.powernukkitx.blockentity.BlockEntity;
 import org.powernukkitx.command.Command;
@@ -638,6 +639,8 @@ public class Server {
         this.enablePlugins(PluginLoadOrder.STARTUP);
 
         LevelProviderManager.addProvider("leveldb", LevelDBProvider.class);
+
+        BlockLightProperties.build();
 
         loadLevels();
 

--- a/src/main/java/org/powernukkitx/block/BlockLightProperties.java
+++ b/src/main/java/org/powernukkitx/block/BlockLightProperties.java
@@ -2,13 +2,16 @@ package org.powernukkitx.block;
 
 import org.powernukkitx.registry.Registries;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 
 /**
  * Shared, precomputed lighting/opacity properties keyed by {@link BlockState#blockStateHash()}.
  *
- * <p>The table is built lazily on first use from a snapshot of all registered block states, then never mutated,
- * so reads are lock-free. Block states created after the first use (e.g. unknown/custom states registered later)
- * are not in the table and fall back to a live property read.</p>
+ * <p>The table is built once from a snapshot of all registered block states, then never mutated, so reads are
+ * lock-free. It should be built eagerly during server startup via {@link #build()} (after block registration,
+ * before any level ticks) so its cost never lands on a live tick; if that never happens it falls back to building
+ * lazily on first use. Block states created after the build (e.g. unknown/custom states registered later) are not
+ * in the table and fall back to a live property read.</p>
  */
 public final class BlockLightProperties {
 
@@ -32,24 +35,45 @@ public final class BlockLightProperties {
         return packed;
     }
 
+    /**
+     * Eagerly builds the property table. Intended to be called once during server startup, after all blocks are
+     * registered and before any level starts ticking, so the (palette-wide) build cost never stalls a live tick.
+     * Idempotent: subsequent calls, and any concurrent lazy {@link #table()} access, are no-ops.
+     */
+    public static void build() {
+        table();
+    }
+
     private static Int2IntOpenHashMap table() {
         Int2IntOpenHashMap t = table;
         if (t == null) {
             synchronized (BUILD_LOCK) {
                 t = table;
                 if (t == null) {
-                    var states = Registries.BLOCKSTATE.getAllState();
-                    t = new Int2IntOpenHashMap(states.size());
-                    t.defaultReturnValue(-1);
-                    for (BlockState state : states) {
-                        Block block = Registries.BLOCK.get(state);
-                        if (block != null) {
-                            t.put(state.blockStateHash(), packOf(block));
-                        }
-                    }
+                    t = buildTable();
                     table = t;
                 }
             }
+        }
+        return t;
+    }
+
+    private static Int2IntOpenHashMap buildTable() {
+        var states = Registries.BLOCKSTATE.getAllState();
+        Int2IntOpenHashMap t = new Int2IntOpenHashMap(states.size());
+        t.defaultReturnValue(-1);
+        Object2ObjectOpenHashMap<String, Block> prototypes = new Object2ObjectOpenHashMap<>();
+        for (BlockState state : states) {
+            Block block = prototypes.get(state.getIdentifier());
+            if (block == null) {
+                block = Registries.BLOCK.get(state);
+                if (block == null) {
+                    continue;
+                }
+                prototypes.put(state.getIdentifier(), block);
+            }
+            block.blockstate = state;
+            t.put(state.blockStateHash(), packOf(block));
         }
         return t;
     }


### PR DESCRIPTION
Fixes [#"Sending/loading chunks makes the whole level lag"](<https://discord.com/channels/944227466912870410/1528839751594021014>). Confirmed in-game.

`BlockLightProperties` previously built its packed light table lazily on first use, which meant the palette-wide build cost landed on a live tick. This moves the build to server startup and speeds the build itself up.

AI usage: Claude Opus 4.8 analyzed a spark profile and suggested this fix, please review carefully.