### PR TITLE
fix: Sync mounted passenger movement and rotation

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -1075,10 +1075,11 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
     }
 
     public void broadcastMountedMovement() {
-        if (this.riding == null) return;
+        Entity riding = this.riding;
+        if (riding == null) return;
 
         MovePlayerPacket pk = new MovePlayerPacket();
-        pk.setPlayerRuntimeID(this.getId());
+        pk.setPlayerRuntimeID(this.id);
         pk.setPosition(Vector3f.from(
             (float) this.x,
             (float) this.y,
@@ -1090,17 +1091,24 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
             (float) this.headYaw
         ));
         pk.setPositionMode(PositionMode.NORMAL);
-        pk.setOnGround(false);
-        pk.setRidingRuntimeID(this.riding.getId());
+        pk.setOnGround(this.onGround);
+        pk.setRidingRuntimeID(riding.getId());
+        pk.setTick(this.getServer().getTick());
 
-        final MovePlayerTeleportData teleportData = new MovePlayerTeleportData();
-        teleportData.setTeleportationCause(TeleportationCause.UNKNOWN);
-        teleportData.setSourceActorType(0);
-        pk.setTeleportData(teleportData);
+        Set<Player> viewers = new HashSet<>();
 
-        pk.setTick(this.getLevel().getCurrentTick());
+        viewers.addAll(this.hasSpawned.values());
+        viewers.addAll(riding.getViewers().values());
 
-        Server.broadcastPacket(this.hasSpawned.values(), pk);
+        for (Entity passenger : riding.getPassengers()) {
+            if (passenger instanceof Player player) {
+                viewers.add(player);
+            }
+        }
+
+        viewers.remove(this);
+
+        Server.broadcastPacket(viewers, pk);
     }
 
     /**

--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -1074,6 +1074,11 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         this.fastMove(diffX, diffY, diffZ);
     }
 
+    /**
+     * Broadcasts this player's mounted position and rotation to relevant viewers.
+     *
+     * <p>Does nothing if the player is not riding an entity.</p>
+     */
     public void broadcastMountedMovement() {
         Entity riding = this.riding;
         if (riding == null) return;

--- a/src/main/java/org/powernukkitx/entity/Entity.java
+++ b/src/main/java/org/powernukkitx/entity/Entity.java
@@ -2549,6 +2549,9 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         }
     }
 
+    /**
+     * Broadcasts the mounted movement of all player passengers.
+     */
     public void broadcastMountedPassengerMovements() {
         if (this.passengers.isEmpty()) return;
 

--- a/src/main/java/org/powernukkitx/entity/Entity.java
+++ b/src/main/java/org/powernukkitx/entity/Entity.java
@@ -2556,7 +2556,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         if (this.passengers.isEmpty()) return;
 
         for (Entity passenger : List.copyOf(this.passengers)) {
-            if (passenger instanceof Player player) {
+            if (passenger instanceof Player player && player.getRiding() == this) {
                 player.broadcastMountedMovement();
             }
         }

--- a/src/main/java/org/powernukkitx/entity/Entity.java
+++ b/src/main/java/org/powernukkitx/entity/Entity.java
@@ -2549,6 +2549,16 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         }
     }
 
+    public void broadcastMountedPassengerMovements() {
+        if (this.passengers.isEmpty()) return;
+
+        for (Entity passenger : List.copyOf(this.passengers)) {
+            if (passenger instanceof Player player) {
+                player.broadcastMountedMovement();
+            }
+        }
+    }
+
     /**
      * Resolves the seat offset to apply to a passenger for a specific seat index.
      */
@@ -2604,9 +2614,13 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
                 }
 
                 Float lock = sm.lockRiderRotationDegrees();
+                boolean bodyFollowsHead = this.getDataFlag(ActorFlags.BODY_ROTATION_ALWAYS_FOLLOWS_HEAD);
+
                 if (lock != null) {
+                    p.setSeatLockPassengerRotation(!bodyFollowsHead, false);
                     p.setSeatLockRiderRotationDegrees(lock, false);
                 } else {
+                    p.setSeatLockPassengerRotation(false, false);
                     p.setSeatLockRiderRotationDegrees(0.0f, false);
                 }
 
@@ -2756,6 +2770,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
 
     public void clearSeatData(Player passenger) {
         passenger.setSeatCameraRelaxDistanceSmoothing(0.0f, false);
+        passenger.setSeatLockPassengerRotation(false, false);
         passenger.setSeatLockRiderRotationDegrees(0.0f, false);
         passenger.setSeatThirdPersonCameraRadius(0.0f, false);
         passenger.setSeatRotationOffset(false, false);
@@ -2863,6 +2878,10 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
 
         if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_CAMERA_RELAX_DISTANCE_SMOOTHING)) {
             data.put(ActorDataTypes.SEAT_CAMERA_RELAX_DISTANCE_SMOOTHING, this.actorDataMap.get(ActorDataTypes.SEAT_CAMERA_RELAX_DISTANCE_SMOOTHING));
+        }
+
+        if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION)) {
+            data.put(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION, this.actorDataMap.get(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION));
         }
 
         if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION_DEGREES)) {

--- a/src/main/java/org/powernukkitx/entity/EntityPhysical.java
+++ b/src/main/java/org/powernukkitx/entity/EntityPhysical.java
@@ -504,7 +504,6 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
         }
 
         this.syncRiderLocationFromInput(rider, pk);
