### PR TITLE
fix: memory leak of freezable array dead references

### DIFF
--- a/src/main/java/org/powernukkitx/Server.java
+++ b/src/main/java/org/powernukkitx/Server.java
@@ -1221,11 +1221,8 @@ public class Server {
 
         long nanosPerTick = getNanosPerTick();
 
-        // Handle freezable array
         int freezableArrayCompressTime = (int) ((nanosPerTick - (System.nanoTime() - tickTimeNano)) / 1_000_000L);
-        if (freezableArrayCompressTime > 4) {
-            getFreezableArrayManager().setMaxCompressionTime(freezableArrayCompressTime).tick();
-        }
+        getFreezableArrayManager().setMaxCompressionTime(Math.max(0, freezableArrayCompressTime)).tick();
 
         long nowNano = System.nanoTime();
         this.tickDurationsNanos[(int) (this.tickCounter & (this.tickDurationsNanos.length - 1))] = nowNano - tickTimeNano;

--- a/src/main/java/org/powernukkitx/utils/collection/FreezableArrayManager.java
+++ b/src/main/java/org/powernukkitx/utils/collection/FreezableArrayManager.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -21,6 +22,11 @@ public class FreezableArrayManager {
      */
     private int maxCompressionTime = 50;
     private final AtomicInteger currentArrayId = new AtomicInteger(0);
+    /**
+     * Guards against stacking up cycle tasks on the compute thread pool when a cycle takes longer than
+     * {@link #cycleTick} ticks to finish.
+     */
+    private final AtomicBoolean cycleRunning = new AtomicBoolean(false);
     private int currentTick;
 
     /**
@@ -127,7 +133,7 @@ public class FreezableArrayManager {
     public ByteArrayWrapper createByteArray(int length) {
         if (enable) {
             var tmp = new FreezableByteArray(length, this);
-            var set = tickArrayMap.computeIfAbsent(currentArrayId.getAndIncrement() % cycleTick, (ignore) -> new WeakConcurrentSet<>(WeakConcurrentSet.Cleaner.MANUAL));
+            var set = tickArrayMap.computeIfAbsent(Math.floorMod(currentArrayId.getAndIncrement(), cycleTick), (ignore) -> new WeakConcurrentSet<>(WeakConcurrentSet.Cleaner.MANUAL));
             set.add(tmp);
             return tmp;
         } else {
@@ -138,7 +144,7 @@ public class FreezableArrayManager {
     public ByteArrayWrapper wrapByteArray(@NotNull byte[] array) {
         if (enable) {
             var tmp = new FreezableByteArray(array, this);
-            var set = tickArrayMap.computeIfAbsent(currentArrayId.getAndIncrement() % cycleTick, (ignore) -> new WeakConcurrentSet<>(WeakConcurrentSet.Cleaner.MANUAL));
+            var set = tickArrayMap.computeIfAbsent(Math.floorMod(currentArrayId.getAndIncrement(), cycleTick), (ignore) -> new WeakConcurrentSet<>(WeakConcurrentSet.Cleaner.MANUAL));
             set.add(tmp);
             return tmp;
         } else {
@@ -149,7 +155,7 @@ public class FreezableArrayManager {
     public ByteArrayWrapper cloneByteArray(@NotNull byte[] array) {
         if (enable) {
             var tmp = new FreezableByteArray(Arrays.copyOf(array, array.length), this);
-            var set = tickArrayMap.computeIfAbsent(currentArrayId.getAndIncrement() % cycleTick, (ignore) -> new WeakConcurrentSet<>(WeakConcurrentSet.Cleaner.MANUAL));
+            var set = tickArrayMap.computeIfAbsent(Math.floorMod(currentArrayId.getAndIncrement(), cycleTick), (ignore) -> new WeakConcurrentSet<>(WeakConcurrentSet.Cleaner.MANUAL));
             set.add(tmp);
             return tmp;
         } else {
@@ -160,9 +166,10 @@ public class FreezableArrayManager {
     public void tick() {
         currentTick++;
         if (!enable) return;
-        var dt = currentTick % cycleTick;
+        var dt = Math.floorMod(currentTick, cycleTick);
         var set = tickArrayMap.get(dt);
         if (set == null) return;
+        if (!cycleRunning.compareAndSet(false, true)) return;
         // freeze arrays
         var start = System.currentTimeMillis();
         // clean up dead references
@@ -184,6 +191,13 @@ public class FreezableArrayManager {
                     }
                 }
             }
-        }, Server.getInstance().getComputeThreadPool()).thenRun(set::clearDeadReferences);
+        }, Server.getInstance().getComputeThreadPool())
+                .whenComplete((ignored, throwable) -> {
+                    try {
+                        set.clearDeadReferences();
+                    } finally {
+                        cycleRunning.set(false);
+                    }
+                });
     }
 }

--- a/src/main/java/org/powernukkitx/utils/collection/FreezableByteArray.java
+++ b/src/main/java/org/powernukkitx/utils/collection/FreezableByteArray.java
@@ -61,7 +61,7 @@ public final class FreezableByteArray implements ByteArrayWrapper, AutoFreezable
     @Override
     public void deepFreeze() {
         if (temperature > manager.getAbsoluteZero()) return;
-        if (freezeStatus.get() != FreezeStatus.NONE || freezeStatus.get() != FreezeStatus.FREEZE) return;
+        if (freezeStatus.get() != FreezeStatus.NONE && freezeStatus.get() != FreezeStatus.FREEZE) return;
         var needDecompressFirst = freezeStatus.get() == FreezeStatus.FREEZE;
         freezeStatus.set(FreezeStatus.DEEP_FREEZING);
         var tmp = needDecompressFirst ? LZ4Freezer.decompressor.decompress(data, rawLength) : data;


### PR DESCRIPTION
## What does this PR do?

This PR fixes an existing memory leak within FreezableArray:
- servers with no spare tick time never used `tick()` on the FreezableArrayManager, thus not clearing dead references
- `deepFreeze()` inside FreezableByteArray always returned immediately
- As precaution: prevents AtomicInteger overflow for servers with high uptime or TPS

## Why?

A sparkheap revealed a memory leak within FreezableArrays

## Type of change

- [X] Bug Fix
- [ ] New Feature
- [X] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** `07c8e81`
- **Bedrock client version:** 1.26
- **Plugins loaded:** None

**Steps performed and results:**

1. Patched the affected network
2. Waited, then used `/spark heapsummary`
3. Heap summary showed `0` orphans of `FreezableByteArray`

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [X] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

JMH not suitable for this change, as we do not yet have coverage for this change. For the situation of the affected server, this might increase ticking time by 2 microseconds per tick, which is negligible.

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
| Claude Opus 5 | Investigated `.sparkheap` file and suggested possible fixes, wrote javadoc |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] ~~"Allow maintainer edits" is enabled~~
