### PR TITLE
fix: preserve BDS entity motion during translation

### DIFF
--- a/src/main/java/org/powernukkitx/level/format/leveldb/BDSEntityTranslator.java
+++ b/src/main/java/org/powernukkitx/level/format/leveldb/BDSEntityTranslator.java
@@ -38,7 +38,7 @@ public final class BDSEntityTranslator {
                 target.add(new DoubleTag(v.data));
             }
             from.putList("Motion", target);
-            linkedCompoundTag.putList("Pos", target);
+            linkedCompoundTag.putList("Motion", target);
         } else {
             ListTag<DoubleTag> target = new ListTag<>();
             target.add(new DoubleTag(0));

--- a/src/test/java/org/powernukkitx/level/format/leveldb/BDSEntityTranslatorTest.java
+++ b/src/test/java/org/powernukkitx/level/format/leveldb/BDSEntityTranslatorTest.java
@@ -1,0 +1,44 @@
+package org.powernukkitx.level.format.leveldb;
+
+import org.junit.jupiter.api.Test;
+import org.powernukkitx.nbt.tag.CompoundTag;
+import org.powernukkitx.nbt.tag.DoubleTag;
+import org.powernukkitx.nbt.tag.FloatTag;
+import org.powernukkitx.nbt.tag.ListTag;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BDSEntityTranslatorTest {
+    @Test
+    void translatesPositionAndMotionIntoSeparateLists() {
+        CompoundTag source = new CompoundTag()
+                .putList("Pos", new ListTag<FloatTag>()
+                        .add(new FloatTag(1.25))
+                        .add(new FloatTag(64.5))
+                        .add(new FloatTag(-3.75)))
+                .putList("Motion", new ListTag<FloatTag>()
+                        .add(new FloatTag(0.125))
+                        .add(new FloatTag(-0.25))
+                        .add(new FloatTag(0.5)))
+                .putList("Rotation", new ListTag<FloatTag>()
+                        .add(new FloatTag(90))
+                        .add(new FloatTag(15)));
+
+        CompoundTag translated = BDSEntityTranslator.translate(source);
+
+        assertEquals(
+                List.of(1.25, 64.5, -3.75),
+                translated.getList("Pos", DoubleTag.class).getAll().stream()
+                        .map(DoubleTag::getData)
+                        .toList()
+        );
+        assertEquals(
+                List.of(0.125, -0.25, 0.5),
+                translated.getList("Motion", DoubleTag.class).getAll().stream()
+                        .map(DoubleTag::getData)
+                        .toList()
+        );
+    }
+}


### PR DESCRIPTION

## Summary

- During entity conversion from the bedrock format, Motion data that had already been converted was mistakenly stored in Pos.
- We corrected the storage destination to Motion and added a test to verify Pos and Motion separately.

## Problem

- BDSEntityTranslator converts float lists of Pos and Motion into double lists.
- The converted Motion results were written to the Pos field, overwriting the previously converted Pos values.
- The Motion tag was missing from the conversion results.
- As a result, the displacement values could have been treated as entity coordinates.

## Changes

- Stored the Motion conversion results in the Motion key
- Added regression tests using different values for Pos and Motion
- Verified that both are maintained as independent double lists

## Testing

Environment
- WSL2 Ubuntu 24.04.3 JDK 21
- `./gradlew test --tests org.powernukkitx.level.format.leveldb.BDSEntityTranslatorTest`
- `./gradlew test`


## AI usage

We are using ChatGPT 5.6 Sol for code generation and research.

# I'm using Deepl Translate. The text before translation is shown below.


## Summary

- bedrock形式からのエンティティ変換で誤って変換済みのMotionがPosへ格納されていた。
- 格納先をMotionへ修正し、PosとMotionを別々に確認するテストを追加した。

## Problem

- BDSEntityTranslatorはPosとMotionのfloatリストをdoubleリストへ変換する
- Motionの変換結果がPosへ書き込まれ、先に変換したPosを上書きしていた
- Motionタグは変換結果から欠落していた
- その結果、移動量がエンティティ座標として扱われる可能性があった

## Changes

- Motionの変換結果をMotionキーへ格納
- PosとMotionに異なる値を使った回帰テストを追加
- 両方が独立したdoubleリストとして保持されることを検証

## Testing

環境
- WSL2 Ubuntu 24.04.3 JDK 21
- `./gradlew test --tests org.powernukkitx.level.format.leveldb.BDSEntityTranslatorTest`
- `./gradlew test`


## AI usage

chatgpt 5.6 Solをコード生成、調査に使用しています。