### PR TITLE
fix: shield crafting not working

### DIFF
--- a/src/main/java/org/powernukkitx/inventory/request/CraftResultDeprecatedActionProcessor.java
+++ b/src/main/java/org/powernukkitx/inventory/request/CraftResultDeprecatedActionProcessor.java
@@ -43,6 +43,9 @@ public class CraftResultDeprecatedActionProcessor implements ItemStackRequestAct
             if (!validateResultAgainstInput(player, resultItem)) {
                 return context.error();
             }
+            if (resultItem.getId().equals(Item.SHIELD)) {
+                resultItem.setDamage(0);
+            }
             var createdOutput = player.getCreativeOutputInventory();
             resultItem.autoAssignStackNetworkId();
             createdOutput.setItem(0, resultItem, false);
@@ -53,7 +56,7 @@ public class CraftResultDeprecatedActionProcessor implements ItemStackRequestAct
     }
 
     protected boolean validateResultAgainstInput(Player player, Item resultItem) {
-        if (resultItem.getId().equals(Item.FIREWORK_ROCKET) || resultItem.getId().equals(Item.FIREWORK_STAR)) {
+        if (resultItem.getId().equals(Item.FIREWORK_ROCKET) || resultItem.getId().equals(Item.FIREWORK_STAR) || resultItem.getId().equals(Item.SHIELD)) {
             return true;
         }
         Inventory inventory = player.getTopWindow().orElseGet(player::getCraftingGrid);

--- a/src/main/java/org/powernukkitx/inventory/request/CraftResultDeprecatedActionProcessor.java
+++ b/src/main/java/org/powernukkitx/inventory/request/CraftResultDeprecatedActionProcessor.java
@@ -43,9 +43,6 @@ public class CraftResultDeprecatedActionProcessor implements ItemStackRequestAct
             if (!validateResultAgainstInput(player, resultItem)) {
                 return context.error();
             }
-            if (resultItem.getId().equals(Item.SHIELD)) {
-                resultItem.setDamage(0);
-            }
             var createdOutput = player.getCreativeOutputInventory();
             resultItem.autoAssignStackNetworkId();
             createdOutput.setItem(0, resultItem, false);


### PR DESCRIPTION
<!--
  Read CONTRIBUTING.md before submitting:
  https://github.com/PowerNukkitX/PowerNukkitX/blob/master/CONTRIBUTING.md

  PRs that leave this template unfilled, or fill it with generated filler,
  are closed without review. Delete the HTML comments as you go.

  SECURITY: never report a vulnerability in a public PR. See SECURITY.md.
-->

## What does this PR do?

this pr fixes the banners with the patterns

## Why?

Fixes #2921

## Type of change

- [X] Bug Fix

I tried making a banner with a colorful pattern 

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** 8a35c7eb3
- **Bedrock client version:** 26.33
- **Plugins loaded:** none

**Steps performed and results:**

1. join the world
2. craft banner with colorful pattern

- [X] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
none

- {X]  The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
