### PR TITLE
fix: Entity home initialization deadlock after chunk loading changes

### DIFF
--- a/src/main/java/org/powernukkitx/entity/EntityLiving.java
+++ b/src/main/java/org/powernukkitx/entity/EntityLiving.java
@@ -77,6 +77,8 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
     private int shieldAttackInterruptTicks = 0;
     private boolean shieldReblockAfterAttack = false;
 
+    private Vector3 pendingHomePosition;
+
     public EntityLiving(IChunk chunk, CompoundTag nbt) {
         super(chunk, nbt);
     }
@@ -161,7 +163,49 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
         }
     }
 
+    protected void prepareHomePosition() {
+        if (!this.hasHome() || !(this instanceof EntityIntelligent)) return;
 
+        if (this.nbt.contains("HomeX")
+                && this.nbt.contains("HomeY")
+                && this.nbt.contains("HomeZ")) {
+            this.pendingHomePosition = new Vector3(
+                    this.nbt.getDouble("HomeX"),
+                    this.nbt.getDouble("HomeY"),
+                    this.nbt.getDouble("HomeZ")
+            );
+        } else {
+            this.pendingHomePosition = this.getPosition().floor();
+
+            this.nbt.putDouble("HomeX", this.pendingHomePosition.x);
+            this.nbt.putDouble("HomeY", this.pendingHomePosition.y);
+            this.nbt.putDouble("HomeZ", this.pendingHomePosition.z);
+        }
+    }
+
+    protected void initializeHomeMemoryIfNeeded() {
+        if (!this.hasHome() || !(this instanceof EntityIntelligent ei)) return;
+        if (this.pendingHomePosition == null) return;
+        if (this.level == null) return;
+        if (this.closed) return;
+        if (ei.getMemoryStorage().notEmpty(CoreMemoryTypes.NEAREST_BLOCK)) return;
+
+        int chunkX = this.pendingHomePosition.getFloorX() >> 4;
+        int chunkZ = this.pendingHomePosition.getFloorZ() >> 4;
+
+        IChunk chunk = this.level.getChunk(chunkX, chunkZ, false);
+        if (chunk == null) return;
+
+        Block home = this.level.getTickCachedBlock(
+                this.pendingHomePosition.getFloorX(),
+                this.pendingHomePosition.getFloorY(),
+                this.pendingHomePosition.getFloorZ()
+        );
+
+        if (home == null) return;
+
+        ei.getMemoryStorage().put(CoreMemoryTypes.NEAREST_BLOCK, home);
+    }
 
     protected void loadParentFromNBT() {
         if (!(this instanceof EntityIntelligent ei)) return;
@@ -228,6 +272,8 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
 
     @Override
     public boolean onUpdate(int currentTick) {
+        this.initializeHomeMemoryIfNeeded();
+
         if (restoreMountTries > 0) {
             restoreMountTries--;
             if ((restoreMountTries % 4) == 0) tryRestoreMountLink();
@@ -1006,17 +1052,23 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
     public void setHomePosition() {
         if (!this.hasHome() || !(this instanceof EntityIntelligent ei)) return;
 
-        int x = ei.getFloorX();
-        int y = ei.getFloorY();
-        int z = ei.getFloorZ();
-        Block home = ei.level.getBlock(x, y, z);
+        this.pendingHomePosition = this.getPosition().floor();
 
-        ei.setNbt(
-                ei.nbt.putDouble("HomeX", home.x)
-                        .putDouble("HomeY", home.y)
-                        .putDouble("HomeZ", home.z)
+        this.nbt.putDouble("HomeX", this.pendingHomePosition.x);
+        this.nbt.putDouble("HomeY", this.pendingHomePosition.y);
+        this.nbt.putDouble("HomeZ", this.pendingHomePosition.z);
+
+        if (this.level == null || this.closed) return;
+
+        Block home = this.level.getTickCachedBlock(
+                this.pendingHomePosition.getFloorX(),
+                this.pendingHomePosition.getFloorY(),
+                this.pendingHomePosition.getFloorZ()
         );
-        ei.getMemoryStorage().put(CoreMemoryTypes.NEAREST_BLOCK, home);
+
+        if (home != null) {
+            ei.getMemoryStorage().put(CoreMemoryTypes.NEAREST_BLOCK, home);
+        }
     }
 
     public Block getHomePosition() {

--- a/src/main/java/org/powernukkitx/entity/passive/EntityHappyGhast.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityHappyGhast.java
@@ -4,7 +4,6 @@ import org.powernukkitx.Player;
 import org.powernukkitx.block.Block;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityFlyable;
-import org.powernukkitx.entity.EntityIntelligent;
 import org.powernukkitx.entity.ai.behavior.Behavior;
 import org.powernukkitx.entity.ai.behaviorgroup.BehaviorGroup;
 import org.powernukkitx.entity.ai.behaviorgroup.IBehaviorGroup;
@@ -21,7 +20,6 @@ import org.powernukkitx.entity.ai.executor.TemptExecutor;
 import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
 import org.powernukkitx.entity.ai.route.finder.impl.SimpleSpaceAStarRouteFinder;
 import org.powernukkitx.entity.ai.route.posevaluator.HoveringPosEvaluator;
-import org.powernukkitx.entity.ai.sensor.ISensor;
 import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.components.AgeableComponent;
 import org.powernukkitx.entity.components.HomeComponent;
@@ -138,11 +136,7 @@ public class EntityHappyGhast extends EntityAnimal implements EntityFlyable, Inv
         }
 
         // Init home memory
-        if (this.nbt.contains("HomeX")) {
-            this.initHome();
-        } else {
-            this.setHomePosition();
-        }
+        this.prepareHomePosition();
     }
 
     @Override
@@ -696,21 +690,7 @@ public class EntityHappyGhast extends EntityAnimal implements EntityFlyable, Inv
                     )
                 )
                 .sensors(
-                    new NearestPlayerSensor(56, 0, 20),
-                    // Ensure HOME memory exists + stays valid
-                    new ISensor() {
-                        @Override
-                        public void sense(EntityIntelligent entity) {
-                            EntityHappyGhast g = (EntityHappyGhast) entity;
-                            if (entity.getMemoryStorage().isEmpty(CoreMemoryTypes.NEAREST_BLOCK))
-                                g.setHomePosition();
-                        }
-
-                        @Override
-                        public int getPeriod() {
-                            return 60;
-                        }
-                    }
+                    new NearestPlayerSensor(56, 0, 20)
                 )
                 .controllers(
                     new SpaceMoveController(),

--- a/src/main/java/org/powernukkitx/entity/passive/EntityNautilus.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityNautilus.java
@@ -5,7 +5,6 @@ import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockFlowingWater;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityID;
-import org.powernukkitx.entity.EntityIntelligent;
 import org.powernukkitx.entity.EntitySwimmable;
 import org.powernukkitx.entity.ai.behavior.Behavior;
 import org.powernukkitx.entity.ai.behaviorgroup.BehaviorGroup;
@@ -22,7 +21,6 @@ import org.powernukkitx.entity.ai.executor.TemptExecutor;
 import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
 import org.powernukkitx.entity.ai.route.finder.impl.SimpleSpaceAStarRouteFinder;
 import org.powernukkitx.entity.ai.route.posevaluator.SwimmingPosEvaluator;
-import org.powernukkitx.entity.ai.sensor.ISensor;
 import org.powernukkitx.entity.components.*;
 import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.event.entity.EntityDamageEvent;
@@ -316,7 +314,7 @@ public class EntityNautilus extends EntityAnimal implements EntitySwimmable, Inv
         }
 
         // Init home memory
-        this.initHome();
+        this.prepareHomePosition();
     }
 
     @Override
