### PR TITLE
feat: recipe unlocking full implementation

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -162,6 +162,7 @@ import org.powernukkitx.permission.PermissionAttachmentInfo;
 import org.powernukkitx.plugin.InternalPlugin;
 import org.powernukkitx.plugin.Plugin;
 import org.powernukkitx.positiontracking.PositionTrackingService;
+import org.powernukkitx.recipe.unlock.PlayerRecipeBook;
 import org.powernukkitx.registry.Registries;
 import org.powernukkitx.scheduler.AsyncTask;
 import org.powernukkitx.scheduler.ServerScheduler;
@@ -337,6 +338,10 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
      * Fog settings of player.
      */
     protected List<String> fogStack = new ObjectArrayList<>();
+    /**
+     * Recipes this player has discovered.
+     */
+    protected final PlayerRecipeBook recipeBook = new PlayerRecipeBook(this);
     /**
      * The entity that the player is attacked last.
      */
@@ -717,6 +722,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         this.sendPacketImmediately(Registries.RECIPE.getCraftingPacket());
         this.syncInventory();
         this.resetInventory();
+        this.recipeBook.onSpawn();
 
         this.setEnableClientCommand(true);
 
@@ -1429,6 +1435,8 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         for (int i = 0; i < fogIdentifiers.size(); i++) {
             this.fogStack.add(i, fogIdentifiers.get(i).parseValue());
         }
+
+        this.recipeBook.load(this.nbt);
 
         if (!this.server.getSettings().playerSettings().checkMovement()) {
             this.checkMovement = false;
@@ -3957,6 +3965,8 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
 
             this.nbt.putInt("TimeSinceRest", this.timeSinceRest);
 
+            this.recipeBook.save(this.nbt);
+
             if (!this.getName().isBlank() && this.nbt != null) {
                 this.server.saveOfflinePlayerData(this.uuid, this.getNbt(), async);
             }
@@ -5955,6 +5965,17 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
      */
     public List<String> getFogStack() {
         return fogStack;
+    }
+
+    /**
+     * The player's recipe book, holding every recipe this player has discovered.
+     * The instance lives as long as the player and is usable before spawn, although it only
+     * mirrors changes to the client once {@code recipesUnlock} discovery is active.
+     *
+     * @return the recipe book, never {@code null}
+     */
+    public @NotNull PlayerRecipeBook getRecipeBook() {
+        return this.recipeBook;
     }
 
     /**

--- a/src/main/java/org/powernukkitx/event/player/PlayerUnlockRecipeEvent.java
+++ b/src/main/java/org/powernukkitx/event/player/PlayerUnlockRecipeEvent.java
@@ -11,6 +11,9 @@ import org.powernukkitx.recipe.Recipe;
  * <p>
  * Cancelling the event leaves the recipe locked, the client is not notified and the recipe
  * stays a candidate for a later unlock attempt.
+ *
+ * @author xRookieFight
+ * @since 29/07/2026
  */
 public class PlayerUnlockRecipeEvent extends PlayerEvent implements Cancellable {
     private static final HandlerList handlers = new HandlerList();

--- a/src/main/java/org/powernukkitx/event/player/PlayerUnlockRecipeEvent.java
+++ b/src/main/java/org/powernukkitx/event/player/PlayerUnlockRecipeEvent.java
@@ -1,0 +1,35 @@
+package org.powernukkitx.event.player;
+
+import org.jetbrains.annotations.NotNull;
+import org.powernukkitx.Player;
+import org.powernukkitx.event.Cancellable;
+import org.powernukkitx.event.HandlerList;
+import org.powernukkitx.recipe.Recipe;
+
+/**
+ * Called before a recipe is added to a player's recipe book.
+ * <p>
+ * Cancelling the event leaves the recipe locked, the client is not notified and the recipe
+ * stays a candidate for a later unlock attempt.
+ */
+public class PlayerUnlockRecipeEvent extends PlayerEvent implements Cancellable {
+    private static final HandlerList handlers = new HandlerList();
+
+    public static HandlerList getHandlers() {
+        return handlers;
+    }
+
+    private final Recipe recipe;
+
+    public PlayerUnlockRecipeEvent(@NotNull Player player, @NotNull Recipe recipe) {
+        this.player = player;
+        this.recipe = recipe;
+    }
+
+    /**
+     * @return the recipe about to be unlocked, never {@code null}
+     */
+    public @NotNull Recipe getRecipe() {
+        return this.recipe;
+    }
+}

--- a/src/main/java/org/powernukkitx/inventory/request/CraftRecipeActionProcessor.java
+++ b/src/main/java/org/powernukkitx/inventory/request/CraftRecipeActionProcessor.java
@@ -241,6 +241,7 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
                 }
             }
             context.put(GRID_CONSUMED_KEY, true);