-        rider.broadcastMountedMovement();
 
         if ((type == RideableComponent.InputType.GROUND || type == RideableComponent.InputType.WATER) && handleRideJumpOrDash(pk, type)) {
             return true;
@@ -900,10 +899,7 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
 
     /** Air Input Controls */
     public boolean onRiderInputAirControlled(Player rider, PlayerAuthInputPacket pk) {
-        if (!isControllingRider(rider)) {
-            resetAirRideRotation();
-            return false;
-        }
+        if (!isControllingRider(rider)) return false;
         if (!prepareManualRiderControl()) return false;
 
         // INPUT KNOBS
@@ -1377,11 +1373,11 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
     }
 
     protected int getAirRideRotationDelayTicks() {
-        return 2;
+        return 1;
     }
 
     protected float getAirRideYawTurnSpeed() {
-        return 4.21875f;
+        return 5.625f;
     }
 
     protected float getAirRideYawInputThreshold() {

--- a/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
@@ -204,8 +204,20 @@ public class PlayerAuthInputHandler implements PacketHandler<PlayerAuthInputPack
 
         Entity vehicle = null;
         if ((vehicle = player.getRiding()) != null && vehicle.hasWASDControls()) {
+            boolean controllingRider = vehicle.getRider() == player;
+
+            if (!controllingRider) {
+                syncMountedPlayerRotationFromInput(player, packet);
+            }
+
             syncVehiclePositionFromRiderInput(player, vehicle, packet);
-            if (vehicle.onRiderInput(player, packet)) return;
+
+            boolean handled = vehicle.onRiderInput(player, packet);
+
+            vehicle.updatePassengers(false, false);
+            vehicle.broadcastMountedPassengerMovements();
+
+            if (handled) return;
         }
 
         player.offerMovementTask(clientLoc);
@@ -257,6 +269,18 @@ public class PlayerAuthInputHandler implements PacketHandler<PlayerAuthInputPack
             itemStackRequestPacket.getRequests().add(packet.getItemStackRequest());
             PacketHandlerRegistry.getPacketHandler(ItemStackRequestPacket.class).handle(itemStackRequestPacket, holder, server);
         }
+    }
+
+    private static void syncMountedPlayerRotationFromInput(Player player, PlayerAuthInputPacket pk) {
+        Vector3f rot = Vector3f.fromNetwork(pk.getPlayerRotation());
+
+        if (!Float.isFinite(rot.x) || !Float.isFinite(rot.y) || !Float.isFinite(rot.z)) {
+            log.debug("Player {} sent invalid rotation values (NaN or Infinite)", player.getName());
+            return;
+        }
+
+        player.setRotation(rot.getY(), rot.getX());
+        player.setHeadYaw(rot.getZ());
     }
 
     private static void syncVehiclePositionFromRiderInput(Player player, Entity vehicle, PlayerAuthInputPacket pk) {
@@ -315,9 +339,7 @@ public class PlayerAuthInputHandler implements PacketHandler<PlayerAuthInputPack
         vehicle.setHeadYaw(vehicleYaw);
         vehicle.updateMovement();
 
-        if (boat != null) {
-            boat.updatePassengers(false, false);
-        } else {
+        if (boat == null) {
             player.setPosition(packetPosition);
         }
 

--- a/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
@@ -215,7 +215,12 @@ public class PlayerAuthInputHandler implements PacketHandler<PlayerAuthInputPack
             boolean handled = vehicle.onRiderInput(player, packet);
 
             vehicle.updatePassengers(false, false);
-            vehicle.broadcastMountedPassengerMovements();
+
+            if (controllingRider) {
+                vehicle.broadcastMountedPassengerMovements();
+            } else {
+                player.broadcastMountedMovement();
+            }
 
             if (handled) return;
         }


### PR DESCRIPTION
<!--
  Read CONTRIBUTING.md before submitting:
  https://github.com/PowerNukkitX/PowerNukkitX/blob/master/CONTRIBUTING.md

  PRs that leave this template unfilled, or fill it with generated filler,
  are closed without review. Delete the HTML comments as you go.

  SECURITY: never report a vulnerability in a public PR. See SECURITY.md.
-->

## What does this PR do?

Improved rideable controls.
Increased turn direction response when riding entities controlled by looking direction.

## Why?

Body lock rotation was not set while riding entities, like Boat.
When a second passenger mount, the rider could not control the looking direction of entities like Happy Ghast.
The rotation speed of entities was a bit slower when looking direction of rider is changed, ie: Happy Ghast.

Closes #

## Type of change

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** 68bc0f1a93a1e88ae4ebd95c568c5037784664d8
- **Bedrock client version:** 26.34
- **Plugins loaded:** None

**Steps performed and results:**

1. Mount rideable entities that supports additional passengers (ie: boat, happy ghast)
2. Move, rotate, while looking to the passenger position/rotation.

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
|    codex   |      Tshoot packet sync from proxypass       |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