@@ -563,24 +561,7 @@ public class EntityNautilus extends EntityAnimal implements EntitySwimmable, Inv
                                 1
                         )
                 )
-                .sensors(
-                        new ISensor() {
-                            @Override
-                            public void sense(EntityIntelligent entity) {
-                                EntityNautilus n = (EntityNautilus) entity;
-
-                                if (!n.isTamed()) return;
-                                Block home = n.getHomePosition();
-                                if (home == null) return;
-                                entity.getMemoryStorage().put(CoreMemoryTypes.NEAREST_BLOCK, home);
-                            }
-
-                            @Override
-                            public int getPeriod() {
-                                return 60;
-                            }
-                        }
-                )
+                .sensors()
                 .controllers(
                         new SpaceMoveController(),
                         new LookController(true, true),

--- a/src/main/java/org/powernukkitx/entity/passive/EntityZombieNautilus.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityZombieNautilus.java
@@ -3,7 +3,6 @@ package org.powernukkitx.entity.passive;
 import org.powernukkitx.Player;
 import org.powernukkitx.block.Block;
 import org.powernukkitx.entity.Entity;
-import org.powernukkitx.entity.EntityIntelligent;
 import org.powernukkitx.entity.ai.behavior.Behavior;
 import org.powernukkitx.entity.ai.behaviorgroup.BehaviorGroup;
 import org.powernukkitx.entity.ai.behaviorgroup.IBehaviorGroup;
@@ -17,7 +16,6 @@ import org.powernukkitx.entity.ai.executor.TemptExecutor;
 import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
 import org.powernukkitx.entity.ai.route.finder.impl.SimpleSpaceAStarRouteFinder;
 import org.powernukkitx.entity.ai.route.posevaluator.SwimmingPosEvaluator;
-import org.powernukkitx.entity.ai.sensor.ISensor;
 import org.powernukkitx.entity.components.AgeableComponent;
 import org.powernukkitx.entity.components.BreedableComponent;
 import org.powernukkitx.entity.components.EquippableComponent;
@@ -360,24 +358,7 @@ public class EntityZombieNautilus extends EntityNautilus {
                                 1
                         )
                 )
