### PR TITLE
fix: Patch getCreationMapIDs() NPE

### DIFF
--- a/src/main/java/org/powernukkitx/item/ItemFilledMap.java
+++ b/src/main/java/org/powernukkitx/item/ItemFilledMap.java
@@ -1,6 +1,7 @@
 package org.powernukkitx.item;
 
 import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
 import org.powernukkitx.Player;
 import org.powernukkitx.Server;
 import org.powernukkitx.level.Level;
@@ -126,6 +127,7 @@ public class ItemFilledMap extends Item {
         BufferedImage image = this.image != null ? this.image : loadImageFromNBT();
 
         final ClientboundMapItemDataPacket packet = new ClientboundMapItemDataPacket();
+        packet.setCreationMapIDs(new LongArrayList());
         packet.getCreationMapIDs().add(this.getMapId());
         packet.setMapID(this.getMapId());
         packet.setDimension(DimensionType.from(player.getLevel().getDimension()));


### PR DESCRIPTION
<details><summary>NullPointerException when opening a map</summary>
<p>

```
12:58:00 [Nukkit Asynchronous Task Handler #825] [ERROR] Exception in asynchronous task
java.lang.NullPointerException: Cannot invoke "it.unimi.dsi.fastutil.longs.LongList.add(long)" because the return value of "org.cloudburstmc.protocol.bedrock.packet.ClientboundMapItemDataPacket.getCreationMapIDs()" is null
        at org.powernukkitx.item.ItemFilledMap.sendImage(ItemFilledMap.java:129)
        at org.powernukkitx.item.ItemFilledMap.sendImage(ItemFilledMap.java:121)
        at org.powernukkitx.network.process.handler.MapInfoRequestHandler$1.onRun(MapInfoRequestHandler.java:98)
        at org.powernukkitx.scheduler.AsyncTask.run(AsyncTask.java:25)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
``` 

</p>
</details>

The code expected `ClientboundMapItemDataPacket.getCreationMapIDs()` to not be null, however, the default in the protocol is not initialized. So whenever the client sent `MapInfoRequestPacket`, it threw an `NullPointerException` and the map didn't render at all. **Fix not verified in-game.**