### PR TITLE
perf: validate logins off the network thread

### DIFF
--- a/src/main/java/org/powernukkitx/network/process/SessionState.java
+++ b/src/main/java/org/powernukkitx/network/process/SessionState.java
@@ -5,6 +5,7 @@ public enum SessionState {
     INITIAL,
     REQUESTED_NETWORK_SETTINGS,
     LOGIN,
+    AUTHENTICATING,
     ENCRYPTION,
     RESOURCE_PACK,
     BEFORE_SPAWN,

--- a/src/main/java/org/powernukkitx/network/process/handler/ClientToServerHandshakeHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/ClientToServerHandshakeHandler.java
@@ -15,7 +15,7 @@ public class ClientToServerHandshakeHandler implements PacketHandler<ClientToSer
 
     @Override
     public void handle(ClientToServerHandshakePacket packet, PlayerSessionHolder holder, Server server) {
-        if (holder.getState().equals(SessionState.RESOURCE_PACK)) {
+        if (!holder.getState().equals(SessionState.ENCRYPTION)) {
             holder.disconnect(DisconnectFailReason.UNEXPECTED_PACKET);
             return;
         }

--- a/src/main/java/org/powernukkitx/network/process/handler/LoginHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/LoginHandler.java
@@ -1,5 +1,6 @@
 package org.powernukkitx.network.process.handler;
 
+import io.netty.channel.EventLoop;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.cloudburstmc.protocol.bedrock.data.DisconnectFailReason;
@@ -10,11 +11,11 @@ import org.cloudburstmc.protocol.bedrock.packet.LoginPacket;
 import org.cloudburstmc.protocol.bedrock.packet.ServerToClientHandshakePacket;
 import org.cloudburstmc.protocol.bedrock.util.ChainValidationResult;
 import org.cloudburstmc.protocol.bedrock.util.EncryptionUtils;
+import org.jetbrains.annotations.Nullable;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.consumer.InvalidJwtException;
 import org.jose4j.jwt.consumer.JwtConsumerBuilder;
 import org.jose4j.jwt.consumer.JwtContext;
-import org.jose4j.lang.JoseException;
 import org.powernukkitx.Player;
 import org.powernukkitx.Server;
 import org.powernukkitx.event.player.PlayerPreLoginEvent;
@@ -27,12 +28,26 @@ import org.powernukkitx.network.process.auth.ClientChainData;
 import org.powernukkitx.network.process.auth.ClientSkinData;
 import org.powernukkitx.utils.SkinUtils;
 
-import java.security.NoSuchAlgorithmException;
+import javax.crypto.SecretKey;
 import java.security.PublicKey;
-import java.security.spec.InvalidKeySpecException;
 import java.util.Locale;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 /**
+ * Handles the client's {@code LoginPacket}.
+ * <p>
+ * Validating a login costs several milliseconds of cryptography: the identity chain, the client
+ * JWT, and the encryption key exchange. RakNet pins a session to one Netty event loop that also
+ * serves every other session on that loop, so doing this inline stalls unrelated players whenever
+ * a batch of logins arrives.
+ * <p>
+ * The work therefore runs on the compute pool in two steps, with the checks that read server
+ * state - the pre-login event, player count, whitelist and bans - on the event loop between them.
+ * That ordering is deliberate: it matches the sequence used when this ran inline, so failures are
+ * still reported in the same order, and a login the server is going to refuse anyway never pays
+ * for the client JWT or the key exchange.
+ *
  * @author Kaooot
  */
 @Slf4j
@@ -40,16 +55,10 @@ public class LoginHandler implements PacketHandler<LoginPacket> {
 
     @Override
     public void handle(LoginPacket packet, PlayerSessionHolder holder, Server server) {
-        PlayerLoginFailEvent sessionFailEvent = new PlayerLoginFailEvent(holder, DisconnectFailReason.NO_REASON);
-
         if (!holder.getState().equals(SessionState.LOGIN)) {
-            sessionFailEvent.setDisconnectFailReason(DisconnectFailReason.UNEXPECTED_PACKET);
-            server.getPluginManager().callEvent(sessionFailEvent);
-
-            holder.disconnect(sessionFailEvent.getDisconnectFailReason());
+            failLogin(holder, server, DisconnectFailReason.UNEXPECTED_PACKET, null);
             return;
         }
-
 
         final int clientNetworkVersion = packet.getClientNetworkVersion();
         final int serverNetworkVersion = NetworkConstants.CODEC.getProtocolVersion();
@@ -60,135 +69,207 @@ public class LoginHandler implements PacketHandler<LoginPacket> {
                 serverOutdated ?
                     PlayStatus.LOGIN_FAILED_SERVER_OLD : PlayStatus.LOGIN_FAILED_CLIENT_OLD
             );
-
-            sessionFailEvent.setDisconnectFailReason(serverOutdated ? DisconnectFailReason.OUTDATED_SERVER : DisconnectFailReason.OUTDATED_CLIENT);
-            server.getPluginManager().callEvent(sessionFailEvent);
-
-            holder.disconnect(sessionFailEvent.getDisconnectFailReason());
+            failLogin(holder, server, serverOutdated ? DisconnectFailReason.OUTDATED_SERVER : DisconnectFailReason.OUTDATED_CLIENT, null);
             return;
         }
 
         final PlayerAuthenticationType type = packet.getAuthenticationType();
-        final DisconnectFailReason notAuthenticated = DisconnectFailReason.NOT_AUTHENTICATED;
         if (type.equals(PlayerAuthenticationType.UNKNOWN)) {
-            sessionFailEvent.setDisconnectFailReason(notAuthenticated);
-            server.getPluginManager().callEvent(sessionFailEvent);
-
-            holder.disconnect(sessionFailEvent.getDisconnectFailReason());
+            failLogin(holder, server, DisconnectFailReason.NOT_AUTHENTICATED, null);
             return;
         }
 
         final boolean xboxAuthRequired = server.getSettings().baseSettings().xboxAuth();
         if (xboxAuthRequired && (packet.getToken() == null || packet.getToken().isEmpty())) {
-            sessionFailEvent.setDisconnectFailReason(notAuthenticated);
-            server.getPluginManager().callEvent(sessionFailEvent);
-
-            holder.disconnect(sessionFailEvent.getDisconnectFailReason());
+            failLogin(holder, server, DisconnectFailReason.NOT_AUTHENTICATED, null);
             return;
         }
-        try {
-            final ChainValidationResult result = EncryptionUtils.validateToken(type, packet.getToken());
-            final boolean unsignedAllowed = server.getProxyAuthProvider() != null
-                && server.getProxyAuthProvider().isUnsignedLoginAllowed();
-            if (xboxAuthRequired && !result.signed() && !unsignedAllowed) {
-                sessionFailEvent.setDisconnectFailReason(notAuthenticated);
-                server.getPluginManager().callEvent(sessionFailEvent);
 
-                holder.disconnect(sessionFailEvent.getDisconnectFailReason());
-                return;
-            }
-            final ChainValidationResult.IdentityClaims identityClaims = result.identityClaims();
+        final Credentials credentials = new Credentials(type, packet.getToken(), packet.getClientJwt());
 
-            final PlayerPreLoginEvent event = new PlayerPreLoginEvent(identityClaims);
-            server.getPluginManager().callEvent(event);
+        holder.setState(SessionState.AUTHENTICATING);
 
-            if (event.isCancelled()) {
-                sessionFailEvent.setDisconnectFailReason(DisconnectFailReason.UNKNOWN);
-                sessionFailEvent.setDisconnectMessage(event.getKickMessage());
+        offLoop(holder, server,
+            () -> validateChain(credentials, server, xboxAuthRequired),
+            chain -> applyChain(chain, credentials, holder, server));
+    }
 
-                server.getPluginManager().callEvent(sessionFailEvent);
+    /**
+     * Verifies the identity chain. First off-loop step, and the only one a login must pass before
+     * the server decides whether it wants the player at all.
+     */
+    private ChainOutcome validateChain(Credentials credentials, Server server, boolean xboxAuthRequired) throws Exception {
+        final ChainValidationResult result = EncryptionUtils.validateToken(credentials.authenticationType(), credentials.token());
+        final boolean unsignedAllowed = server.getProxyAuthProvider() != null
+            && server.getProxyAuthProvider().isUnsignedLoginAllowed();
+        if (xboxAuthRequired && !result.signed() && !unsignedAllowed) {
+            return new ChainOutcome(DisconnectFailReason.NOT_AUTHENTICATED, null, false);
+        }
+        return new ChainOutcome(null, result.identityClaims(), result.signed());
+    }
 
-                holder.disconnect(sessionFailEvent.getDisconnectFailReason(), sessionFailEvent.getDisconnectMessage());
-                return;
-            }
-            if (server.getOnlinePlayers().size() >= server.getMaxPlayers()) {
-                sessionFailEvent.setDisconnectFailReason(DisconnectFailReason.SERVER_FULL);
-                server.getPluginManager().callEvent(sessionFailEvent);
+    /**
+     * Runs the checks that read server state, then starts the second off-loop step for a login
+     * that passed them.
+     */
+    private void applyChain(ChainOutcome chain, Credentials credentials, PlayerSessionHolder holder, Server server) {
+        if (chain.failure() != null) {
+            failLogin(holder, server, chain.failure(), null);
+            return;
+        }
+        final ChainValidationResult.IdentityClaims identityClaims = Objects.requireNonNull(
+            chain.identityClaims(), "a chain outcome without a failure always carries identity claims");
 
-                holder.disconnect(sessionFailEvent.getDisconnectFailReason());
-                return;
-            }
+        final PlayerPreLoginEvent event = new PlayerPreLoginEvent(identityClaims);
+        server.getPluginManager().callEvent(event);
+        if (event.isCancelled()) {
+            failLogin(holder, server, DisconnectFailReason.UNKNOWN, event.getKickMessage());
+            return;
+        }
+        if (server.getOnlinePlayers().size() >= server.getMaxPlayers()) {
+            failLogin(holder, server, DisconnectFailReason.SERVER_FULL, null);
+            return;
+        }
 
-            if (!server.isWhitelisted(identityClaims.extraData.displayName.toLowerCase(Locale.ENGLISH))) {
-                sessionFailEvent.setDisconnectFailReason(DisconnectFailReason.NOT_ALLOWED);
-                server.getPluginManager().callEvent(sessionFailEvent);
+        final String displayName = identityClaims.extraData.displayName.toLowerCase(Locale.ENGLISH);
+        if (!server.isWhitelisted(displayName)) {
+            failLogin(holder, server, DisconnectFailReason.NOT_ALLOWED, null);
+            return;
+        }
 
-                holder.disconnect(sessionFailEvent.getDisconnectFailReason());
-                return;
-            }
+        final var entry = server.getNameBans().getEntires().get(displayName);
+        if (entry != null) {
+            final String reason = entry.getReason();
+            failLogin(holder, server, DisconnectFailReason.UNKNOWN,
+                !reason.isEmpty() ? "You are banned. Reason: " + reason : "You are banned");
+            return;
+        }
 
-            var entry = server.getNameBans().getEntires().get(identityClaims.extraData.displayName.toLowerCase(Locale.ENGLISH));
-            if (entry != null) {
-                String reason = entry.getReason();
+        offLoop(holder, server,
+            () -> validateClient(credentials, server, identityClaims),
+            client -> completeLogin(client, identityClaims, chain.signed(), holder, server));
+    }
 
-                sessionFailEvent.setDisconnectFailReason(DisconnectFailReason.UNKNOWN);
-                sessionFailEvent.setDisconnectMessage(
-                    !reason.isEmpty() ? "You are banned. Reason: " + reason : "You are banned"
+    /**
+     * Verifies the client JWT and prepares the key exchange. Second off-loop step, reached only
+     * once the server has accepted the identity.
+     */
+    private ClientOutcome validateClient(Credentials credentials, Server server, ChainValidationResult.IdentityClaims identityClaims) throws Exception {
+        final ClientJwtValidationResult clientJwt = this.validateClientJwt(credentials.clientJwt(), identityClaims.parsedIdentityPublicKey());
+        if (!clientJwt.isValid()) {
+            return new ClientOutcome(null, null, null, false);
+        }
+        EncryptionHandshake handshake = null;
+        boolean encryptionFailed = false;
+        if (server.enabledNetworkEncryption) {
+            try {
+                final PublicKey clientKey = EncryptionUtils.parseKey(identityClaims.identityPublicKey);
+                final var encryptionKeyPair = EncryptionUtils.createKeyPair();
+                final byte[] encryptionToken = EncryptionUtils.generateRandomToken();
+                handshake = new EncryptionHandshake(
+                    EncryptionUtils.getSecretKey(encryptionKeyPair.getPrivate(), clientKey, encryptionToken),
+                    EncryptionUtils.createHandshakeJwt(encryptionKeyPair, encryptionToken)
                 );
+            } catch (Exception e) {
+                log.debug("Failed to prepare the encryption handshake", e);
+                encryptionFailed = true;
+            }
+        }
+        return new ClientOutcome(clientJwt.getClientChainData(), clientJwt.getSkin(), handshake, encryptionFailed);
+    }
 
-                server.getPluginManager().callEvent(sessionFailEvent);
+    /**
+     * Answers the client: the remaining rejections, then either the encryption handshake or the
+     * resource pack stage.
+     */
+    private void completeLogin(ClientOutcome client, ChainValidationResult.IdentityClaims identityClaims,
+                               boolean signed, PlayerSessionHolder holder, Server server) {
+        final ClientChainData clientChainData = client.clientChainData();
+        if (clientChainData == null) {
+            failLogin(holder, server, DisconnectFailReason.INVALID_PLATFORM_SKIN, null);
+            return;
+        }
+        if (clientChainData.isEduMode()) {
+            holder.sendPlayStatus(PlayStatus.LOGIN_FAILED_EDITION_MISMATCH_EDU_TO_VANILLA);
+            failLogin(holder, server, DisconnectFailReason.EDITION_MISMATCH_EDU_TO_VANILLA, null);
+            return;
+        }
 
-                holder.disconnect(sessionFailEvent.getDisconnectFailReason(), sessionFailEvent.getDisconnectMessage());
+        holder.setPlayerInfo(new Player.PlayerInfo(identityClaims, clientChainData, client.skin(), signed));
+
+        if (client.encryptionFailed()) {
+            holder.disconnect(DisconnectFailReason.UNKNOWN, "encryption error");
+            return;
+        }
+        if (client.encryption() != null) {
+            try {
+                final ServerToClientHandshakePacket pk = new ServerToClientHandshakePacket();
+                pk.setHandshakeWebToken(client.encryption().handshakeJwt());
+                holder.getSession().sendPacketImmediately(pk);
+                holder.getSession().enableEncryption(client.encryption().secretKey());
+            } catch (Exception e) {
+                log.debug("Failed to start the encrypted session", e);
+                holder.disconnect(DisconnectFailReason.UNKNOWN, "encryption error");
                 return;
             }
+            holder.setState(SessionState.ENCRYPTION);
+        } else {
+            holder.sendPlayStatus(PlayStatus.LOGIN_SUCCESS);
+            holder.setState(SessionState.RESOURCE_PACK);
+            holder.sendResourcePacksInfo(server);
+        }
+    }
 
-            final ClientJwtValidationResult clientJwtValidationResult = this.validateClientJwt(packet, identityClaims.parsedIdentityPublicKey());
-            if (!clientJwtValidationResult.isValid()) {
-                sessionFailEvent.setDisconnectFailReason(DisconnectFailReason.INVALID_PLATFORM_SKIN);
-                server.getPluginManager().callEvent(sessionFailEvent);
-
-                holder.disconnect(sessionFailEvent.getDisconnectFailReason());
-
+    /**
+     * Runs {@code work} on the compute pool and hands its result to {@code then} back on the
+     * session's event loop, so everything touching session or server state stays on one thread.
+     * A session that went away in the meantime is dropped, and a failing step disconnects rather
+     * than leaving the login stuck in {@link SessionState#AUTHENTICATING}.
+     */
+    private <T> void offLoop(PlayerSessionHolder holder, Server server, ThrowingSupplier<T> work, Consumer<T> then) {
+        final EventLoop eventLoop = holder.getSession().getPeer().getChannel().eventLoop();
+        server.getComputeThreadPool().execute(() -> {
+            final T result;
+            try {
+                result = work.get();
+            } catch (Exception e) {
+                log.debug("Error while validating login", e);
+                eventLoop.execute(() -> {
+                    if (holder.getSession().isConnected()) {
+                        failLogin(holder, server, DisconnectFailReason.NOT_AUTHENTICATED, null);
+                    }
+                });
                 return;
             }
+            eventLoop.execute(() -> {
+                if (holder.getSession().isConnected()) {
+                    then.accept(result);
+                }
+            });
+        });
+    }
 
-            final ClientChainData clientChainData = clientJwtValidationResult.getClientChainData();
-            if (clientChainData.isEduMode()) {
-                holder.sendPlayStatus(PlayStatus.LOGIN_FAILED_EDITION_MISMATCH_EDU_TO_VANILLA);
+    /**
+     * Fires {@link PlayerLoginFailEvent} so plugins may adjust the reason, then disconnects with
+     * whatever they left in place.
+     *
+     * @param message an explicit disconnect message, or {@code null} to use the reason's default
+     */
+    private void failLogin(PlayerSessionHolder holder, Server server, DisconnectFailReason reason, @Nullable String message) {
+        final PlayerLoginFailEvent sessionFailEvent = new PlayerLoginFailEvent(holder, reason);
+        if (message != null) {
+            sessionFailEvent.setDisconnectMessage(message);
+        }
+        server.getPluginManager().callEvent(sessionFailEvent);
 
-                sessionFailEvent.setDisconnectFailReason(DisconnectFailReason.EDITION_MISMATCH_EDU_TO_VANILLA);
-                server.getPluginManager().callEvent(sessionFailEvent);
-
-                holder.disconnect(sessionFailEvent.getDisconnectFailReason());
-                return;
-            }
-            holder.setPlayerInfo(
-                new Player.PlayerInfo(
-                    identityClaims,
-                    clientChainData,
-                    clientJwtValidationResult.getSkin(),
-                    result.signed()
-                )
-            );
-
-            if (server.enabledNetworkEncryption) {
-                this.enableEncryption(identityClaims, holder);
-            } else {
-                holder.sendPlayStatus(PlayStatus.LOGIN_SUCCESS);
-                holder.setState(SessionState.RESOURCE_PACK);
-                holder.sendResourcePacksInfo(server);
-            }
-        } catch(InvalidJwtException | JoseException | NoSuchAlgorithmException | InvalidKeySpecException e){
-            log.debug("Error while validating jwt", e);
-            sessionFailEvent.setDisconnectFailReason(DisconnectFailReason.NOT_AUTHENTICATED);
-            server.getPluginManager().callEvent(sessionFailEvent);
-
+        if (sessionFailEvent.getDisconnectMessage() != null) {
+            holder.disconnect(sessionFailEvent.getDisconnectFailReason(), sessionFailEvent.getDisconnectMessage());
+        } else {
             holder.disconnect(sessionFailEvent.getDisconnectFailReason());
         }
     }
 
-    private ClientJwtValidationResult validateClientJwt(LoginPacket packet, PublicKey identityPublicKey) {
-        final String clientJwt = packet.getClientJwt();
+    private ClientJwtValidationResult validateClientJwt(String clientJwt, PublicKey identityPublicKey) {
         if (clientJwt == null || clientJwt.isEmpty()) {
             return ClientJwtValidationResult.INVALID;
         }
@@ -224,29 +305,46 @@ public class LoginHandler implements PacketHandler<LoginPacket> {
         Skin skin;
     }
 
-    private void enableEncryption(ChainValidationResult.IdentityClaims claims, PlayerSessionHolder holder) {
-        try {
-            var session = holder.getSession();
-            var clientKey = EncryptionUtils.parseKey(claims.identityPublicKey);
-            var encryptionKeyPair = EncryptionUtils.createKeyPair();
-            var encryptionToken = EncryptionUtils.generateRandomToken();
-            var encryptionKey = EncryptionUtils.getSecretKey(
-                encryptionKeyPair.getPrivate(), clientKey,
-                encryptionToken
-            );
-            var handshakeWebToken = EncryptionUtils.createHandshakeJwt(encryptionKeyPair, encryptionToken);
-            if (!holder.getSession().isConnected()) {
-                return;
-            }
-            var pk = new ServerToClientHandshakePacket();
-            pk.setHandshakeWebToken(handshakeWebToken);
+    @FunctionalInterface
+    private interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
 
-            session.sendPacketImmediately(pk);
-            session.enableEncryption(encryptionKey);
+    /**
+     * The parts of the login packet the off-loop steps need, copied out on the network thread so
+     * that nothing reads the packet once the pipeline has moved on from it.
+     */
+    private record Credentials(PlayerAuthenticationType authenticationType, String token, String clientJwt) {
+    }
 
-            holder.setState(SessionState.ENCRYPTION);
-        } catch (Exception e) {
-            holder.disconnect(DisconnectFailReason.UNKNOWN, "encryption error");
-        }
+    /**
+     * Result of {@link #validateChain}: either a {@code failure} with the other fields unset, or
+     * the verified identity.
+     */
+    private record ChainOutcome(
+        @Nullable DisconnectFailReason failure,
+        @Nullable ChainValidationResult.IdentityClaims identityClaims,
+        boolean signed
+    ) {
+    }
+
+    /**
+     * Result of {@link #validateClient}.
+     *
+     * @param clientChainData  {@code null} when the client JWT was rejected
+     * @param encryption       the prepared key exchange, or {@code null} when encryption is
+     *                         disabled, the JWT was rejected, or preparation failed
+     * @param encryptionFailed whether preparing the key exchange threw
+     */
+    private record ClientOutcome(
+        @Nullable ClientChainData clientChainData,
+        @Nullable Skin skin,
+        @Nullable EncryptionHandshake encryption,
+        boolean encryptionFailed
+    ) {
+    }
+
+    /** Encryption material derived off the event loop, applied once back on it. */
+    private record EncryptionHandshake(SecretKey secretKey, String handshakeJwt) {
     }
 }

--- a/src/main/java/org/powernukkitx/network/process/handler/RequestNetworkSettingsHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/RequestNetworkSettingsHandler.java
@@ -38,7 +38,7 @@ public class RequestNetworkSettingsHandler implements PacketHandler<RequestNetwo
             return;
         }
 
-        if (holder.getState().equals(SessionState.REQUESTED_NETWORK_SETTINGS)) {
+        if (!holder.getState().equals(SessionState.INITIAL)) {
             holder.disconnect(DisconnectFailReason.UNEXPECTED_PACKET);
             return;
         }

--- a/src/test/java/org/powernukkitx/network/process/SessionStateTest.java
+++ b/src/test/java/org/powernukkitx/network/process/SessionStateTest.java
@@ -7,10 +7,11 @@ class SessionStateTest {
 
     @Test
     void hasExpectedConstants() {
-        Assertions.assertEquals(7, SessionState.values().length);
+        Assertions.assertEquals(8, SessionState.values().length);
         Assertions.assertNotNull(SessionState.valueOf("INITIAL"));
         Assertions.assertNotNull(SessionState.valueOf("REQUESTED_NETWORK_SETTINGS"));
         Assertions.assertNotNull(SessionState.valueOf("LOGIN"));
+        Assertions.assertNotNull(SessionState.valueOf("AUTHENTICATING"));
         Assertions.assertNotNull(SessionState.valueOf("ENCRYPTION"));
         Assertions.assertNotNull(SessionState.valueOf("RESOURCE_PACK"));
         Assertions.assertNotNull(SessionState.valueOf("BEFORE_SPAWN"));


### PR DESCRIPTION
<!--
  Read CONTRIBUTING.md before submitting:
  https://github.com/PowerNukkitX/PowerNukkitX/blob/master/CONTRIBUTING.md

  PRs that leave this template unfilled, or fill it with generated filler,
  are closed without review. Delete the HTML comments as you go.

  SECURITY: never report a vulnerability in a public PR. See SECURITY.md.
-->

## What does this PR do?

- Running cryptography on compute pool now.
- Added SessionState.AUTHENTICATING -> second login packet on the same session rejected as unexpected rather than starting another validation (prevents DoS)
- Patched validation:
  - `ClientToServerHandshakeHandler` accepted the packet in any state except `RESOURCE_PACK`, allowing clients to reach the resource pack stage without encryption
  - `RequestNetworkSettingsHandler` accepted a repeat in any state except `REQUESTED_NETWORK_SETTINGS`, allowing sessions to be reset back to login

Cost: Competes with Terrain Generation

## Why?

<!-- What problem does this solve? Link the issue: Closes #123 -->

Running cryptography on the Netty event loop stalled unrelated players during a join burst.

## Type of change

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [X] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** Unrelated
- **Bedrock client version:** 1.26.33
- **Plugins loaded:** None

**Steps performed and results:**

1. Setup fresh PNX server
2. Tested login with `xboxAuth` on/off, whitelist/bans and `networkEncryption` on/off

- [X] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [X] Existing unit tests pass (`gradlew test`)
- [X] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

Not measurable from current JMH implementation. Noticable difference when join waves occur.

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
| Claude Opus 5 | Research based on internal benchmarks, javadoc, tests |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