+            player.getRecipeBook().unlock(recipe);
             if (recipe instanceof MultiRecipe && recipe.getResults().isEmpty()) {
                 context.put(RECIPE_DATA_KEY, recipe);
             } else if (recipe.getResults().size() == 1) {

--- a/src/main/java/org/powernukkitx/inventory/request/CraftRecipeAutoProcessor.java
+++ b/src/main/java/org/powernukkitx/inventory/request/CraftRecipeAutoProcessor.java
@@ -74,6 +74,7 @@ public class CraftRecipeAutoProcessor implements ItemStackRequestActionProcessor
             return context.error();
         } else {
             context.put(RECIPE_DATA_KEY, recipe);
+            player.getRecipeBook().unlock(recipe);
             var consumeActions = findAllConsumeActions(context.getItemStackRequest().getActions(), context.getCurrentActionIndex() + 1);
 
             int consumeActionCountNeeded = 0;

--- a/src/main/java/org/powernukkitx/item/Item.java
+++ b/src/main/java/org/powernukkitx/item/Item.java
@@ -2703,6 +2703,17 @@ public abstract class Item implements Cloneable, ItemID {
                 .build();
     }
 
+    public ItemData toRecipeNetwork() {
+        final CompoundTag nbt = this.getNbt();
+        if (nbt == null || !nbt.contains("Damage") || nbt.getInt("Damage") != 0) {
+            return this.toNetwork();
+        }
+        final Item stripped = this.clone();
+        final CompoundTag strippedNbt = nbt.copy().remove("Damage");
+        stripped.setNbt(strippedNbt.isEmpty() ? null : strippedNbt);
+        return stripped.toNetwork();
+    }
+
     public ItemData toCreativeNetwork() {
         final boolean hasNbt = this.getNbt() != null;
         final boolean clearCreativeTag = this.isCreativeTagEmpty();

--- a/src/main/java/org/powernukkitx/recipe/ShapedRecipe.java
+++ b/src/main/java/org/powernukkitx/recipe/ShapedRecipe.java
@@ -316,7 +316,7 @@ public class ShapedRecipe extends CraftingRecipe {
         payload.setWidth(this.getWidth());
         payload.setHeight(this.getHeight());
         payload.getIngredients().addAll(ingredients.stream().map(ItemDescriptor::toNetwork).toList());
-        payload.getResults().addAll(this.getResults().stream().map(Item::toNetwork).toList());
+        payload.getResults().addAll(this.getResults().stream().map(Item::toRecipeNetwork).toList());
         payload.setUuid(this.getUUID());
         payload.setTag("crafting_table");
         payload.setPriority(this.getPriority());

--- a/src/main/java/org/powernukkitx/recipe/ShapelessRecipe.java
+++ b/src/main/java/org/powernukkitx/recipe/ShapelessRecipe.java
@@ -74,7 +74,7 @@ public class ShapelessRecipe extends CraftingRecipe {
         final ShapelessRecipePayload payload = new ShapelessRecipePayload();
         payload.setRecipeId(this.getRecipeId());
         payload.getIngredients().addAll(this.getIngredients().stream().map(ItemDescriptor::toNetwork).toList());
-        payload.getResults().addAll(this.getResults().stream().map(Item::toNetwork).toList());
+        payload.getResults().addAll(this.getResults().stream().map(Item::toRecipeNetwork).toList());
         payload.setUuid(this.getUUID());
         payload.setTag(this.getRecipeIdTag());
         payload.setPriority(this.getPriority());

--- a/src/main/java/org/powernukkitx/recipe/SmeltingRecipe.java
+++ b/src/main/java/org/powernukkitx/recipe/SmeltingRecipe.java
@@ -1,6 +1,7 @@
 package org.powernukkitx.recipe;
 
 import org.cloudburstmc.protocol.bedrock.data.payload.crafting.RecipeNetId;
+import org.cloudburstmc.protocol.bedrock.data.payload.crafting.RecipeUnlockingContext;
 import org.cloudburstmc.protocol.bedrock.data.payload.crafting.RecipeUnlockingRequirement;
 import org.cloudburstmc.protocol.bedrock.data.payload.crafting.ShapelessRecipePayload;
 import org.powernukkitx.item.Item;
@@ -10,6 +11,8 @@ import org.powernukkitx.registry.RecipeRegistry;
 import java.util.UUID;
 
 public abstract class SmeltingRecipe extends BaseRecipe {
+    private RecipeUnlockingRequirement unlockingRequirement;
+
     protected SmeltingRecipe(String id) {
         super(id);
     }
@@ -30,13 +33,26 @@ public abstract class SmeltingRecipe extends BaseRecipe {
         final ShapelessRecipePayload payload = new ShapelessRecipePayload();
         payload.setRecipeId(this.getRecipeId());
         payload.getIngredients().add(this.getInput().toNetwork());
-        payload.getResults().add(this.getResult().toNetwork());
+        payload.getResults().add(this.getResult().toRecipeNetwork());
         payload.setUuid( UUID.randomUUID());
         payload.setTag(this.getRecipeIdTag());
         payload.setPriority(0);
-        payload.setUnlockingRequirement(RecipeUnlockingRequirement.INVALID);
+        payload.setUnlockingRequirement(this.getUnlockingRequirement());
         payload.setNetId(new RecipeNetId( RecipeRegistry.FURNACE_RECIPE_NET_ID_COUNTER++));
         return payload;
+    }
+
+    public void setUnlockingRequirement(RecipeUnlockingRequirement unlockingRequirement) {
+        this.unlockingRequirement = unlockingRequirement;
+    }
+
+    public RecipeUnlockingRequirement getUnlockingRequirement() {
+        if (this.unlockingRequirement != null) {
+            return this.unlockingRequirement;
+        }
+        final RecipeUnlockingRequirement derived = new RecipeUnlockingRequirement(RecipeUnlockingContext.NONE);
+        derived.getUnlockingIngredients().add(this.getInput().toNetwork());
+        return derived;
     }
 
     public abstract String getRecipeIdTag();

--- a/src/main/java/org/powernukkitx/recipe/SmithingTransformRecipe.java
+++ b/src/main/java/org/powernukkitx/recipe/SmithingTransformRecipe.java
@@ -77,7 +77,7 @@ public class SmithingTransformRecipe extends BaseRecipe {
         payload.setTemplateIngredient(this.getTemplate().toNetwork());
         payload.setBaseIngredient(this.getBase().toNetwork());
         payload.setAdditionIngredient(this.getAddition().toNetwork());
-        payload.setResult(this.getResult().toNetwork());
+        payload.setResult(this.getResult().toRecipeNetwork());
         payload.setTag("smithing_table");
         payload.setNetId(new RecipeNetId(this.netId));
         return payload;

--- a/src/main/java/org/powernukkitx/recipe/StonecutterRecipe.java
+++ b/src/main/java/org/powernukkitx/recipe/StonecutterRecipe.java
@@ -57,7 +57,7 @@ public class StonecutterRecipe extends CraftingRecipe {
         final ShapelessRecipePayload payload = new ShapelessRecipePayload();
         payload.setRecipeId(this.getRecipeId());
         payload.getIngredients().addAll(this.getIngredients().stream().map(ItemDescriptor::toNetwork).toList());
-        payload.getResults().addAll(this.getResults().stream().map(Item::toNetwork).toList());
+        payload.getResults().addAll(this.getResults().stream().map(Item::toRecipeNetwork).toList());
         payload.setUuid(this.getUUID());
         payload.setTag(this.getRecipeIdTag());
         payload.setPriority(this.getPriority());

--- a/src/main/java/org/powernukkitx/recipe/unlock/PlayerRecipeBook.java
+++ b/src/main/java/org/powernukkitx/recipe/unlock/PlayerRecipeBook.java
@@ -1,0 +1,246 @@
+package org.powernukkitx.recipe.unlock;
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import org.cloudburstmc.protocol.bedrock.packet.UnlockedRecipesPacket;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.UnmodifiableView;
+import org.powernukkitx.Player;
+import org.powernukkitx.event.player.PlayerUnlockRecipeEvent;
+import org.powernukkitx.inventory.HumanInventory;
+import org.powernukkitx.inventory.Inventory;
+import org.powernukkitx.inventory.InventoryListener;
+import org.powernukkitx.item.Item;
+import org.powernukkitx.level.GameRule;
+import org.powernukkitx.nbt.tag.CompoundTag;
+import org.powernukkitx.nbt.tag.ListTag;
+import org.powernukkitx.nbt.tag.StringTag;
+import org.powernukkitx.recipe.Recipe;
+import org.powernukkitx.recipe.descriptor.ItemDescriptor;
+import org.powernukkitx.registry.Registries;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The set of recipes a player has discovered, mirrored to the client through
+ * {@link UnlockedRecipesPacket}.
+ * <p>
+ * Discovery is driven by the {@code recipesUnlock} game rule of the level the player spawned in.
+ * While the rule is off the client keeps showing the full recipe book and no packet is sent, so
+ * the book behaves exactly as it did before this class existed. While it is on the player starts
+ * from the persisted set and unlocks a recipe as soon as every one of its ingredients is present
+ * in the inventory, or as soon as the recipe is crafted.
+ * <p>
+ * Every method must be called from the thread that owns the player.
+ */
+public class PlayerRecipeBook implements InventoryListener {
+    private static final String UNLOCKED_RECIPES_TAG = "UnlockedRecipes";
+
+    private final Player player;
+    private final Set<String> unlockedRecipes = new ObjectOpenHashSet<>();
+    private boolean discovering;
+
+    public PlayerRecipeBook(@NotNull Player player) {
+        this.player = player;
+    }
+
+    /**
+     * Whether this book progressively discovers recipes. {@code false} means the client sees every
+     * recipe from the start, which is the case when the {@code recipesUnlock} game rule is off or
+     * when the recipe registry is disabled entirely.
+     */
+    public boolean isDiscovering() {
+        return this.discovering;
+    }
+
+    /**
+     * @return the unlocked recipe ids, in no particular order
+     */
+    public @NotNull @UnmodifiableView Set<String> getUnlockedRecipes() {
+        return Collections.unmodifiableSet(this.unlockedRecipes);
+    }
+
+    public boolean isUnlocked(@NotNull String recipeId) {
+        return this.unlockedRecipes.contains(recipeId);
+    }
+
+    /**
+     * Reads the persisted recipe ids. Recipes that no longer exist are dropped on the next spawn.
+     *
+     * @param nbt the player's root tag
+     */
+    public void load(@NotNull CompoundTag nbt) {
+        this.unlockedRecipes.clear();
+        if (!nbt.contains(UNLOCKED_RECIPES_TAG)) {
+            return;
+        }
+        for (StringTag tag : nbt.getList(UNLOCKED_RECIPES_TAG, StringTag.class).getAll()) {
+            this.unlockedRecipes.add(tag.parseValue());
+        }
+    }
+
+    /**
+     * Writes the unlocked recipe ids into the player's root tag.
+     *
+     * @param nbt the player's root tag
+     */
+    public void save(@NotNull CompoundTag nbt) {
+        if (this.unlockedRecipes.isEmpty() && !nbt.contains(UNLOCKED_RECIPES_TAG)) {
+            return;
+        }
+        final ListTag<StringTag> list = new ListTag<>();
+        for (String recipeId : this.unlockedRecipes) {
+            list.add(new StringTag(recipeId));
+        }
+        nbt.putList(UNLOCKED_RECIPES_TAG, list);
+    }
+
+    /**
+     * Decides whether to discover recipes for this session, sends the initial book state and starts
+     * listening for inventory changes. Called once the player has spawned and its inventory holds
+     * the loaded contents.
+     */
+    public void onSpawn() {
+        this.discovering = Registries.RECIPE.isEnabled()
+            && this.player.getLevel().getGameRules().getBoolean(GameRule.RECIPES_UNLOCK);
+        if (!this.discovering) {
+            return;
+        }
+        this.unlockedRecipes.removeIf(recipeId -> Registries.RECIPE.get(recipeId) == null);
+        this.sendPacket(UnlockedRecipesPacket.UnlockedRecipesPacketType.INITIALLY_UNLOCKED, this.unlockedRecipes);
+        this.player.getInventory().addListener(this);
+        this.discoverFromInventory();
+    }
+
+    /**
+     * Unlocks a single recipe and notifies the client. Fires {@link PlayerUnlockRecipeEvent}.
+     *
+     * @param recipe the recipe to unlock
+     * @return {@code false} when discovery is off, when it was already unlocked, or when a plugin
+     * cancelled the event
+     */
+    public boolean unlock(@NotNull Recipe recipe) {
+        if (!this.addUnlocked(recipe)) {
+            return false;
+        }
+        this.sendPacket(UnlockedRecipesPacket.UnlockedRecipesPacketType.NEWLY_UNLOCKED, List.of(recipe.getRecipeId()));
+        return true;
+    }
+
+    /**
+     * Removes a recipe from the book and hides it on the client again.
+     *
+     * @param recipe the recipe to lock
+     * @return {@code false} when it was not unlocked in the first place
+     */
+    public boolean lock(@NotNull Recipe recipe) {
+        if (!this.unlockedRecipes.remove(recipe.getRecipeId())) {
+            return false;
+        }
+        this.sendPacket(UnlockedRecipesPacket.UnlockedRecipesPacketType.REMOVE_UNLOCKED, List.of(recipe.getRecipeId()));
+        return true;
+    }
+
+    /**
+     * Empties the book and tells the client to forget everything it had unlocked.
+     */
+    public void reset() {
+        this.unlockedRecipes.clear();
+        this.sendPacket(UnlockedRecipesPacket.UnlockedRecipesPacketType.REMOVE_ALL, List.of());
+    }
+
+    @Override
+    public void onInventoryChanged(Inventory inventory, Item oldItem, int slot) {
+        if (!this.discovering) {
+            return;
+        }
+        final Item current = inventory.getUnclonedItem(slot);
+        if (current.isNull()) {
+            return;
+        }
+        final Set<String> candidates = Registries.RECIPE.getUnlockIndex().getCandidates(current.getId());
+        if (candidates.isEmpty()) {
+            return;
+        }
+        this.unlockMatching(candidates);
+    }
+
+    private void discoverFromInventory() {
+        final RecipeUnlockIndex index = Registries.RECIPE.getUnlockIndex();
+        final Set<String> candidates = new ObjectOpenHashSet<>();
+        final HumanInventory inventory = this.player.getInventory();
+        for (int slot = 0; slot < HumanInventory.ARMORS_INDEX; slot++) {
+            final Item item = inventory.getUnclonedItem(slot);
+            if (!item.isNull()) {
+                candidates.addAll(index.getCandidates(item.getId()));
+            }
+        }
+        if (!candidates.isEmpty()) {
+            this.unlockMatching(candidates);
+        }
+    }
+
+    private void unlockMatching(Collection<String> candidates) {
+        List<String> newlyUnlocked = null;
+        for (String recipeId : candidates) {
+            if (this.unlockedRecipes.contains(recipeId)) {
+                continue;
+            }
+            final Recipe recipe = Registries.RECIPE.get(recipeId);
+            if (recipe == null || !this.hasEveryIngredient(recipe)) {
+                continue;
+            }
+            if (!this.addUnlocked(recipe)) {
+                continue;
+            }
+            if (newlyUnlocked == null) {
+                newlyUnlocked = new ObjectArrayList<>();
+            }
+            newlyUnlocked.add(recipeId);
+        }
+        if (newlyUnlocked != null) {
+            this.sendPacket(UnlockedRecipesPacket.UnlockedRecipesPacketType.NEWLY_UNLOCKED, newlyUnlocked);
+        }
+    }
+
+    private boolean hasEveryIngredient(Recipe recipe) {
+        final HumanInventory inventory = this.player.getInventory();
+        for (ItemDescriptor ingredient : recipe.getIngredients()) {
+            boolean found = false;
+            for (int slot = 0; slot < HumanInventory.ARMORS_INDEX && !found; slot++) {
+                final Item item = inventory.getUnclonedItem(slot);
+                found = !item.isNull() && ingredient.match(item);
+            }
+            if (!found) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean addUnlocked(Recipe recipe) {
+        if (!this.discovering || this.unlockedRecipes.contains(recipe.getRecipeId())) {
+            return false;
+        }
+        final PlayerUnlockRecipeEvent event = new PlayerUnlockRecipeEvent(this.player, recipe);
+        this.player.getServer().getPluginManager().callEvent(event);
+        if (event.isCancelled()) {
+            return false;
+        }
+        this.unlockedRecipes.add(recipe.getRecipeId());
+        return true;
+    }
+
+    private void sendPacket(UnlockedRecipesPacket.UnlockedRecipesPacketType type, Collection<String> recipeIds) {
+        if (!this.discovering) {
+            return;
+        }
+        final UnlockedRecipesPacket packet = new UnlockedRecipesPacket();
+        packet.setType(type);
+        packet.getUnlockedRecipesList().addAll(recipeIds);
+        this.player.sendPacket(packet);
+    }
+}

--- a/src/main/java/org/powernukkitx/recipe/unlock/PlayerRecipeBook.java
+++ b/src/main/java/org/powernukkitx/recipe/unlock/PlayerRecipeBook.java
@@ -16,7 +16,6 @@ import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.nbt.tag.ListTag;
 import org.powernukkitx.nbt.tag.StringTag;
 import org.powernukkitx.recipe.Recipe;
-import org.powernukkitx.recipe.descriptor.ItemDescriptor;
 import org.powernukkitx.registry.Registries;
 
 import java.util.Collection;
@@ -31,8 +30,8 @@ import java.util.Set;
  * Discovery is driven by the {@code recipesUnlock} game rule of the level the player spawned in.
  * While the rule is off the client keeps showing the full recipe book and no packet is sent, so
  * the book behaves exactly as it did before this class existed. While it is on the player starts
- * from the persisted set and unlocks a recipe as soon as every one of its ingredients is present
- * in the inventory, or as soon as the recipe is crafted.
+ * from the persisted set and unlocks a recipe as soon as one of its vanilla unlock trigger items
+ * enters the inventory, or as soon as the recipe is crafted.
  * <p>
  * Every method must be called from the thread that owns the player.
  */
@@ -165,7 +164,7 @@ public class PlayerRecipeBook implements InventoryListener {
         if (candidates.isEmpty()) {
             return;
         }
-        this.unlockMatching(candidates);
+        this.unlockAll(candidates);
     }
 
     private void discoverFromInventory() {
@@ -179,21 +178,18 @@ public class PlayerRecipeBook implements InventoryListener {
             }
         }
         if (!candidates.isEmpty()) {
-            this.unlockMatching(candidates);
+            this.unlockAll(candidates);
         }
     }
 
-    private void unlockMatching(Collection<String> candidates) {
+    private void unlockAll(Collection<String> candidates) {
         List<String> newlyUnlocked = null;
         for (String recipeId : candidates) {
             if (this.unlockedRecipes.contains(recipeId)) {
                 continue;
             }
             final Recipe recipe = Registries.RECIPE.get(recipeId);
-            if (recipe == null || !this.hasEveryIngredient(recipe)) {
-                continue;
-            }
-            if (!this.addUnlocked(recipe)) {
+            if (recipe == null || !this.addUnlocked(recipe)) {
                 continue;
             }
             if (newlyUnlocked == null) {
@@ -204,21 +200,6 @@ public class PlayerRecipeBook implements InventoryListener {
         if (newlyUnlocked != null) {
             this.sendPacket(UnlockedRecipesPacket.UnlockedRecipesPacketType.NEWLY_UNLOCKED, newlyUnlocked);
         }
-    }
-
-    private boolean hasEveryIngredient(Recipe recipe) {
-        final HumanInventory inventory = this.player.getInventory();
-        for (ItemDescriptor ingredient : recipe.getIngredients()) {
-            boolean found = false;
-            for (int slot = 0; slot < HumanInventory.ARMORS_INDEX && !found; slot++) {
-                final Item item = inventory.getUnclonedItem(slot);
-                found = !item.isNull() && ingredient.match(item);
-            }
-            if (!found) {
-                return false;
-            }
-        }
-        return true;
     }
 
     private boolean addUnlocked(Recipe recipe) {

--- a/src/main/java/org/powernukkitx/recipe/unlock/PlayerRecipeBook.java
+++ b/src/main/java/org/powernukkitx/recipe/unlock/PlayerRecipeBook.java
@@ -34,6 +34,9 @@ import java.util.Set;
  * enters the inventory, or as soon as the recipe is crafted.
  * <p>
  * Every method must be called from the thread that owns the player.
+ *
+ * @author xRookieFight
+ * @since 29/07/2026
  */
 public class PlayerRecipeBook implements InventoryListener {
     private static final String UNLOCKED_RECIPES_TAG = "UnlockedRecipes";

--- a/src/main/java/org/powernukkitx/recipe/unlock/RecipeUnlockIndex.java
+++ b/src/main/java/org/powernukkitx/recipe/unlock/RecipeUnlockIndex.java
@@ -1,0 +1,102 @@
+package org.powernukkitx.recipe.unlock;
+
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.UnmodifiableView;
+import org.powernukkitx.recipe.CraftingRecipe;
+import org.powernukkitx.recipe.Recipe;
+import org.powernukkitx.recipe.SmeltingRecipe;
+import org.powernukkitx.recipe.SmithingTransformRecipe;
+import org.powernukkitx.recipe.SmithingTrimRecipe;
+import org.powernukkitx.recipe.descriptor.DefaultDescriptor;
+import org.powernukkitx.recipe.descriptor.ItemDescriptor;
+import org.powernukkitx.recipe.descriptor.ItemTagDescriptor;
+import org.powernukkitx.tags.ItemTags;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Reverse lookup from an item to the recipes it may unlock.
+ * <p>
+ * Only recipes that the client shows in its recipe book are indexed, since only those can be
+ * addressed by {@link org.cloudburstmc.protocol.bedrock.packet.UnlockedRecipesPacket}. The index
+ * narrows the candidate set for a newly obtained item; whether a candidate is actually unlockable
+ * is decided by matching its ingredients against the player inventory.
+ * <p>
+ * Populated from {@link org.powernukkitx.registry.RecipeRegistry#register(String, Recipe)} on the
+ * thread that registers recipes and read from the player handling code afterwards; it is not
+ * safe to register recipes concurrently with lookups.
+ */
+public final class RecipeUnlockIndex {
+    private final Map<String, Set<String>> recipesByItemId = new Object2ObjectOpenHashMap<>();
+    private final Map<String, Set<String>> recipesByItemTag = new Object2ObjectOpenHashMap<>();
+
+    /**
+     * Indexes a recipe by every ingredient it can be identified through. Recipes that never show up
+     * in the recipe book, and ingredient descriptors that cannot be resolved to a concrete item or
+     * tag, are ignored.
+     *
+     * @param recipe the recipe to index
+     */
+    public void index(@NotNull Recipe recipe) {
+        if (!isBookVisible(recipe)) {
+            return;
+        }
+        final String recipeId = recipe.getRecipeId();
+        for (ItemDescriptor ingredient : recipe.getIngredients()) {
+            switch (ingredient) {
+                case DefaultDescriptor descriptor ->
+                    recipesByItemId.computeIfAbsent(descriptor.getItem().getId(), id -> new ObjectOpenHashSet<>()).add(recipeId);
+                case ItemTagDescriptor descriptor ->
+                    recipesByItemTag.computeIfAbsent(descriptor.getItemTag(), tag -> new ObjectOpenHashSet<>()).add(recipeId);
+                default -> {
+                }
+            }
+        }
+    }
+
+    /**
+     * Recipe ids that use the given item as an ingredient, either directly or through one of its
+     * item tags.
+     *
+     * @param itemId the identifier of the obtained item
+     * @return the candidate recipe ids, empty when the item is not an ingredient of anything
+     */
+    public @NotNull @UnmodifiableView Set<String> getCandidates(@NotNull String itemId) {
+        final Set<String> direct = recipesByItemId.get(itemId);
+        final Set<String> tags = ItemTags.getTagSet(itemId);
+        Set<String> merged = null;
+        for (String tag : tags) {
+            final Set<String> tagged = recipesByItemTag.get(tag);
+            if (tagged == null) {
+                continue;
+            }
+            if (merged == null) {
+                merged = new ObjectOpenHashSet<>(tagged.size() + (direct == null ? 0 : direct.size()));
+                if (direct != null) {
+                    merged.addAll(direct);
+                }
+            }
+            merged.addAll(tagged);
+        }
+        if (merged != null) {
+            return Collections.unmodifiableSet(merged);
+        }
+        return direct == null ? Set.of() : Collections.unmodifiableSet(direct);
+    }
+
+    public void clear() {
+        recipesByItemId.clear();
+        recipesByItemTag.clear();
+    }
+
+    private static boolean isBookVisible(Recipe recipe) {
+        return recipe instanceof CraftingRecipe
+            || recipe instanceof SmeltingRecipe
+            || recipe instanceof SmithingTransformRecipe
+            || recipe instanceof SmithingTrimRecipe;
+    }
+}

--- a/src/main/java/org/powernukkitx/recipe/unlock/RecipeUnlockIndex.java
+++ b/src/main/java/org/powernukkitx/recipe/unlock/RecipeUnlockIndex.java
@@ -31,6 +31,9 @@ import java.util.Set;
  * Populated from {@link org.powernukkitx.registry.RecipeRegistry#register(String, Recipe)} on the
  * thread that registers recipes and read from the player handling code afterwards; it is not
  * safe to register recipes concurrently with lookups.
+ *
+ * @author xRookieFight
+ * @since 29/07/2026
  */
 public final class RecipeUnlockIndex {
     private final Map<String, Set<String>> recipesByItemId = new Object2ObjectOpenHashMap<>();

--- a/src/main/java/org/powernukkitx/recipe/unlock/RecipeUnlockIndex.java
+++ b/src/main/java/org/powernukkitx/recipe/unlock/RecipeUnlockIndex.java
@@ -2,16 +2,16 @@ package org.powernukkitx.recipe.unlock;
 
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.ItemTagDescriptor;
+import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.NameDescriptor;
+import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.RecipeIngredient;
+import org.cloudburstmc.protocol.bedrock.data.payload.crafting.RecipeUnlockingContext;
+import org.cloudburstmc.protocol.bedrock.data.payload.crafting.RecipeUnlockingRequirement;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnmodifiableView;
 import org.powernukkitx.recipe.CraftingRecipe;
 import org.powernukkitx.recipe.Recipe;
 import org.powernukkitx.recipe.SmeltingRecipe;
-import org.powernukkitx.recipe.SmithingTransformRecipe;
-import org.powernukkitx.recipe.SmithingTrimRecipe;
-import org.powernukkitx.recipe.descriptor.DefaultDescriptor;
-import org.powernukkitx.recipe.descriptor.ItemDescriptor;
-import org.powernukkitx.recipe.descriptor.ItemTagDescriptor;
 import org.powernukkitx.tags.ItemTags;
 
 import java.util.Collections;
@@ -19,12 +19,14 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * Reverse lookup from an item to the recipes it may unlock.
+ * Reverse lookup from an item to the recipes that item unlocks.
  * <p>
- * Only recipes that the client shows in its recipe book are indexed, since only those can be
- * addressed by {@link org.cloudburstmc.protocol.bedrock.packet.UnlockedRecipesPacket}. The index
- * narrows the candidate set for a newly obtained item; whether a candidate is actually unlockable
- * is decided by matching its ingredients against the player inventory.
+ * The index follows the vanilla unlock triggers carried in each recipe's
+ * {@link RecipeUnlockingRequirement}: a recipe becomes a candidate the moment the player obtains
+ * one of the trigger items, which is not necessarily the full ingredient list. Wooden tools for
+ * example unlock through a single stick. Recipes without unlock data, or recipes unlocked through
+ * a special context such as {@code ALWAYS_UNLOCKED} or {@code PLAYER_IN_WATER}, carry no item
+ * trigger and are therefore not indexed - the client resolves those contexts on its own.
  * <p>
  * Populated from {@link org.powernukkitx.registry.RecipeRegistry#register(String, Recipe)} on the
  * thread that registers recipes and read from the player handling code afterwards; it is not
@@ -35,21 +37,28 @@ public final class RecipeUnlockIndex {
     private final Map<String, Set<String>> recipesByItemTag = new Object2ObjectOpenHashMap<>();
 
     /**
-     * Indexes a recipe by every ingredient it can be identified through. Recipes that never show up
-     * in the recipe book, and ingredient descriptors that cannot be resolved to a concrete item or
-     * tag, are ignored.
+     * Indexes a recipe by its unlock trigger items. Recipes without an item based unlock
+     * requirement are ignored.
      *
      * @param recipe the recipe to index
      */
     public void index(@NotNull Recipe recipe) {
-        if (!isBookVisible(recipe)) {
+        switch (recipe) {
+            case CraftingRecipe crafting -> index(crafting.getRecipeId(), crafting.getRequirement());
+            case SmeltingRecipe smelting -> index(smelting.getRecipeId(), smelting.getUnlockingRequirement());
+            default -> {
+            }
+        }
+    }
+
+    private void index(String recipeId, RecipeUnlockingRequirement requirement) {
+        if (requirement == null || requirement.getUnlockingContext() != RecipeUnlockingContext.NONE) {
             return;
         }
-        final String recipeId = recipe.getRecipeId();
-        for (ItemDescriptor ingredient : recipe.getIngredients()) {
-            switch (ingredient) {
-                case DefaultDescriptor descriptor ->
-                    recipesByItemId.computeIfAbsent(descriptor.getItem().getId(), id -> new ObjectOpenHashSet<>()).add(recipeId);
+        for (RecipeIngredient trigger : requirement.getUnlockingIngredients()) {
+            switch (trigger.getDescriptor()) {
+                case NameDescriptor descriptor ->
+                    recipesByItemId.computeIfAbsent(descriptor.getItemId().getIdentifier(), id -> new ObjectOpenHashSet<>()).add(recipeId);
                 case ItemTagDescriptor descriptor ->
                     recipesByItemTag.computeIfAbsent(descriptor.getItemTag(), tag -> new ObjectOpenHashSet<>()).add(recipeId);
                 default -> {
@@ -59,11 +68,11 @@ public final class RecipeUnlockIndex {
     }
 
     /**
-     * Recipe ids that use the given item as an ingredient, either directly or through one of its
+     * Recipe ids unlocked by obtaining the given item, either directly or through one of its
      * item tags.
      *
      * @param itemId the identifier of the obtained item
-     * @return the candidate recipe ids, empty when the item is not an ingredient of anything
+     * @return the unlocked recipe ids, empty when the item unlocks nothing
      */
     public @NotNull @UnmodifiableView Set<String> getCandidates(@NotNull String itemId) {
         final Set<String> direct = recipesByItemId.get(itemId);
@@ -91,12 +100,5 @@ public final class RecipeUnlockIndex {
     public void clear() {
         recipesByItemId.clear();
         recipesByItemTag.clear();
-    }
-
-    private static boolean isBookVisible(Recipe recipe) {
-        return recipe instanceof CraftingRecipe
-            || recipe instanceof SmeltingRecipe
-            || recipe instanceof SmithingTransformRecipe
-            || recipe instanceof SmithingTrimRecipe;
     }
 }

--- a/src/main/java/org/powernukkitx/registry/RecipeRegistry.java
+++ b/src/main/java/org/powernukkitx/registry/RecipeRegistry.java
@@ -1,5 +1,6 @@
 package org.powernukkitx.registry;
 
+import org.cloudburstmc.protocol.bedrock.data.payload.crafting.RecipeUnlockingContext;
 import org.cloudburstmc.protocol.bedrock.data.payload.crafting.RecipeUnlockingRequirement;
 import org.powernukkitx.Server;
 import org.powernukkitx.item.Item;
@@ -720,7 +721,8 @@ public class RecipeRegistry implements IRegistry<String, Recipe, Recipe> {
                             netId,
                             priority,
                             primaryResult.toItem(),
-                            ingredients.getFirst().toItem()
+                            ingredients.getFirst().toItem(),
+                            parseUnlockingRequirement(recipe, inputParseType)
                         ));
                     }
                     case "cartography_table" -> {
@@ -749,7 +751,8 @@ public class RecipeRegistry implements IRegistry<String, Recipe, Recipe> {
                             netId,
                             priority,
                             primaryResult.toItem(),
-                            ingredients
+                            ingredients,
+                            parseUnlockingRequirement(recipe, inputParseType)
                         ));
                     }
 
@@ -768,6 +771,7 @@ public class RecipeRegistry implements IRegistry<String, Recipe, Recipe> {
                         UUID uuid = UUID.fromString((String) recipe.get("uuid"));
                         int priority = (int) ((double) recipe.get("priority"));
                         int netId = (int) ((double) recipe.get("netId"));
+                        RecipeUnlockingRequirement unlockingRequirement = parseUnlockingRequirement(recipe, inputParseType);
 
                         List<Map<String, Object>> outputs = (List<Map<String, Object>>) recipe.get("output");
                         Map<String, Object> primaryResultData = outputs.removeFirst();
@@ -808,7 +812,7 @@ public class RecipeRegistry implements IRegistry<String, Recipe, Recipe> {
                                 ingredients,
                                 extraResults,
                                 false,
-                                RecipeUnlockingRequirement.INVALID
+                                unlockingRequirement
                             ));
                         } else {    // is shapeless recipe
 
@@ -828,7 +832,7 @@ public class RecipeRegistry implements IRegistry<String, Recipe, Recipe> {
                                     priority,
                                     primaryResult.toItem(),
                                     ingredients,
-                                    RecipeUnlockingRequirement.INVALID
+                                    unlockingRequirement
                                 ));
                             } else {
                                 this.register(new ShapelessRecipe(
@@ -838,7 +842,7 @@ public class RecipeRegistry implements IRegistry<String, Recipe, Recipe> {
                                     priority,
                                     primaryResult.toItem(),
                                     ingredients,
-                                    RecipeUnlockingRequirement.INVALID
+                                    unlockingRequirement
                                 ));
                             }
                         }
@@ -871,15 +875,17 @@ public class RecipeRegistry implements IRegistry<String, Recipe, Recipe> {
 
                         this.register(smeltingRecipe);*/
 
+                        RecipeUnlockingRequirement unlockingRequirement = parseUnlockingRequirement(recipe, ParseType.FURNACE_INPUT);
+
                         if (primaryResult instanceof ItemTagDescriptor tagDescriptor) {
                             final Set<String> ids = ItemTags.getItemSet(tagDescriptor.getItemTag());
                             for (String id : ids) {
                                 final Item outputItem = Item.get(id, 0, tagDescriptor.getCount());
-                                this.registerFurnaceRecipe(block, outputItem, ingredients, furnaceXpConfig);
+                                this.registerFurnaceRecipe(block, outputItem, ingredients, furnaceXpConfig, unlockingRequirement);
                             }
                         } else {
                             final Item outputItem = primaryResult.toItem();
-                            this.registerFurnaceRecipe(block, outputItem, ingredients, furnaceXpConfig);
+                            this.registerFurnaceRecipe(block, outputItem, ingredients, furnaceXpConfig, unlockingRequirement);
                         }
                     }
                 }
@@ -909,21 +915,21 @@ public class RecipeRegistry implements IRegistry<String, Recipe, Recipe> {
             Collections.singletonList(Item.get(ItemID.FILLED_MAP, 5, 1, EmptyArrays.EMPTY_BYTES, false))));
     }
 
-    private void registerFurnaceRecipe(String block, Item outputItem, List<ItemDescriptor> ingredients, Config furnaceXpConfig) {
+    private void registerFurnaceRecipe(String block, Item outputItem, List<ItemDescriptor> ingredients, Config furnaceXpConfig, RecipeUnlockingRequirement unlockingRequirement) {
         final ItemDescriptor descriptor = ingredients.getFirst();
         if (descriptor instanceof ItemTagDescriptor tagDescriptor) {
             final Set<String> ids = ItemTags.getItemSet(tagDescriptor.getItemTag());
             for (String id : ids) {
                 final Item inputItem = Item.get(id, 0, tagDescriptor.getCount());
-                this.registerFurnaceRecipe(block, outputItem, inputItem, furnaceXpConfig);
+                this.registerFurnaceRecipe(block, outputItem, inputItem, furnaceXpConfig, unlockingRequirement);
             }
         } else {
             final Item inputItem = ingredients.getFirst().toItem();
-            this.registerFurnaceRecipe(block, outputItem, inputItem, furnaceXpConfig);
+            this.registerFurnaceRecipe(block, outputItem, inputItem, furnaceXpConfig, unlockingRequirement);
         }
     }
 
-    private void registerFurnaceRecipe(String block, Item outputItem, Item inputItem, Config furnaceXpConfig) {
+    private void registerFurnaceRecipe(String block, Item outputItem, Item inputItem, Config furnaceXpConfig, RecipeUnlockingRequirement unlockingRequirement) {
         final SmeltingRecipe smeltingRecipeInternal = switch (block) {
             case "blast_furnace" -> new BlastFurnaceRecipe(outputItem, inputItem);
             case "smoker" -> new SmokerRecipe(outputItem, inputItem);
@@ -931,6 +937,9 @@ public class RecipeRegistry implements IRegistry<String, Recipe, Recipe> {
             case "soul_campfire" -> new SoulCampfireRecipe(outputItem, inputItem);
             default -> new FurnaceRecipe(outputItem, inputItem);
         };
+        if (unlockingRequirement != null && !unlockingRequirement.isInvalid()) {
+            smeltingRecipeInternal.setUnlockingRequirement(unlockingRequirement);
+        }
         try {
             this.register(smeltingRecipeInternal);
 
@@ -947,6 +956,32 @@ public class RecipeRegistry implements IRegistry<String, Recipe, Recipe> {
     private void registerSpecial() {
         this.register(new DecoratedPotRecipe(10000));
         this.register(new SmithingArmorTrimCorrectedRecipe(10001));
+    }
+
+    /**
+     * Parses the vanilla {@code unlockingRequirements} block of a recipe entry. The requirement is
+     * forwarded to the client inside the crafting data packet so it can unlock the recipe on its
+     * own, and it drives the server side {@link RecipeUnlockIndex}.
+     *
+     * @return the parsed requirement, or {@link RecipeUnlockingRequirement#INVALID} when the recipe
+     * has no unlock data
+     */
+    private RecipeUnlockingRequirement parseUnlockingRequirement(Map<String, Object> recipeData, ParseType inputParseType) {
+        Map<String, Object> data = (Map<String, Object>) recipeData.get("unlockingRequirements");
+        if (data == null) {
+            return RecipeUnlockingRequirement.INVALID;
+        }
+        final RecipeUnlockingRequirement requirement = new RecipeUnlockingRequirement(RecipeUnlockingContext.from(Utils.toInt(data.get("context"))));
+        final List<Map<String, Object>> items = (List<Map<String, Object>>) data.get("items");
+        if (items != null) {
+            for (Map<String, Object> item : items) {
+                final ItemDescriptor descriptor = parseDescription(item, inputParseType);
+                if (descriptor != null) {
+                    requirement.getUnlockingIngredients().add(descriptor.toNetwork());
+                }
+            }
+        }
+        return requirement;
     }
 
     /**

--- a/src/main/java/org/powernukkitx/registry/RecipeRegistry.java
+++ b/src/main/java/org/powernukkitx/registry/RecipeRegistry.java
@@ -11,6 +11,7 @@ import org.powernukkitx.recipe.descriptor.ItemDescriptorType;
 import org.powernukkitx.recipe.descriptor.ItemTagDescriptor;
 import org.powernukkitx.recipe.special.DecoratedPotRecipe;
 import org.powernukkitx.recipe.special.SmithingArmorTrimCorrectedRecipe;
+import org.powernukkitx.recipe.unlock.RecipeUnlockIndex;
 import org.powernukkitx.tags.ItemTags;
 import org.powernukkitx.utils.Config;
 import org.powernukkitx.utils.Identifier;
@@ -63,11 +64,23 @@ public class RecipeRegistry implements IRegistry<String, Recipe, Recipe> {
     private final Object2ObjectOpenHashMap<String, Recipe> allRecipeMaps = new Object2ObjectOpenHashMap<>();
     private final Object2DoubleOpenHashMap<Recipe> recipeXpMap = new Object2DoubleOpenHashMap<>();
     private final Int2ObjectMap<Recipe> networkIdRecipeMap = new Int2ObjectOpenHashMap<>();
+    private final RecipeUnlockIndex unlockIndex = new RecipeUnlockIndex();
 
     public static int FURNACE_RECIPE_NET_ID_COUNTER = 111000;
 
     public VanillaRecipeParser getVanillaRecipeParser() {
         return vanillaRecipeParser;
+    }
+
+    /**
+     * The reverse ingredient lookup used to decide which recipes a player may unlock.
+     * It is kept in sync by {@link #register(String, Recipe)} and is empty while the registry
+     * is disabled.
+     *
+     * @return the shared index, never {@code null}
+     */
+    public RecipeUnlockIndex getUnlockIndex() {
+        return unlockIndex;
     }
 
     public Int2ObjectMap<Recipe> getNetworkIdRecipeMap() {
@@ -455,6 +468,7 @@ public class RecipeRegistry implements IRegistry<String, Recipe, Recipe> {
         recipeXpMap.clear();
         allRecipeMaps.clear();
         networkIdRecipeMap.clear();
+        unlockIndex.clear();
         if (enabled) {
             init();
         } else {
@@ -492,6 +506,7 @@ public class RecipeRegistry implements IRegistry<String, Recipe, Recipe> {
 
             }
         }
+        this.unlockIndex.index(recipe);
     }
 
     public void register(Recipe recipe) {
@@ -507,6 +522,7 @@ public class RecipeRegistry implements IRegistry<String, Recipe, Recipe> {
         networkIdRecipeMap.clear();
         recipeMaps.values().forEach(Map::clear);
         allRecipeMaps.clear();
+        unlockIndex.clear();
         RECIPE_COUNT = 0;
         PACKET = null;
     }

--- a/src/main/java/org/powernukkitx/registry/RegistryCache.java
+++ b/src/main/java/org/powernukkitx/registry/RegistryCache.java
@@ -45,7 +45,7 @@ import java.util.Map;
 @Slf4j
 public final class RegistryCache {
     private static final byte[] MAGIC = {'P', 'N', 'X', 'C'};
-    private static final byte SCHEMA_VERSION = 1;
+    private static final byte SCHEMA_VERSION = 2;
 
     private static final byte SECTION_ITEM_RUNTIMEID = 1;
     private static final byte SECTION_BLOCK_STATE_COLORS = 2;

--- a/src/test/java/org/powernukkitx/recipe/unlock/RecipeResultPayloadTest.java
+++ b/src/test/java/org/powernukkitx/recipe/unlock/RecipeResultPayloadTest.java
@@ -1,0 +1,74 @@
+package org.powernukkitx.recipe.unlock;
+
+import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.powernukkitx.ServerMockFixture;
+import org.powernukkitx.item.Item;
+import org.powernukkitx.item.ItemID;
+import org.powernukkitx.registry.Registries;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class RecipeResultPayloadTest {
+
+    @BeforeAll
+    static void boot() {
+        ServerMockFixture.boot();
+        Registries.RECIPE.init();
+    }
+
+    private static List<String> resultsCarryingDamageTag() {
+        final List<String> offenders = new ArrayList<>();
+        final var packet = Registries.RECIPE.getCraftingPacket();
+        packet.getShapedRecipes().forEach(p -> p.getResults().forEach(res -> {
+            if (carriesDamageTag(res)) offenders.add(p.getRecipeId());
+        }));
+        packet.getShapelessRecipes().forEach(p -> p.getResults().forEach(res -> {
+            if (carriesDamageTag(res)) offenders.add(p.getRecipeId());
+        }));
+        packet.getSmithingTransformRecipes().forEach(p -> {
+            if (carriesDamageTag(p.getResult())) offenders.add(p.getRecipeId());
+        });
+        return offenders;
+    }
+
+    private static boolean carriesDamageTag(ItemData data) {
+        return data.getTag() != null && data.getTag().containsKey("Damage");
+    }
+
+    @Test
+    void noRecipeResultCarriesADamageTag() {
+        final List<String> offenders = resultsCarryingDamageTag();
+        Assertions.assertTrue(offenders.isEmpty(),
+            () -> offenders.size() + " recipe results still carry a Damage tag, e.g. " + offenders.stream().limit(5).toList());
+    }
+
+    @Test
+    void woodenSwordReachesTheClientAsAPlainItem() {
+        final var sword = Registries.RECIPE.getCraftingPacket().getShapedRecipes().stream()
+            .filter(p -> p.getRecipeId().equals("minecraft:wooden_sword"))
+            .findFirst()
+            .orElseThrow();
+
+        Assertions.assertEquals(1, sword.getResults().size());
+        final ItemData result = sword.getResults().getFirst();
+        Assertions.assertEquals(ItemID.WOODEN_SWORD, result.getDefinition().getIdentifier());
+        Assertions.assertNull(result.getTag(), "a pristine wooden sword must reach the client without user data");
+    }
+
+    @Test
+    void stripingOnlyAppliesToPristineDamageableItems() {
+        // the item itself keeps mirroring its durability, only the recipe payload drops a zero tag
+        final Item pristine = Item.get(ItemID.WOODEN_SWORD, 0, 1);
+        Assertions.assertTrue(pristine.hasNbt());
+        Assertions.assertNull(pristine.toRecipeNetwork().getTag());
+
+        final Item worn = Item.get(ItemID.WOODEN_SWORD, 0, 1);
+        worn.setDamage(17);
+        Assertions.assertNotNull(worn.toRecipeNetwork().getTag());
+        Assertions.assertEquals(17, worn.toRecipeNetwork().getTag().getInt("Damage"));
+    }
+}

--- a/src/test/java/org/powernukkitx/recipe/unlock/RecipeUnlockIndexTest.java
+++ b/src/test/java/org/powernukkitx/recipe/unlock/RecipeUnlockIndexTest.java
@@ -1,0 +1,85 @@
+package org.powernukkitx.recipe.unlock;
+
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.powernukkitx.item.Item;
+import org.powernukkitx.item.ItemID;
+import org.powernukkitx.recipe.MultiRecipe;
+import org.powernukkitx.recipe.ShapelessRecipe;
+import org.powernukkitx.recipe.descriptor.DefaultDescriptor;
+import org.powernukkitx.recipe.descriptor.ItemDescriptor;
+import org.powernukkitx.recipe.descriptor.ItemTagDescriptor;
+import org.powernukkitx.registry.Registries;
+import org.powernukkitx.tags.ItemTags;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+class RecipeUnlockIndexTest {
+    private static final String TAG = "unlock_index_test_tag";
+
+    private static Item planks;
+    private static Item diamond;
+
+    @BeforeAll
+    @SneakyThrows
+    static void before() {
+        Registries.POTION.init();
+        Registries.BLOCK.init();
+        Registries.ITEM.init();
+        Registries.ITEM_RUNTIMEID.init();
+        planks = Item.get(ItemID.PLANKS);
+        diamond = Item.get(ItemID.DIAMOND);
+        ItemTags.register(diamond.getId(), List.of(TAG));
+    }
+
+    private static ShapelessRecipe recipe(String id, ItemDescriptor... ingredients) {
+        return new ShapelessRecipe(id, UUID.randomUUID(), 1, 0, Item.get(ItemID.STICK), List.of(ingredients));
+    }
+
+    @Test
+    void indexesDirectIngredients() {
+        RecipeUnlockIndex index = new RecipeUnlockIndex();
+        index.index(recipe("direct", new DefaultDescriptor(planks)));
+
+        Assertions.assertEquals(Set.of("direct"), index.getCandidates(planks.getId()));
+        Assertions.assertTrue(index.getCandidates(Item.get(ItemID.STICK).getId()).isEmpty());
+    }
+
+    @Test
+    void indexesTaggedIngredients() {
+        RecipeUnlockIndex index = new RecipeUnlockIndex();
+        index.index(recipe("tagged", new ItemTagDescriptor(TAG, 1)));
+
+        Assertions.assertEquals(Set.of("tagged"), index.getCandidates(diamond.getId()));
+    }
+
+    @Test
+    void mergesDirectAndTaggedCandidates() {
+        RecipeUnlockIndex index = new RecipeUnlockIndex();
+        index.index(recipe("direct", new DefaultDescriptor(diamond)));
+        index.index(recipe("tagged", new ItemTagDescriptor(TAG, 1)));
+
+        Assertions.assertEquals(Set.of("direct", "tagged"), index.getCandidates(diamond.getId()));
+    }
+
+    @Test
+    void skipsRecipesTheBookNeverShows() {
+        RecipeUnlockIndex index = new RecipeUnlockIndex();
+        index.index(new MultiRecipe(UUID.randomUUID(), 1));
+
+        Assertions.assertTrue(index.getCandidates(planks.getId()).isEmpty());
+    }
+
+    @Test
+    void clearDropsEverything() {
+        RecipeUnlockIndex index = new RecipeUnlockIndex();
+        index.index(recipe("direct", new DefaultDescriptor(planks)));
+        index.clear();
+
+        Assertions.assertTrue(index.getCandidates(planks.getId()).isEmpty());
+    }
+}

--- a/src/test/java/org/powernukkitx/recipe/unlock/RecipeUnlockIndexTest.java
+++ b/src/test/java/org/powernukkitx/recipe/unlock/RecipeUnlockIndexTest.java
@@ -1,11 +1,14 @@
 package org.powernukkitx.recipe.unlock;
 
 import lombok.SneakyThrows;
+import org.cloudburstmc.protocol.bedrock.data.payload.crafting.RecipeUnlockingContext;
+import org.cloudburstmc.protocol.bedrock.data.payload.crafting.RecipeUnlockingRequirement;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemID;
+import org.powernukkitx.recipe.FurnaceRecipe;
 import org.powernukkitx.recipe.MultiRecipe;
 import org.powernukkitx.recipe.ShapelessRecipe;
 import org.powernukkitx.recipe.descriptor.DefaultDescriptor;
@@ -36,23 +39,32 @@ class RecipeUnlockIndexTest {
         ItemTags.register(diamond.getId(), List.of(TAG));
     }
 
-    private static ShapelessRecipe recipe(String id, ItemDescriptor... ingredients) {
-        return new ShapelessRecipe(id, UUID.randomUUID(), 1, 0, Item.get(ItemID.STICK), List.of(ingredients));
+    private static RecipeUnlockingRequirement triggeredBy(ItemDescriptor... triggers) {
+        RecipeUnlockingRequirement requirement = new RecipeUnlockingRequirement(RecipeUnlockingContext.NONE);
+        for (ItemDescriptor trigger : triggers) {
+            requirement.getUnlockingIngredients().add(trigger.toNetwork());
+        }
+        return requirement;
+    }
+
+    private static ShapelessRecipe recipe(String id, RecipeUnlockingRequirement requirement) {
+        return new ShapelessRecipe(id, UUID.randomUUID(), 1, 0, Item.get(ItemID.STICK),
+            List.of(new DefaultDescriptor(planks)), requirement);
     }
 
     @Test
-    void indexesDirectIngredients() {
+    void indexesDirectTriggers() {
         RecipeUnlockIndex index = new RecipeUnlockIndex();
-        index.index(recipe("direct", new DefaultDescriptor(planks)));
+        index.index(recipe("direct", triggeredBy(new DefaultDescriptor(diamond))));
 
-        Assertions.assertEquals(Set.of("direct"), index.getCandidates(planks.getId()));
+        Assertions.assertEquals(Set.of("direct"), index.getCandidates(diamond.getId()));
         Assertions.assertTrue(index.getCandidates(Item.get(ItemID.STICK).getId()).isEmpty());
     }
 
     @Test
-    void indexesTaggedIngredients() {
+    void indexesTaggedTriggers() {
         RecipeUnlockIndex index = new RecipeUnlockIndex();
-        index.index(recipe("tagged", new ItemTagDescriptor(TAG, 1)));
+        index.index(recipe("tagged", triggeredBy(new ItemTagDescriptor(TAG, 1))));
 
         Assertions.assertEquals(Set.of("tagged"), index.getCandidates(diamond.getId()));
     }
@@ -60,26 +72,46 @@ class RecipeUnlockIndexTest {
     @Test
     void mergesDirectAndTaggedCandidates() {
         RecipeUnlockIndex index = new RecipeUnlockIndex();
-        index.index(recipe("direct", new DefaultDescriptor(diamond)));
-        index.index(recipe("tagged", new ItemTagDescriptor(TAG, 1)));
+        index.index(recipe("direct", triggeredBy(new DefaultDescriptor(diamond))));
+        index.index(recipe("tagged", triggeredBy(new ItemTagDescriptor(TAG, 1))));
 
         Assertions.assertEquals(Set.of("direct", "tagged"), index.getCandidates(diamond.getId()));
     }
 
     @Test
-    void skipsRecipesTheBookNeverShows() {
+    void triggerItemDoesNotHaveToBeAnIngredient() {
         RecipeUnlockIndex index = new RecipeUnlockIndex();
+        index.index(recipe("wooden_sword_like", triggeredBy(new DefaultDescriptor(diamond))));
+
+        Assertions.assertTrue(index.getCandidates(planks.getId()).isEmpty());
+        Assertions.assertEquals(Set.of("wooden_sword_like"), index.getCandidates(diamond.getId()));
+    }
+
+    @Test
+    void skipsRecipesWithoutItemTriggers() {
+        RecipeUnlockIndex index = new RecipeUnlockIndex();
+        index.index(recipe("invalid", RecipeUnlockingRequirement.INVALID));
+        index.index(recipe("always", new RecipeUnlockingRequirement(RecipeUnlockingContext.ALWAYS_UNLOCKED)));
         index.index(new MultiRecipe(UUID.randomUUID(), 1));
 
         Assertions.assertTrue(index.getCandidates(planks.getId()).isEmpty());
+        Assertions.assertTrue(index.getCandidates(diamond.getId()).isEmpty());
+    }
+
+    @Test
+    void indexesSmeltingRecipesByInput() {
+        RecipeUnlockIndex index = new RecipeUnlockIndex();
+        index.index(new FurnaceRecipe(Item.get(ItemID.IRON_INGOT), diamond.clone()));
+
+        Assertions.assertEquals(1, index.getCandidates(diamond.getId()).size());
     }
 
     @Test
     void clearDropsEverything() {
         RecipeUnlockIndex index = new RecipeUnlockIndex();
-        index.index(recipe("direct", new DefaultDescriptor(planks)));
+        index.index(recipe("direct", triggeredBy(new DefaultDescriptor(diamond))));
         index.clear();
 
-        Assertions.assertTrue(index.getCandidates(planks.getId()).isEmpty());
+        Assertions.assertTrue(index.getCandidates(diamond.getId()).isEmpty());
     }
 }

--- a/src/test/java/org/powernukkitx/recipe/unlock/VanillaUnlockRequirementTest.java
+++ b/src/test/java/org/powernukkitx/recipe/unlock/VanillaUnlockRequirementTest.java
@@ -1,0 +1,83 @@
+package org.powernukkitx.recipe.unlock;
+
+import org.cloudburstmc.protocol.bedrock.data.payload.crafting.RecipeUnlockingContext;
+import org.cloudburstmc.protocol.bedrock.data.payload.crafting.RecipeUnlockingRequirement;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.powernukkitx.ServerMockFixture;
+import org.powernukkitx.block.BlockID;
+import org.powernukkitx.item.ItemID;
+import org.powernukkitx.recipe.CraftingRecipe;
+import org.powernukkitx.recipe.ShapedRecipe;
+import org.powernukkitx.recipe.SmeltingRecipe;
+import org.powernukkitx.registry.Registries;
+
+import java.util.Set;
+
+class VanillaUnlockRequirementTest {
+
+    @BeforeAll
+    static void boot() {
+        ServerMockFixture.boot();
+        Registries.RECIPE.init();
+    }
+
+    @Test
+    void woodenSwordUnlocksThroughStick() {
+        CraftingRecipe sword = (CraftingRecipe) Registries.RECIPE.get("minecraft:wooden_sword");
+        Assertions.assertNotNull(sword);
+
+        RecipeUnlockingRequirement requirement = sword.getRequirement();
+        Assertions.assertEquals(RecipeUnlockingContext.NONE, requirement.getUnlockingContext());
+        Assertions.assertFalse(requirement.getUnlockingIngredients().isEmpty());
+
+        Set<String> unlockedByStick = Registries.RECIPE.getUnlockIndex().getCandidates(ItemID.STICK);
+        Assertions.assertTrue(unlockedByStick.contains("minecraft:wooden_sword"));
+    }
+
+    @Test
+    void planksUnlockStickCraftingButNotTheSword() {
+        Set<String> unlockedByPlanks = Registries.RECIPE.getUnlockIndex().getCandidates(BlockID.OAK_PLANKS);
+        Assertions.assertTrue(unlockedByPlanks.contains("minecraft:stick"));
+        Assertions.assertFalse(unlockedByPlanks.contains("minecraft:wooden_sword"));
+    }
+
+    @Test
+    void breadUnlocksThroughWheat() {
+        Assertions.assertTrue(Registries.RECIPE.getUnlockIndex().getCandidates("minecraft:wheat").contains("minecraft:bread"));
+    }
+
+    @Test
+    void contextRequirementsSurviveParsing() {
+        CraftingRecipe workbench = (CraftingRecipe) Registries.RECIPE.get("minecraft:WorkBench_recipeId");
+        Assertions.assertNotNull(workbench);
+        Assertions.assertEquals(RecipeUnlockingContext.ALWAYS_UNLOCKED, workbench.getRequirement().getUnlockingContext());
+
+        CraftingRecipe boat = (CraftingRecipe) Registries.RECIPE.get("minecraft:boat");
+        Assertions.assertNotNull(boat);
+        Assertions.assertEquals(RecipeUnlockingContext.PLAYER_IN_WATER, boat.getRequirement().getUnlockingContext());
+    }
+
+    @Test
+    void requirementsReachTheNetworkPayload() {
+        ShapedRecipe sword = (ShapedRecipe) Registries.RECIPE.get("minecraft:wooden_sword");
+        RecipeUnlockingRequirement payloadRequirement = sword.toNetwork().getUnlockingRequirement();
+        Assertions.assertNotNull(payloadRequirement);
+        Assertions.assertFalse(payloadRequirement.isInvalid());
+    }
+
+    @Test
+    void smeltingRecipesUnlockThroughTheirInput() {
+        Assertions.assertFalse(Registries.RECIPE.getUnlockIndex().getCandidates("minecraft:deepslate_iron_ore").isEmpty());
+    }
+
+    @Test
+    void spongeDryingUnlocksThroughTheDrySponge() {
+        // the one smelting recipe whose vanilla trigger is not its input: wet sponge drying unlocks via dry sponge
+        Assertions.assertTrue(Registries.RECIPE.getUnlockIndex().getCandidates("minecraft:sponge").stream()
+            .map(Registries.RECIPE::get)
+            .anyMatch(recipe -> recipe instanceof SmeltingRecipe smelting
+                && smelting.getResult().getId().equals("minecraft:sponge")));
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Implements full recipe unlocking system

## Why?

We hadn't this implemented for awhile, thats why this is needed.

Closes #2798

## Type of change

- [x] New Feature

## How was this tested?

- **Server build tested:** c85a079300bbc8ab6dfde13f3503c7c08daab903
- **Bedrock client version:** 1.26.30
- **Plugins loaded:** Nothing

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] Existing unit tests pass (`gradlew test`)
- [x] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

No breaking changes. Additive only:
- `Player#getRecipeBook()`
- `PlayerRecipeBook` (new, `org.powernukkitx.recipe.unlock`)
- `RecipeUnlockIndex` (new) + `RecipeRegistry#getUnlockI
- `PlayerUnlockRecipeEvent` (new, cancellable)

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| Claude Opus 5 | Javadoc comments |

- [x] The disclosure above covers all AI use in this PR
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled