### PR TITLE
fix: incorrect/null BlockFace in ProjectileHitEvent on block collision

### DIFF
--- a/src/main/java/org/powernukkitx/entity/projectile/EntityProjectile.java
+++ b/src/main/java/org/powernukkitx/entity/projectile/EntityProjectile.java
@@ -27,6 +27,7 @@ import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.nbt.tag.ListTag;
 import org.cloudburstmc.protocol.bedrock.data.actor.ActorDataTypes;
+import org.powernukkitx.utils.RayTraceUtils;
 
 import javax.annotation.Nullable;
 import java.util.EnumMap;
@@ -285,11 +286,37 @@ public abstract class EntityProjectile extends Entity {
             if (this.isCollided && !this.hadCollision) { //collide with block
                 this.hadCollision = true;
 
+                Vector3 intendedEnd = new Vector3(
+                    position.x + motion.x,
+                    position.y + motion.y,
+                    position.z + motion.z
+                );
+
                 this.motionX = 0;
                 this.motionY = 0;
                 this.motionZ = 0;
 
-                this.server.getPluginManager().callEvent(new ProjectileHitEvent(this, MovingObjectPosition.fromBlock(this.getFloorX(), this.getFloorY(), this.getFloorZ(), BlockFace.UP, this)));
+                RayTraceUtils.BlockRayTraceResult rayResult =
+                    RayTraceUtils.raytraceBlocks(this.getLevel(), position, intendedEnd);
+
+                BlockFace face;
+                int bx, by, bz;
+
+                if (rayResult != null) {
+                    face = rayResult.face() != null ? rayResult.face() : BlockFace.UP;
+                    bx = rayResult.x();
+                    by = rayResult.y();
+                    bz = rayResult.z();
+                } else {
+                    face = BlockFace.UP;
+                    bx = this.getFloorX();
+                    by = this.getFloorY();
+                    bz = this.getFloorZ();
+                }
+
+                MovingObjectPosition blockHitResult = MovingObjectPosition.fromBlock(bx, by, bz, face, this);
+
+                this.server.getPluginManager().callEvent(new ProjectileHitEvent(this, blockHitResult));
                 onCollideWithBlock(position, motion);
                 addHitEffect();
                 return false;

--- a/src/main/java/org/powernukkitx/utils/RayTraceUtils.java
+++ b/src/main/java/org/powernukkitx/utils/RayTraceUtils.java
@@ -1,0 +1,95 @@
+package org.powernukkitx.utils;
+
+import org.powernukkitx.block.Block;
+import org.powernukkitx.level.Level;
+import org.powernukkitx.math.BlockFace;
+import org.powernukkitx.math.Vector3;
+
+public final class RayTraceUtils {
+
+    public record BlockRayTraceResult(int x, int y, int z, BlockFace face, Vector3 hitPos) {}
+
+    /**
+     * Shoots a ray between two points and returns the first solid block it hits,
+     * along with the exact entry face. Returns null if nothing is hit.
+     */
+    public static BlockRayTraceResult raytraceBlocks(Level level, Vector3 start, Vector3 end) {
+        double dx = end.x - start.x;
+        double dy = end.y - start.y;
+        double dz = end.z - start.z;
+
+        double length = Math.sqrt(dx * dx + dy * dy + dz * dz);
+        if (length < 1e-6) return null;
+
+        int voxelX = (int) Math.floor(start.x);
+        int voxelY = (int) Math.floor(start.y);
+        int voxelZ = (int) Math.floor(start.z);
+
+        int stepX = Double.compare(dx, 0);
+        int stepY = Double.compare(dy, 0);
+        int stepZ = Double.compare(dz, 0);
+
+        double tMaxX = intbound(start.x, dx);
+        double tMaxY = intbound(start.y, dy);
+        double tMaxZ = intbound(start.z, dz);
+
+        double tDeltaX = stepX != 0 ? Math.abs(1 / dx) : Double.POSITIVE_INFINITY;
+        double tDeltaY = stepY != 0 ? Math.abs(1 / dy) : Double.POSITIVE_INFINITY;
+        double tDeltaZ = stepZ != 0 ? Math.abs(1 / dz) : Double.POSITIVE_INFINITY;
+
+        BlockFace lastFace = null;
+        double t = 0;
+        int maxSteps = 256;
+
+        while (t <= 1.0 && maxSteps-- > 0) {
+            Block block = level.getBlock(voxelX, voxelY, voxelZ);
+            if (block != null && !block.isAir() && block.getBoundingBox() != null) {
+                Vector3 hitPos = new Vector3(
+                    start.x + t * dx,
+                    start.y + t * dy,
+                    start.z + t * dz
+                );
+                return new BlockRayTraceResult(voxelX, voxelY, voxelZ, lastFace, hitPos);
+            }
+
+            if (tMaxX < tMaxY) {
+                if (tMaxX < tMaxZ) {
+                    voxelX += stepX;
+                    t = tMaxX;
+                    tMaxX += tDeltaX;
+                    lastFace = stepX > 0 ? BlockFace.WEST : BlockFace.EAST;
+                } else {
+                    voxelZ += stepZ;
+                    t = tMaxZ;
+                    tMaxZ += tDeltaZ;
+                    lastFace = stepZ > 0 ? BlockFace.NORTH : BlockFace.SOUTH;
+                }
+            } else {
+                if (tMaxY < tMaxZ) {
+                    voxelY += stepY;
+                    t = tMaxY;
+                    tMaxY += tDeltaY;
+                    lastFace = stepY > 0 ? BlockFace.DOWN : BlockFace.UP;
+                } else {
+                    voxelZ += stepZ;
+                    t = tMaxZ;
+                    tMaxZ += tDeltaZ;
+                    lastFace = stepZ > 0 ? BlockFace.NORTH : BlockFace.SOUTH;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static double intbound(double s, double ds) {
+        if (ds == 0) return Double.POSITIVE_INFINITY;
+        if (ds < 0) return intbound(-s, -ds);
+        double frac = mod(s, 1);
+        return (1 - frac) / ds;
+    }
+
+    private static double mod(double value, double modulus) {
+        return (value % modulus + modulus) % modulus;
+    }
+}


### PR DESCRIPTION
ProjectileHitEvent was always reporting BlockFace.UP for block hits, and the block coordinates came from getFloorX/Y/Z() on the entity instead of the actual block that was hit sometimes pointing at the air block next to it. This could throw NPEs in plugins calling face.getXOffset()/etc. on a null or wrong face.

Added a raytrace (Amanatides & Woo voxel traversal) that follows the projectile's actual path for the tick and returns the first solid block hit along with the real entry face, instead of guessing after the fact.