-                .sensors(
-                        new ISensor() {
-                            @Override
-                            public void sense(EntityIntelligent entity) {
-                                EntityNautilus n = (EntityNautilus) entity;
-
-                                if (!n.isTamed()) return;
-                                Block home = n.getHomePosition();
-                                if (home == null) return;
-                                entity.getMemoryStorage().put(CoreMemoryTypes.NEAREST_BLOCK, home);
-                            }
-
-                            @Override
-                            public int getPeriod() {
-                                return 60;
-                            }
-                        }
-                )
+                .sensors()
                 .controllers(
                         new SpaceMoveController(),
                         new LookController(true, true),

--- a/src/main/java/org/powernukkitx/inventory/HorseInventory.java
+++ b/src/main/java/org/powernukkitx/inventory/HorseInventory.java
@@ -40,6 +40,7 @@ public class HorseInventory<T extends EntityCreature & InventoryHolder> extends 
     protected final T equineHolder;
     private boolean revertingSlot = false;
     private final EquippableComponent equippable;
+    private boolean loading;
 
     public HorseInventory(T holder, int size) {
         super(holder, ContainerType.HORSE, Math.max(size, resolveMinSize(holder)));
@@ -160,7 +161,7 @@ public class HorseInventory<T extends EntityCreature & InventoryHolder> extends 
                 } else if (getHolder().hasDashAction()) {
                     getHolder().setCanDash(false);
                 }
-                if (getHolder().hasHome()) getHolder().setHomePosition();
+                if (!this.loading && getHolder().hasHome()) getHolder().setHomePosition();
             } else {
                 getHolder().getLevel().addLevelSoundEvent(getHolder(), SoundEvent.SADDLE, -1, getHolder().getIdentifier(), false, false);
                 getHolder().setSaddle(true);
@@ -171,7 +172,7 @@ public class HorseInventory<T extends EntityCreature & InventoryHolder> extends 
                 } else if (getHolder().hasDashAction()) {
                     getHolder().setCanDash(true);
                 }
-                if (getHolder().hasHome()) getHolder().setHomePosition();
+                if (!this.loading && getHolder().hasHome()) getHolder().setHomePosition();
             }
             return;
         }
@@ -387,38 +388,44 @@ public class HorseInventory<T extends EntityCreature & InventoryHolder> extends 
     public void load(Collection<CompoundTag> inventoryTag) {
         if (inventoryTag == null) return;
 
-        EquippableComponent eq = this.getEquippableDefinition();
-        int equipCount = eq != null ? eq.getEquipCount() : 0;
-        int base = getStorageBaseUiSlot();
+        this.loading = true;
 
-        int i = 0;
-        for (CompoundTag entry : inventoryTag) {
-            int slot = entry.contains("Slot") ? (entry.getByte("Slot") & 0xff) : i;
+        try {
+            EquippableComponent eq = this.getEquippableDefinition();
+            int equipCount = eq != null ? eq.getEquipCount() : 0;
+            int base = getStorageBaseUiSlot();
 
-            Item it = ItemHelper.read(entry);
-            i++;
-            if (it == null || it.isNull()) continue;
+            int i = 0;
+            for (CompoundTag entry : inventoryTag) {
+                int slot = entry.contains("Slot") ? (entry.getByte("Slot") & 0xff) : i;
 
-            // 1) Equippable by UI slotNumber
-            if (eq != null) {
-                EquippableComponent.Type type = eq.getTypeByUiSlot(slot);
-                if (type != null && this.setEquippedItem(type, it)) continue;
-            }
+                Item it = ItemHelper.read(entry);
+                i++;
+                if (it == null || it.isNull()) continue;
 
-            // 2) Storage by UI slotNumber
-            if (slot >= base) {
-                int storageOffset = slot - base;
-                int idx = equipCount + storageOffset;
-                if (idx >= 0 && idx < this.getSize()) {
-                    this.setItem(idx, it, false);
-                    continue;
+                // 1) Equippable by UI slotNumber
+                if (eq != null) {
+                    EquippableComponent.Type type = eq.getTypeByUiSlot(slot);
+                    if (type != null && this.setEquippedItem(type, it)) continue;
+                }
+
+                // 2) Storage by UI slotNumber
+                if (slot >= base) {
+                    int storageOffset = slot - base;
+                    int idx = equipCount + storageOffset;
+                    if (idx >= 0 && idx < this.getSize()) {
+                        this.setItem(idx, it, false);
+                        continue;
+                    }
+                }
+
+                // 3) Legacy fallback: raw internal index
+                if (slot >= 0 && slot < this.getSize()) {
+                    this.setItem(slot, it, false);
                 }
             }
-
-            // 3) Legacy fallback: raw internal index
-            if (slot >= 0 && slot < this.getSize()) {
-                this.setItem(slot, it, false);
-            }
+        } finally {
+            this.loading = false;
         }
     }
 


### PR DESCRIPTION
The previous chunk loading changes exposed entity initEntity() calls that accessed world blocks while the chunk lock was still held, causing a deadlock when home positions were restored or created.
Home coordinates are now prepared during initialization and the actual block memory is resolved later during normal entity updates.