### PR TITLE
Add village raid system

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -3615,6 +3615,17 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         this.sendPacket(pk);
     }
 
+    public void sendTranslatedTitle(String key, int fadeIn, int stay, int fadeOut) {
+        this.setTitleAnimationTimes(fadeIn, stay, fadeOut);
+        this.setRawTextTitle(RawText.fromRawText("{\"rawtext\":[{\"translate\":\"" + key + "\"}]}"));
+    }
+
+    public void playOmenScreenAnimation() {
+        OnScreenTextureAnimationPacket pk = new OnScreenTextureAnimationPacket();
+        pk.setEffectId(1);
+        this.sendPacket(pk);
+    }
+
 
     /**
      * {@code subtitle=null,fadeIn=20,stay=20,fadeOut=5}

--- a/src/main/java/org/powernukkitx/entity/effect/EffectRaidOmen.java
+++ b/src/main/java/org/powernukkitx/entity/effect/EffectRaidOmen.java
@@ -1,0 +1,10 @@
+package org.powernukkitx.entity.effect;
+
+import java.awt.*;
+
+public class EffectRaidOmen extends Effect {
+
+    public EffectRaidOmen() {
+        super(EffectType.RAID_OMEN, "%effect.raidOmen", new Color(182, 17, 56), true);
+    }
+}

--- a/src/main/java/org/powernukkitx/entity/effect/EffectType.java
+++ b/src/main/java/org/powernukkitx/entity/effect/EffectType.java
@@ -79,6 +79,8 @@ public record EffectType(String stringId, Integer id) {
 
     public static final EffectType INFESTED = new EffectType("infested", 35);
 
+    public static final EffectType RAID_OMEN = new EffectType("raid_omen", 36);
+
     public static EffectType get(String stringId) {
         return Registries.EFFECT.getType(stringId);
     }

--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -79,6 +79,7 @@ import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.nbt.tag.DoubleTag;
 import org.powernukkitx.nbt.tag.FloatTag;
 import org.powernukkitx.nbt.tag.ListTag;
+import org.powernukkitx.level.raid.RaidManager;
 import org.powernukkitx.plugin.InternalPlugin;
 import org.powernukkitx.plugin.Plugin;
 import org.powernukkitx.registry.Registries;
@@ -348,6 +349,8 @@ public class Level implements Metadatable {
     private final Long2IntMap chunkTickList = new Long2IntOpenHashMap();
     private final VibrationManager vibrationManager = new SimpleVibrationManager(this);
     private final VillageManager villageManager = new VillageManager(this);
+    @Getter
+    private final RaidManager raidManager = new RaidManager(this);
     public boolean stopTime;
     public int skyLightSubtracted;
     public int sleepTicks = 0;
@@ -1311,6 +1314,8 @@ public class Level implements Metadatable {
                 }
             }
             checkWeather();
+
+            this.raidManager.onTick(currentTick);
 
             if (gameplaySettings.enableDaylightCycle() || gameplaySettings.enableWeather()
                     || (currentTick & 127) == 0) {

--- a/src/main/java/org/powernukkitx/level/raid/Raid.java
+++ b/src/main/java/org/powernukkitx/level/raid/Raid.java
@@ -10,6 +10,9 @@ import org.powernukkitx.entity.effect.Effect;
 import org.powernukkitx.entity.effect.EffectType;
 import org.powernukkitx.entity.passive.EntityVillagerV2;
 import org.powernukkitx.level.Level;
+import org.powernukkitx.level.village.Village;
+import org.powernukkitx.level.village.VillageDwellers;
+import org.powernukkitx.level.village.VillageRaid;
 import org.powernukkitx.math.Vector3;
 import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.registry.Registries;
@@ -58,10 +61,10 @@ public class Raid {
     private static final int WAVE_DELAY        = 300;
     private static final int RAID_EXPIRY_TICKS = 48000;
 
-    private static final double VILLAGE_RADIUS_SQ = 128.0 * 128.0;
     private static final double NOTIFY_RADIUS_SQ  =  96.0 *  96.0;
 
     private final Level level;
+    private final Village village;
     private final Vector3 center;
     private final int totalWaves;
     private final int difficultyIdx;
@@ -79,9 +82,10 @@ public class Raid {
     private final Map<String, DummyBossBar> bossBars = new HashMap<>();
     private int bossBarUpdateTick = 0;
 
-    public Raid(Level level, Vector3 center) {
+    public Raid(Level level, Village village) {
         this.level = level;
-        this.center = center.clone();
+        this.village = village;
+        this.center = village.center().asVector3();
         int difficulty = Server.getInstance().getDifficulty();
         this.difficultyIdx = (difficulty <= 1) ? 0 : (difficulty == 2) ? 1 : 2;
         this.totalWaves    = WAVES[difficultyIdx].length;
@@ -91,6 +95,11 @@ public class Raid {
                 p.playOmenScreenAnimation();
             }
         }
+        publishToVillage();
+    }
+
+    public Village getVillage() {
+        return village;
     }
 
     public void tick(int currentTick) {
@@ -103,7 +112,7 @@ public class Raid {
             return;
         }
 
-        if (raidAge % 100 == 0 && !hasVillagerNearby()) {
+        if (raidAge % 100 == 0 && !hasVillagerAlive()) {
             onDefeat();
             return;
         }
@@ -125,6 +134,7 @@ public class Raid {
                     spawnNextWave();
                 }
             }
+            publishToVillage();
             return;
         }
 
@@ -152,6 +162,8 @@ public class Raid {
                 waitTick = 0;
             }
         }
+
+        publishToVillage();
     }
 
     private void spawnNextWave() {
@@ -210,10 +222,12 @@ public class Raid {
         level.addLevelSoundEvent(hornPos, SoundEvent.RAID_HORN, -1);
     }
 
-    private boolean hasVillagerNearby() {
-        for (Entity e : level.getEntities()) {
-            if (e instanceof EntityVillagerV2 && e.isAlive() && e.distanceSquared(center) <= VILLAGE_RADIUS_SQ) {
-                return true;
+    private boolean hasVillagerAlive() {
+        for (VillageDwellers.Dweller dweller : village.dwellers().dwellers()) {
+            for (VillageDwellers.Actor actor : dweller.actors()) {
+                if (level.getEntity(actor.id()) instanceof EntityVillagerV2 villager && villager.isAlive()) {
+                    return true;
+                }
             }
         }
         return false;
@@ -276,6 +290,7 @@ public class Raid {
         }
         raidMobs.forEach(e -> { if (e.isAlive()) e.kill(); });
         raidMobs.clear();
+        village.setRaid(null);
     }
 
     private void onDefeat() {
@@ -293,6 +308,7 @@ public class Raid {
             }
         }
         raidMobs.clear();
+        village.setRaid(null);
     }
 
     private void onExpiry() {
@@ -305,6 +321,20 @@ public class Raid {
         }
         raidMobs.forEach(e -> { if (e.isAlive()) e.despawnable = true; });
         raidMobs.clear();
+        village.setRaid(null);
+    }
+
+    private void publishToVillage() {
+        List<Long> raiderIds = raidMobs.stream().filter(e -> e.isAlive() && !e.closed)
+                .map(Entity::getId).toList();
+        float totalMaxHealth = 0f;
+        for (Entity mob : raidMobs) {
+            if (mob.isAlive() && !mob.closed) totalMaxHealth += mob.getHealthDefaultMax();
+        }
+        village.setRaid(new VillageRaid(
+                level.getCurrentTick(), (byte) Math.max(1, currentWave), (byte) totalWaves,
+                (byte) raiderIds.size(), raiderIds, (byte) 0, center, state.ordinal(), state.ordinal(),
+                raidAge, totalMaxHealth));
     }
 
     public boolean isEnded() { return state == RaidState.ENDED; }

--- a/src/main/java/org/powernukkitx/level/raid/Raid.java
+++ b/src/main/java/org/powernukkitx/level/raid/Raid.java
@@ -1,0 +1,315 @@
+package org.powernukkitx.level.raid;
+
+import org.powernukkitx.Player;
+import org.powernukkitx.Server;
+import org.powernukkitx.entity.Entity;
+import org.powernukkitx.entity.EntityID;
+import org.powernukkitx.entity.EntityIntelligent;
+import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
+import org.powernukkitx.entity.effect.Effect;
+import org.powernukkitx.entity.effect.EffectType;
+import org.powernukkitx.entity.passive.EntityVillagerV2;
+import org.powernukkitx.level.Level;
+import org.powernukkitx.math.Vector3;
+import org.powernukkitx.nbt.tag.CompoundTag;
+import org.powernukkitx.registry.Registries;
+import org.powernukkitx.utils.BossBarColor;
+import org.powernukkitx.utils.DummyBossBar;
+import org.cloudburstmc.protocol.bedrock.data.SoundEvent;
+
+import java.util.*;
+
+public class Raid {
+
+    public enum RaidState {
+        ONGOING,
+        VICTORY,
+        DEFEAT,
+        ENDED
+    }
+
+    @SuppressWarnings("unchecked")
+    private static final Map<String, Integer>[][] WAVES = new Map[3][];
+
+    static {
+        WAVES[0] = new Map[]{
+            Map.of(EntityID.PILLAGER, 3),
+            Map.of(EntityID.PILLAGER, 3, EntityID.VINDICATOR, 1),
+            Map.of(EntityID.PILLAGER, 3, EntityID.VINDICATOR, 2, EntityID.WITCH, 1, EntityID.RAVAGER, 1)
+        };
+        WAVES[1] = new Map[]{
+            Map.of(EntityID.PILLAGER, 4, EntityID.VINDICATOR, 1),
+            Map.of(EntityID.PILLAGER, 3, EntityID.VINDICATOR, 2),
+            Map.of(EntityID.PILLAGER, 3, EntityID.VINDICATOR, 2, EntityID.WITCH, 1),
+            Map.of(EntityID.PILLAGER, 4, EntityID.VINDICATOR, 2, EntityID.WITCH, 1, EntityID.RAVAGER, 1),
+            Map.of(EntityID.PILLAGER, 2, EntityID.VINDICATOR, 3, EntityID.WITCH, 1, EntityID.EVOCATION_ILLAGER, 2, EntityID.RAVAGER, 1)
+        };
+        WAVES[2] = new Map[]{
+            Map.of(EntityID.PILLAGER, 4, EntityID.VINDICATOR, 1),
+            Map.of(EntityID.PILLAGER, 4, EntityID.VINDICATOR, 2),
+            Map.of(EntityID.PILLAGER, 4, EntityID.VINDICATOR, 2, EntityID.WITCH, 1),
+            Map.of(EntityID.PILLAGER, 4, EntityID.VINDICATOR, 2, EntityID.WITCH, 1, EntityID.RAVAGER, 1),
+            Map.of(EntityID.PILLAGER, 3, EntityID.VINDICATOR, 2, EntityID.WITCH, 1, EntityID.EVOCATION_ILLAGER, 3),
+            Map.of(EntityID.PILLAGER, 4, EntityID.VINDICATOR, 4, EntityID.EVOCATION_ILLAGER, 1, EntityID.WITCH, 1, EntityID.RAVAGER, 1),
+            Map.of(EntityID.PILLAGER, 3, EntityID.VINDICATOR, 5, EntityID.EVOCATION_ILLAGER, 2, EntityID.WITCH, 2, EntityID.RAVAGER, 1)
+        };
+    }
+
+    private static final int WAVE_DELAY        = 300;
+    private static final int RAID_EXPIRY_TICKS = 48000;
+
+    private static final double VILLAGE_RADIUS_SQ = 128.0 * 128.0;
+    private static final double NOTIFY_RADIUS_SQ  =  96.0 *  96.0;
+
+    private final Level level;
+    private final Vector3 center;
+    private final int totalWaves;
+    private final int difficultyIdx;
+
+    private int currentWave          = 0;
+    private int currentWaveTotalMobs = 0;
+    private int raidAge              = 0;
+    private int waveActiveTick       = 0;
+    private RaidState state          = RaidState.ONGOING;
+    private final Set<Entity> raidMobs = new HashSet<>();
+    private boolean waitingNextWave  = true;
+    private int waitTick             = 0;
+    private final Random random      = new Random();
+
+    private final Map<String, DummyBossBar> bossBars = new HashMap<>();
+    private int bossBarUpdateTick = 0;
+
+    public Raid(Level level, Vector3 center) {
+        this.level = level;
+        this.center = center.clone();
+        int difficulty = Server.getInstance().getDifficulty();
+        this.difficultyIdx = (difficulty <= 1) ? 0 : (difficulty == 2) ? 1 : 2;
+        this.totalWaves    = WAVES[difficultyIdx].length;
+        level.addLevelSoundEvent(this.center, SoundEvent.BELL, -1);
+        for (Player p : level.getPlayers().values()) {
+            if (p.isOnline() && p.distanceSquared(center) <= NOTIFY_RADIUS_SQ) {
+                p.playOmenScreenAnimation();
+            }
+        }
+    }
+
+    public void tick(int currentTick) {
+        if (state != RaidState.ONGOING) return;
+
+        raidAge++;
+
+        if (raidAge >= RAID_EXPIRY_TICKS) {
+            onExpiry();
+            return;
+        }
+
+        if (raidAge % 100 == 0 && !hasVillagerNearby()) {
+            onDefeat();
+            return;
+        }
+
+        boolean updateBar = (++bossBarUpdateTick >= 2);
+        if (updateBar) bossBarUpdateTick = 0;
+
+        if (waitingNextWave) {
+            waitTick++;
+            if (updateBar) {
+                float pct = Math.min(100f, waitTick * 100f / WAVE_DELAY);
+                updateBossBars(pct, "%raid.name");
+            }
+            if (waitTick >= WAVE_DELAY) {
+                if (currentWave >= totalWaves) {
+                    state = RaidState.VICTORY;
+                    onVictory();
+                } else {
+                    spawnNextWave();
+                }
+            }
+            return;
+        }
+
+        if (raidAge % 5 == 0) {
+            raidMobs.removeIf(e -> !e.isAlive() || e.closed);
+        }
+
+        waveActiveTick++;
+
+        if (updateBar) {
+            int alive = (int) raidMobs.stream().filter(e -> e.isAlive() && !e.closed).count();
+            float pct = currentWaveTotalMobs > 0 ? Math.max(0f, alive * 100f / currentWaveTotalMobs) : 0f;
+            String barTitle = (alive > 0 && alive <= 3)
+                    ? "%raid.name - %raid.progress " + alive
+                    : "%raid.name";
+            updateBossBars(pct, barTitle);
+        }
+
+        if (raidMobs.isEmpty()) {
+            if (currentWave >= totalWaves) {
+                state = RaidState.VICTORY;
+                onVictory();
+            } else {
+                waitingNextWave = true;
+                waitTick = 0;
+            }
+        }
+    }
+
+    private void spawnNextWave() {
+        Map<String, Integer> wave = WAVES[difficultyIdx][currentWave];
+        currentWave++;
+        waitingNextWave      = false;
+        waitTick             = 0;
+        waveActiveTick       = 0;
+        currentWaveTotalMobs = 0;
+
+        double angle  = random.nextDouble() * 2 * Math.PI;
+        double dist   = 16 + random.nextDouble() * 12;
+        double groupX = center.x + Math.cos(angle) * dist;
+        double groupZ = center.z + Math.sin(angle) * dist;
+
+        for (Map.Entry<String, Integer> entry : wave.entrySet()) {
+            for (int i = 0; i < entry.getValue(); i++) {
+                spawnMob(entry.getKey(), groupX, groupZ);
+            }
+        }
+
+        playHorn();
+    }
+
+    private void spawnMob(String entityId, double groupX, double groupZ) {
+        double spawnX = groupX + (random.nextDouble() - 0.5) * 4;
+        double spawnZ = groupZ + (random.nextDouble() - 0.5) * 4;
+        int cx = ((int) spawnX) >> 4;
+        int cz = ((int) spawnZ) >> 4;
+        var chunk = level.getChunk(cx, cz, false);
+        if (chunk == null) return;
+        int safeY = level.getHighestBlockAt((int) spawnX, (int) spawnZ) + 1;
+        Vector3 spawnPos = new Vector3(spawnX + 0.5, safeY, spawnZ + 0.5);
+        CompoundTag nbt = Entity.getDefaultNBT(spawnPos);
+        Entity entity = Registries.ENTITY.provideEntity(entityId, chunk, nbt);
+        if (entity != null) {
+            entity.getNbt().putBoolean("IsRaider", true);
+            entity.despawnable = false;
+            entity.spawnToAll();
+            if (entity instanceof EntityIntelligent intelligent) {
+                intelligent.getMemoryStorage().put(CoreMemoryTypes.STAY_NEARBY, center);
+            }
+            raidMobs.add(entity);
+            currentWaveTotalMobs++;
+        }
+    }
+
+    private void playHorn() {
+        Vector3 hornPos = center;
+        if (!raidMobs.isEmpty()) {
+            List<Entity> alive = raidMobs.stream().filter(e -> e.isAlive() && !e.closed).toList();
+            if (!alive.isEmpty()) {
+                hornPos = alive.get(random.nextInt(alive.size()));
+            }
+        }
+        level.addLevelSoundEvent(hornPos, SoundEvent.RAID_HORN, -1);
+    }
+
+    private boolean hasVillagerNearby() {
+        for (Entity e : level.getEntities()) {
+            if (e instanceof EntityVillagerV2 && e.isAlive() && e.distanceSquared(center) <= VILLAGE_RADIUS_SQ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void updateBossBars(float percent, String title) {
+        Set<String> nearbyNames = new HashSet<>();
+        for (Player p : level.getPlayers().values()) {
+            if (!p.isOnline()) continue;
+            if (p.distanceSquared(center) > NOTIFY_RADIUS_SQ) continue;
+            nearbyNames.add(p.getName());
+
+            if (!p.isAlive()) {
+                DummyBossBar existing = bossBars.remove(p.getName());
+                if (existing != null) existing.destroy();
+                continue;
+            }
+
+            DummyBossBar bar = bossBars.get(p.getName());
+            if (bar == null) {
+                bar = new DummyBossBar.Builder(p)
+                        .text(title)
+                        .color(BossBarColor.RED)
+                        .length(percent)
+                        .build();
+                bar.create();
+                bossBars.put(p.getName(), bar);
+            } else {
+                bar.setText(title);
+                bar.setLength(percent);
+                bar.updateBossEntityPosition();
+            }
+        }
+
+        bossBars.entrySet().removeIf(entry -> {
+            if (!nearbyNames.contains(entry.getKey())) {
+                entry.getValue().destroy();
+                return true;
+            }
+            return false;
+        });
+    }
+
+    private void destroyAllBossBars() {
+        bossBars.values().forEach(DummyBossBar::destroy);
+        bossBars.clear();
+    }
+
+    private void onVictory() {
+        state = RaidState.ENDED;
+        destroyAllBossBars();
+        Effect hero = Effect.get(EffectType.VILLAGE_HERO);
+        hero.setDuration(48000);
+        hero.setAmplifier(0);
+        for (Player p : level.getPlayers().values()) {
+            if (p.distanceSquared(center) <= NOTIFY_RADIUS_SQ) {
+                p.addEffect(hero);
+                p.sendTranslatedTitle("raid.victory", 20, 60, 20);
+            }
+        }
+        raidMobs.forEach(e -> { if (e.isAlive()) e.kill(); });
+        raidMobs.clear();
+    }
+
+    private void onDefeat() {
+        state = RaidState.ENDED;
+        destroyAllBossBars();
+        for (Player p : level.getPlayers().values()) {
+            if (p.distanceSquared(center) <= NOTIFY_RADIUS_SQ) {
+                p.sendTranslatedTitle("raid.defeat", 20, 60, 20);
+            }
+        }
+        for (Entity mob : raidMobs) {
+            if (mob.isAlive() && !mob.closed) {
+                level.addLevelSoundEvent(mob, SoundEvent.CELEBRATE, -1, mob.getIdentifier(), false, false);
+                mob.despawnable = true;
+            }
+        }
+        raidMobs.clear();
+    }
+
+    private void onExpiry() {
+        state = RaidState.ENDED;
+        destroyAllBossBars();
+        for (Player p : level.getPlayers().values()) {
+            if (p.distanceSquared(center) <= NOTIFY_RADIUS_SQ) {
+                p.sendTranslatedTitle("raid.expiry", 10, 40, 10);
+            }
+        }
+        raidMobs.forEach(e -> { if (e.isAlive()) e.despawnable = true; });
+        raidMobs.clear();
+    }
+
+    public boolean isEnded() { return state == RaidState.ENDED; }
+
+    public RaidState getState() { return state; }
+
+    public Vector3 getCenter() { return center.clone(); }
+}

--- a/src/main/java/org/powernukkitx/level/raid/RaidManager.java
+++ b/src/main/java/org/powernukkitx/level/raid/RaidManager.java
@@ -1,0 +1,179 @@
+package org.powernukkitx.level.raid;
+
+import org.powernukkitx.Player;
+import org.powernukkitx.command.utils.RawText;
+import org.powernukkitx.entity.Entity;
+import org.powernukkitx.entity.effect.Effect;
+import org.powernukkitx.entity.effect.EffectType;
+import org.powernukkitx.entity.passive.EntityVillagerV2;
+import org.powernukkitx.level.Level;
+import org.powernukkitx.math.Vector3;
+import org.cloudburstmc.protocol.bedrock.data.SoundEvent;
+
+import java.util.*;
+
+public class RaidManager {
+
+    private static final int CHECK_INTERVAL               = 20;
+    private static final double VILLAGE_DETECT_RADIUS_SQ  = 96.0 * 96.0;
+    private static final double RAID_MERGE_RADIUS_SQ      = 128.0 * 128.0;
+    private static final int RAID_OMEN_DURATION           = 500;
+    private static final int VILLAGER_CAP_CHECK_INTERVAL  = 6000;
+    private static final double VILLAGE_CLUSTER_RADIUS_SQ = 64.0 * 64.0;
+    private static final int MAX_VILLAGERS_PER_CLUSTER    = 20;
+    private static final int RAID_COOLDOWN_TICKS          = 24000;
+
+    private record OmenEntry(Vector3 villageCenter, int expiryTick) {}
+    private record VillageCooldown(Vector3 center, int expiryTick) {}
+
+    private final Level level;
+    private final List<Raid> activeRaids = new ArrayList<>();
+    private final Map<String, OmenEntry> omenTracked = new HashMap<>();
+    private final List<VillageCooldown> villageCooldowns = new ArrayList<>();
+
+    public RaidManager(Level level) {
+        this.level = level;
+    }
+
+    public void onTick(int currentTick) {
+        activeRaids.removeIf(raid -> {
+            if (raid.isEnded()) {
+                villageCooldowns.add(new VillageCooldown(raid.getCenter(), currentTick + RAID_COOLDOWN_TICKS));
+                return true;
+            }
+            return false;
+        });
+        villageCooldowns.removeIf(c -> currentTick >= c.expiryTick());
+
+        for (Raid raid : activeRaids) {
+            raid.tick(currentTick);
+        }
+
+        if (currentTick % VILLAGER_CAP_CHECK_INTERVAL == 0) {
+            enforceVillagerCap();
+        }
+
+        if (currentTick % CHECK_INTERVAL != 0) return;
+
+        for (Player player : level.getPlayers().values()) {
+            String name = player.getName();
+
+            if (!player.isOnline() || !player.isAlive()) {
+                omenTracked.remove(name);
+                continue;
+            }
+
+            OmenEntry entry = omenTracked.get(name);
+
+            if (entry == null) {
+                if (player.hasEffect(EffectType.BAD_OMEN) && !isNearActiveRaid(player)) {
+                    EntityVillagerV2 villager = findNearestVillager(player);
+                    if (villager != null && !isVillageOnCooldown(villager)) {
+                        int amplifier = player.getEffect(EffectType.BAD_OMEN).getAmplifier();
+                        player.removeEffect(EffectType.BAD_OMEN);
+                        Effect raidOmenAnim = Effect.get(EffectType.RAID_OMEN);
+                        raidOmenAnim.setDuration(1);
+                        raidOmenAnim.setAmplifier(amplifier);
+                        player.addEffect(raidOmenAnim);
+                        Effect badOmen = Effect.get(EffectType.BAD_OMEN);
+                        badOmen.setDuration(RAID_OMEN_DURATION);
+                        badOmen.setAmplifier(amplifier);
+                        player.addEffect(badOmen);
+                        level.addLevelSoundEvent(player, SoundEvent.APPLY_EFFECT_RAID_OMEN, -1);
+                        player.setTitleAnimationTimes(10, 40, 10);
+                        player.setRawTextSubTitle(RawText.fromRawText("{\"rawtext\":[{\"translate\":\"subtitles.event.mob_effect.raid_omen\"}]}"));
+                        player.setRawTextTitle(RawText.fromRawText("{\"rawtext\":[{\"text\":\" \"}]}"));
+                        omenTracked.put(name, new OmenEntry(villager.clone(), currentTick + RAID_OMEN_DURATION));
+                    }
+                }
+            } else if (currentTick >= entry.expiryTick()) {
+                omenTracked.remove(name);
+                player.removeEffect(EffectType.BAD_OMEN);
+                if (player.isAlive() && !isNearActiveRaid(player) && !isVillageOnCooldown(entry.villageCenter())) {
+                    EntityVillagerV2 villager = findNearestVillager(player);
+                    if (villager != null) {
+                        startRaid(entry.villageCenter());
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean isNearActiveRaid(Player player) {
+        for (Raid raid : activeRaids) {
+            if (player.distanceSquared(raid.getCenter()) <= RAID_MERGE_RADIUS_SQ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isVillageOnCooldown(Vector3 pos) {
+        for (VillageCooldown cooldown : villageCooldowns) {
+            if (pos.distanceSquared(cooldown.center()) <= RAID_MERGE_RADIUS_SQ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private EntityVillagerV2 findNearestVillager(Player player) {
+        for (Entity entity : level.getEntities()) {
+            if (entity instanceof EntityVillagerV2 villager
+                    && villager.isAlive()
+                    && player.distanceSquared(villager) <= VILLAGE_DETECT_RADIUS_SQ) {
+                return villager;
+            }
+        }
+        return null;
+    }
+
+    private void enforceVillagerCap() {
+        List<EntityVillagerV2> villagers = new ArrayList<>();
+        for (Entity e : level.getEntities()) {
+            if (e instanceof EntityVillagerV2 v && v.isAlive()) villagers.add(v);
+        }
+        if (villagers.size() <= MAX_VILLAGERS_PER_CLUSTER) return;
+
+        Set<EntityVillagerV2> assigned = new HashSet<>();
+        for (EntityVillagerV2 anchor : villagers) {
+            if (assigned.contains(anchor)) continue;
+            List<EntityVillagerV2> cluster = new ArrayList<>();
+            for (EntityVillagerV2 other : villagers) {
+                if (anchor.distanceSquared(other) <= VILLAGE_CLUSTER_RADIUS_SQ) cluster.add(other);
+            }
+            if (cluster.size() < 3) continue;
+            assigned.addAll(cluster);
+
+            if (cluster.size() > MAX_VILLAGERS_PER_CLUSTER) {
+                cluster.sort((a, b) -> Integer.compare(b.getAge(), a.getAge()));
+                for (int i = MAX_VILLAGERS_PER_CLUSTER; i < cluster.size(); i++) {
+                    cluster.get(i).close();
+                }
+            }
+        }
+    }
+
+    public Raid startRaid(Vector3 center) {
+        Raid raid = new Raid(level, center);
+        activeRaids.add(raid);
+        return raid;
+    }
+
+    public Raid startRaid(Entity nearVillager) {
+        return startRaid(nearVillager.clone());
+    }
+
+    public Raid getRaidNear(Vector3 pos) {
+        for (Raid raid : activeRaids) {
+            if (pos.distanceSquared(raid.getCenter()) <= RAID_MERGE_RADIUS_SQ) {
+                return raid;
+            }
+        }
+        return null;
+    }
+
+    public List<Raid> getActiveRaids() {
+        return Collections.unmodifiableList(activeRaids);
+    }
+}

--- a/src/main/java/org/powernukkitx/level/raid/RaidManager.java
+++ b/src/main/java/org/powernukkitx/level/raid/RaidManager.java
@@ -2,55 +2,43 @@ package org.powernukkitx.level.raid;
 
 import org.powernukkitx.Player;
 import org.powernukkitx.command.utils.RawText;
-import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.effect.Effect;
 import org.powernukkitx.entity.effect.EffectType;
-import org.powernukkitx.entity.passive.EntityVillagerV2;
 import org.powernukkitx.level.Level;
-import org.powernukkitx.math.Vector3;
+import org.powernukkitx.level.village.Village;
 import org.cloudburstmc.protocol.bedrock.data.SoundEvent;
 
 import java.util.*;
 
 public class RaidManager {
 
-    private static final int CHECK_INTERVAL               = 20;
-    private static final double VILLAGE_DETECT_RADIUS_SQ  = 96.0 * 96.0;
-    private static final double RAID_MERGE_RADIUS_SQ      = 128.0 * 128.0;
-    private static final int RAID_OMEN_DURATION           = 500;
-    private static final int VILLAGER_CAP_CHECK_INTERVAL  = 6000;
-    private static final double VILLAGE_CLUSTER_RADIUS_SQ = 64.0 * 64.0;
-    private static final int MAX_VILLAGERS_PER_CLUSTER    = 20;
-    private static final int RAID_COOLDOWN_TICKS          = 24000;
+    private static final int CHECK_INTERVAL     = 20;
+    private static final int RAID_OMEN_DURATION = 500;
+    private static final int RAID_COOLDOWN_TICKS = 24000;
 
-    private record OmenEntry(Vector3 villageCenter, int expiryTick) {}
-    private record VillageCooldown(Vector3 center, int expiryTick) {}
+    private record OmenEntry(UUID villageUuid, int expiryTick) {}
 
     private final Level level;
-    private final List<Raid> activeRaids = new ArrayList<>();
+    private final Map<UUID, Raid> activeRaids = new HashMap<>();
     private final Map<String, OmenEntry> omenTracked = new HashMap<>();
-    private final List<VillageCooldown> villageCooldowns = new ArrayList<>();
+    private final Map<UUID, Integer> villageCooldowns = new HashMap<>();
 
     public RaidManager(Level level) {
         this.level = level;
     }
 
     public void onTick(int currentTick) {
-        activeRaids.removeIf(raid -> {
-            if (raid.isEnded()) {
-                villageCooldowns.add(new VillageCooldown(raid.getCenter(), currentTick + RAID_COOLDOWN_TICKS));
+        activeRaids.entrySet().removeIf(entry -> {
+            if (entry.getValue().isEnded()) {
+                villageCooldowns.put(entry.getKey(), currentTick + RAID_COOLDOWN_TICKS);
                 return true;
             }
             return false;
         });
-        villageCooldowns.removeIf(c -> currentTick >= c.expiryTick());
+        villageCooldowns.entrySet().removeIf(entry -> currentTick >= entry.getValue());
 
-        for (Raid raid : activeRaids) {
+        for (Raid raid : activeRaids.values()) {
             raid.tick(currentTick);
-        }
-
-        if (currentTick % VILLAGER_CAP_CHECK_INTERVAL == 0) {
-            enforceVillagerCap();
         }
 
         if (currentTick % CHECK_INTERVAL != 0) return;
@@ -66,9 +54,9 @@ public class RaidManager {
             OmenEntry entry = omenTracked.get(name);
 
             if (entry == null) {
-                if (player.hasEffect(EffectType.BAD_OMEN) && !isNearActiveRaid(player)) {
-                    EntityVillagerV2 villager = findNearestVillager(player);
-                    if (villager != null && !isVillageOnCooldown(villager)) {
+                if (player.hasEffect(EffectType.BAD_OMEN)) {
+                    Village village = level.getVillageManager().getVillageAt(player.asBlockVector3()).orElse(null);
+                    if (village != null && village.isValid() && isEligible(village.uuid())) {
                         int amplifier = player.getEffect(EffectType.BAD_OMEN).getAmplifier();
                         player.removeEffect(EffectType.BAD_OMEN);
                         Effect raidOmenAnim = Effect.get(EffectType.RAID_OMEN);
@@ -83,97 +71,37 @@ public class RaidManager {
                         player.setTitleAnimationTimes(10, 40, 10);
                         player.setRawTextSubTitle(RawText.fromRawText("{\"rawtext\":[{\"translate\":\"subtitles.event.mob_effect.raid_omen\"}]}"));
                         player.setRawTextTitle(RawText.fromRawText("{\"rawtext\":[{\"text\":\" \"}]}"));
-                        omenTracked.put(name, new OmenEntry(villager.clone(), currentTick + RAID_OMEN_DURATION));
+                        omenTracked.put(name, new OmenEntry(village.uuid(), currentTick + RAID_OMEN_DURATION));
                     }
                 }
             } else if (currentTick >= entry.expiryTick()) {
                 omenTracked.remove(name);
                 player.removeEffect(EffectType.BAD_OMEN);
-                if (player.isAlive() && !isNearActiveRaid(player) && !isVillageOnCooldown(entry.villageCenter())) {
-                    EntityVillagerV2 villager = findNearestVillager(player);
-                    if (villager != null) {
-                        startRaid(entry.villageCenter());
+                if (player.isAlive() && isEligible(entry.villageUuid())) {
+                    Village village = level.getVillageManager().getVillage(entry.villageUuid());
+                    if (village != null && village.isValid()) {
+                        startRaid(village);
                     }
                 }
             }
         }
     }
 
-    private boolean isNearActiveRaid(Player player) {
-        for (Raid raid : activeRaids) {
-            if (player.distanceSquared(raid.getCenter()) <= RAID_MERGE_RADIUS_SQ) {
-                return true;
-            }
-        }
-        return false;
+    private boolean isEligible(UUID villageUuid) {
+        return !activeRaids.containsKey(villageUuid) && !villageCooldowns.containsKey(villageUuid);
     }
 
-    private boolean isVillageOnCooldown(Vector3 pos) {
-        for (VillageCooldown cooldown : villageCooldowns) {
-            if (pos.distanceSquared(cooldown.center()) <= RAID_MERGE_RADIUS_SQ) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private EntityVillagerV2 findNearestVillager(Player player) {
-        for (Entity entity : level.getEntities()) {
-            if (entity instanceof EntityVillagerV2 villager
-                    && villager.isAlive()
-                    && player.distanceSquared(villager) <= VILLAGE_DETECT_RADIUS_SQ) {
-                return villager;
-            }
-        }
-        return null;
-    }
-
-    private void enforceVillagerCap() {
-        List<EntityVillagerV2> villagers = new ArrayList<>();
-        for (Entity e : level.getEntities()) {
-            if (e instanceof EntityVillagerV2 v && v.isAlive()) villagers.add(v);
-        }
-        if (villagers.size() <= MAX_VILLAGERS_PER_CLUSTER) return;
-
-        Set<EntityVillagerV2> assigned = new HashSet<>();
-        for (EntityVillagerV2 anchor : villagers) {
-            if (assigned.contains(anchor)) continue;
-            List<EntityVillagerV2> cluster = new ArrayList<>();
-            for (EntityVillagerV2 other : villagers) {
-                if (anchor.distanceSquared(other) <= VILLAGE_CLUSTER_RADIUS_SQ) cluster.add(other);
-            }
-            if (cluster.size() < 3) continue;
-            assigned.addAll(cluster);
-
-            if (cluster.size() > MAX_VILLAGERS_PER_CLUSTER) {
-                cluster.sort((a, b) -> Integer.compare(b.getAge(), a.getAge()));
-                for (int i = MAX_VILLAGERS_PER_CLUSTER; i < cluster.size(); i++) {
-                    cluster.get(i).close();
-                }
-            }
-        }
-    }
-
-    public Raid startRaid(Vector3 center) {
-        Raid raid = new Raid(level, center);
-        activeRaids.add(raid);
+    public Raid startRaid(Village village) {
+        Raid raid = new Raid(level, village);
+        activeRaids.put(village.uuid(), raid);
         return raid;
     }
 
-    public Raid startRaid(Entity nearVillager) {
-        return startRaid(nearVillager.clone());
+    public Raid getActiveRaid(UUID villageUuid) {
+        return activeRaids.get(villageUuid);
     }
 
-    public Raid getRaidNear(Vector3 pos) {
-        for (Raid raid : activeRaids) {
-            if (pos.distanceSquared(raid.getCenter()) <= RAID_MERGE_RADIUS_SQ) {
-                return raid;
-            }
-        }
-        return null;
-    }
-
-    public List<Raid> getActiveRaids() {
-        return Collections.unmodifiableList(activeRaids);
+    public Collection<Raid> getActiveRaids() {
+        return Collections.unmodifiableCollection(activeRaids.values());
     }
 }

--- a/src/main/java/org/powernukkitx/level/village/Village.java
+++ b/src/main/java/org/powernukkitx/level/village/Village.java
@@ -11,7 +11,7 @@ public final class Village {
     private VillageInfo info;
     private final VillagePlayers players;
     private final VillagePois pois;
-    private final @Nullable VillageRaid raid;
+    private @Nullable VillageRaid raid;
 
     public Village(UUID uuid, VillageDwellers dwellers, VillageInfo info, VillagePlayers players,
                    VillagePois pois, @Nullable VillageRaid raid) {
@@ -31,6 +31,7 @@ public final class Village {
     public @Nullable VillageRaid raid() { return raid; }
 
     public void setInfo(VillageInfo info) { this.info = info; }
+    public void setRaid(@Nullable VillageRaid raid) { this.raid = raid; }
     public long population() {
         return dwellers.dwellers().stream().flatMap(dweller -> dweller.actors().stream()).count();
     }

--- a/src/main/java/org/powernukkitx/registry/EffectRegistry.java
+++ b/src/main/java/org/powernukkitx/registry/EffectRegistry.java
@@ -47,12 +47,13 @@ public class EffectRegistry implements IRegistry<EffectType, Effect, Class<? ext
         // Effects that cannot be realized at the moment
         register0(EffectType.BAD_OMEN, EffectBadOmen.class);
         register0(EffectType.TRIAL_OMEN, EffectTrialOmen.class);
-        //register0(EffectType.VILLAGE_HERO, VillageHeroEffect.class);
+        register0(EffectType.VILLAGE_HERO, EffectVillageHero.class);
         register0(EffectType.DARKNESS, EffectDarkness.class);
         register0(EffectType.WIND_CHARGED, EffectWindCharged.class);
         register0(EffectType.WEAVING, EffectWeaving.class);
         register0(EffectType.OOZING, EffectOozing.class);
         register0(EffectType.INFESTED, EffectInfested.class);
+        register0(EffectType.RAID_OMEN, EffectRaidOmen.class);
     }
 
     @Override


### PR DESCRIPTION
Adds the village raid system (pillager waves scaled by difficulty, boss bar, Bad Omen / Raid Omen / Village Hero effects).

Replaces #2925, which used ad-hoc entity scanning instead of the village system. This version detects and targets raids through VillageManager/Village (getVillageAt, isValid, dwellers) instead of scanning nearby entities, and publishes live raid state onto Village.raid().