### PR TITLE
perf: skip per-chunk event allocation when no listener is registered

### DIFF
--- a/src/main/java/org/powernukkitx/level/PlayerChunkManager.java
+++ b/src/main/java/org/powernukkitx/level/PlayerChunkManager.java
@@ -230,10 +230,12 @@ public final class PlayerChunkManager {
             long chunkHash = chunkSendQueue.dequeueLong();
             int chunkX = Level.getHashX(chunkHash);
             int chunkZ = Level.getHashZ(chunkHash);
-            PlayerPreChunkRequestEvent event = new PlayerPreChunkRequestEvent(player, chunkX, chunkZ, force);
-            Server.getInstance().getPluginManager().callEvent(event);
-            if (event.isCancelled()) {
-                continue;
+            if (!PlayerPreChunkRequestEvent.getHandlers().isEmpty()) {
+                PlayerPreChunkRequestEvent event = new PlayerPreChunkRequestEvent(player, chunkX, chunkZ, force);
+                Server.getInstance().getPluginManager().callEvent(event);
+                if (event.isCancelled()) {
+                    continue;
+                }
             }
             var chunkTask = chunkLoadingQueue.computeIfAbsent(chunkHash, (hash) -> player.getLevel().getChunkAsync(chunkX, chunkZ));
             if (chunkTask.isDone()) {
@@ -281,8 +283,10 @@ public final class PlayerChunkManager {
                 }
                 int chunkX = Level.getHashX(chunkHash);
                 int chunkZ = Level.getHashZ(chunkHash);
-                PlayerChunkRequestEvent ev = new PlayerChunkRequestEvent(player, chunkX, chunkZ);
-                player.getServer().getPluginManager().callEvent(ev);
+                if (!PlayerChunkRequestEvent.getHandlers().isEmpty()) {
+                    PlayerChunkRequestEvent ev = new PlayerChunkRequestEvent(player, chunkX, chunkZ);
+                    player.getServer().getPluginManager().callEvent(ev);
+                }
                 player.level.requestChunk(chunkX, chunkZ, player);
                 sentChunks.add(chunkHash);
             }


### PR DESCRIPTION
<!--
  Read CONTRIBUTING.md before submitting:
  https://github.com/PowerNukkitX/PowerNukkitX/blob/master/CONTRIBUTING.md

  PRs that leave this template unfilled, or fill it with generated filler,
  are closed without review. Delete the HTML comments as you go.

  SECURITY: never report a vulnerability in a public PR. See SECURITY.md.
-->

## What does this PR do?

Skips calling `PlayerPreChunkRequestEvent` and `PlayerChunkRequestEvent` when there are no handlers picking it up.

## Why?

Saves resources under high pressure

## Type of change

<!-- Tick what applies. -->

- [ ] Bug Fix
- [ ] New Feature
- [X] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- [X] I built the server and ran it with this change

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
|       |             |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] ~~"Allow maintainer edits" is enabled~~
