### PR TITLE
chore: move bedrock connection to "api" field

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     api(libs.fastutil)
     api(libs.snakeyaml)
     api(libs.stateless4j)
+    api(libs.bedrock.connection)
 
     implementation(libs.bundles.leveldb)
     implementation(libs.rng.simple)
@@ -61,13 +62,12 @@ dependencies {
     implementation(libs.bundles.terminal)
     implementation(libs.okaeri)
     implementation(libs.pnxgamedata)
-    implementation(libs.bedrock.connection)
     implementation(libs.commonslang3)
     implementation(libs.caffeine)
 
     testImplementation(libs.bundles.test)
     testImplementation(libs.commonsio)
-    
+
     testRuntimeOnly(libs.junit.platform.launcher)
 
     compileOnly(libs.lombok)


### PR DESCRIPTION
<!--
  Read CONTRIBUTING.md before submitting:
  https://github.com/PowerNukkitX/PowerNukkitX/blob/master/CONTRIBUTING.md

  PRs that leave this template unfilled, or fill it with generated filler,
  are closed without review. Delete the HTML comments as you go.

  SECURITY: never report a vulnerability in a public PR. See SECURITY.md.
-->

## What does this PR do?

Moves bedrock connection library to "api" field on build file

## Why?

In plugins you need to include protocol library too for protocol related things, this avoids that issue and bundles into PNX library

Closes #

## Type of change

<!-- Tick what applies. -->

- [ ] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [x] Build / CI / dependencies

## How was this tested?

- **Server build tested:** Unrelated
- **Bedrock client version:** 1.26.40
- **Plugins loaded:** None

**Steps performed and results:**

1. Joined the server
2. Left the server

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [x] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
|       |             |

- [ ] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
