### PR TITLE
feat: Move item overrides to ItemDefinition

### DIFF
--- a/src/main/java/org/powernukkitx/item/Item.java
+++ b/src/main/java/org/powernukkitx/item/Item.java
@@ -12,6 +12,7 @@ import org.powernukkitx.event.player.PlayerItemConsumeEvent;
 import org.powernukkitx.inventory.HumanInventory;
 import org.powernukkitx.item.customitem.CustomItem;
 import org.powernukkitx.item.customitem.CustomItemDefinition;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.item.utils.ItemArmorType;
 import org.powernukkitx.level.Level;
@@ -49,7 +50,6 @@ import org.powernukkitx.nbt.tag.StringTag;
 import org.powernukkitx.nbt.tag.Tag;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtUtils;
-import org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition;
 import org.cloudburstmc.protocol.bedrock.data.definitions.SimpleItemDefinition;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemUseMethod;
@@ -79,6 +79,55 @@ import static org.powernukkitx.utils.Utils.dynamic;
  */
 @Slf4j
 public abstract class Item implements Cloneable, ItemID {
+    public static final ItemDefinition DEFAULT_DEFINITION = ItemDefinition.builder()
+            .applyEnchantments(true)
+            .armor(false)
+            .armorPoints(0)
+            .attackDamage(1)
+            .axe(false)
+            .boots(false)
+            .bow(false)
+            .canBeActivated(false)
+            .canBreakShield(false)
+            .canTakeDamage(false)
+            .chestplate(false)
+            .consumable(false)
+            .crossbow(false)
+            .damageChanceMax(100)
+            .damageChanceMin(100)
+            .edible(false)
+            .enchantAbility(0)
+            .fertilizer(false)
+            .helmet(false)
+            .hoe(false)
+            .knockbackResistance(0f)
+            .lavaResistant(false)
+            .leggings(false)
+            .mace(false)
+            .maxDurability(-1)
+            .maxStackSize(64)
+            .movementModifier(1f)
+            .noDamageOnAttack(false)
+            .noDamageOnBreak(false)
+            .nutrition(0)
+            .pickaxe(false)
+            .requiresHunger(true)
+            .saturation(0f)
+            .shears(false)
+            .shield(false)
+            .shouldDespawn(true)
+            .shovel(false)
+            .spear(false)
+            .sword(false)
+            .tier(0)
+            .tool(false)
+            .toughness(0)
+            .trident(false)
+            .unbreakable(false)
+            .useDuration(0f)
+            .usingTicks(0)
+            .build();
+
     public static final Item AIR = new ConstAirItem();
     public static final Item[] EMPTY_ARRAY = new Item[0];
 
@@ -90,6 +139,9 @@ public abstract class Item implements Cloneable, ItemID {
     public int count;
     protected Integer netId = null;
     protected Block block = null;
+    protected ItemDefinition definition;
+    private CustomItemDefinition resolvedCustomSource;
+    private ItemDefinition resolvedCustomDefinition;
     protected boolean hasMeta = true;
     private byte[] tags = EmptyArrays.EMPTY_BYTES;
     private CompoundTag cachedNBT;
@@ -131,19 +183,40 @@ public abstract class Item implements Cloneable, ItemID {
         this(id, 0);
     }
 
+    public Item(@NotNull String id, @Nullable ItemDefinition definition) {
+        this(id, 0, 1, (String) null, true, definition);
+    }
+
     public Item(@NotNull String id, int meta) {
         this(id, meta, 1);
     }
 
+    public Item(@NotNull String id, int meta, @Nullable ItemDefinition definition) {
+        this(id, meta, 1, (String) null, true, definition);
+    }
+
     public Item(@NotNull String id, int meta, int count) {
-        this(id, meta, count, null);
+        this(id, meta, count, (String) null);
+    }
+
+    public Item(@NotNull String id, int meta, int count, @Nullable ItemDefinition definition) {
+        this(id, meta, count, (String) null, true, definition);
     }
 
     public Item(@NotNull String id, int meta, int count, @Nullable String name) {
         this(id, meta, count, name, true);
     }
 
+    public Item(@NotNull String id, int meta, int count, @Nullable String name, @Nullable ItemDefinition definition) {
+        this(id, meta, count, name, true, definition);
+    }
+
     public Item(@NotNull String id, int meta, int count, @Nullable String name, boolean autoAssignStackNetworkId) {
+        this(id, meta, count, name, autoAssignStackNetworkId, DEFAULT_DEFINITION);
+    }
+
+    public Item(@NotNull String id, int meta, int count, @Nullable String name, boolean autoAssignStackNetworkId, @Nullable ItemDefinition definition) {
+        this.definition = definition == null ? DEFAULT_DEFINITION : definition;
         this.id = id.intern();
         this.identifier = new Identifier(id);
         this.count = count;
@@ -157,6 +230,11 @@ public abstract class Item implements Cloneable, ItemID {
     }
 
     protected Item(@NotNull Block block, int meta, int count, @Nullable String name, boolean autoAssignStackNetworkId) {
+        this(block, meta, count, name, autoAssignStackNetworkId, DEFAULT_DEFINITION);
+    }
+
+    protected Item(@NotNull Block block, int meta, int count, @Nullable String name, boolean autoAssignStackNetworkId, @Nullable ItemDefinition definition) {
+        this.definition = definition == null ? DEFAULT_DEFINITION : definition;
         this.id = block.getItemId().intern();
         this.identifier = new Identifier(id);
         this.count = count;
@@ -174,6 +252,24 @@ public abstract class Item implements Cloneable, ItemID {
     public void internalAdjust() {
     }
 
+    /**
+     * The definition backing this item. For a custom item the registered
+     * {@link CustomItemDefinition} is folded onto the class definition, so component driven
+     * behaviour and hardcoded behaviour are read through the same object.
+     */
+    @NotNull
+    protected final ItemDefinition definition() {
+        CustomItemDefinition custom = getCustomDefinition();
+        if (custom == null) {
+            return this.definition;
+        }
+        if (custom != this.resolvedCustomSource) {
+            this.resolvedCustomSource = custom;
+            this.resolvedCustomDefinition = custom.toItemDefinition(this.definition);
+        }
+        return this.resolvedCustomDefinition;
+    }
+
     public void setMeta(int meta) {
         this.meta = meta;
     }
@@ -183,7 +279,7 @@ public abstract class Item implements Cloneable, ItemID {
     }
 
     public boolean canBeActivated() {
-        return false;
+        return definition().isCanBeActivated();
     }
 
     public static Item get(String id) {
@@ -311,7 +407,7 @@ public abstract class Item implements Cloneable, ItemID {
      * Whether the item can be enchanted
      */
     public boolean applyEnchantments() {
-        return true;
+        return definition().isApplyEnchantments();
     }
 
     public boolean hasEnchantments() {
@@ -1586,7 +1682,7 @@ public abstract class Item implements Cloneable, ItemID {
      * @return {@code true} if it can act like a bone meal
      */
     public boolean isFertilizer() {
-        return false;
+        return definition().isFertilizer();
     }
 
 
@@ -1885,20 +1981,18 @@ public abstract class Item implements Cloneable, ItemID {
      * Define if item can take damage
      */
     public boolean canTakeDamage() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.canTakeDamage();
-        return false;
+        return definition().isCanTakeDamage();
     }
 
     /**
      * Define the maximum number of items to be stacked
      */
     public int getMaxStackSize() {
-        CompoundTag c = getCustomItemComponent("minecraft:max_stack_size");
-        if (c != null) {
-            return c.getByte("value") & 0xFF;
+        int size = definition().getMaxStackSize();
+        if (block == null || size != DEFAULT_DEFINITION.getMaxStackSize()) {
+            return size;
         }
-        return block == null ? 64 : block.getItemMaxStackSize();
+        return block.getItemMaxStackSize();
     }
 
 
@@ -1925,9 +2019,7 @@ public abstract class Item implements Cloneable, ItemID {
      * Define the maximum durability value of the item
      */
     public int getMaxDurability() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.maxDurability();
-        return -1;
+        return definition().getMaxDurability();
     }
 
     /**
@@ -1936,9 +2028,7 @@ public abstract class Item implements Cloneable, ItemID {
      * getDamageChanceMin() and getDamageChanceMax()
      */
     public int getDamageChanceMin() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.damageChanceMin();
-        return 100;
+        return definition().getDamageChanceMin();
     }
 
     /**
@@ -1947,51 +2037,45 @@ public abstract class Item implements Cloneable, ItemID {
      * getDamageChanceMin() and getDamageChanceMax()
      */
     public int getDamageChanceMax() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.damageChanceMax();
-        return 100;
+        return definition().getDamageChanceMax();
     }
 
     public float getUseDuration() {
-        CompoundTag c = getCustomItemComponent("minecraft:use_modifiers");
-        if (c != null) {
-            return c.getFloat("use_duration");
-        }
-        return 0f;
+        return definition().getUseDuration();
     }
 
 
     public int getUsingTicks() {
+        int ticks = definition().getUsingTicks();
+        if (ticks > 0) {
+            return ticks;
+        }
         return Math.max(0, (int) Math.ceil(getUseDuration() * 20f));
     }
 
     public float getMovimentModifier() {
-        CompoundTag c = getCustomItemComponent("minecraft:use_modifiers");
-        if (c != null) {
-            return c.getFloat("movement_modifier");
-        }
-        return 1f;
+        return definition().getMovementModifier();
     }
 
     /**
      * Define if the item is Unbreakable
      */
     public boolean isUnbreakable() {
-        return false;
+        return definition().isUnbreakable();
     }
 
     /**
      * Define the item Tier level
      */
     public int getTier() {
-        return 0;
+        return definition().getTier();
     }
 
     /**
      * Define the enchantment of an item
      */
     public int getEnchantAbility() {
-        return 0;
+        return definition().getEnchantAbility();
     }
 
     /**
@@ -2000,7 +2084,7 @@ public abstract class Item implements Cloneable, ItemID {
      * @since 1.4.0.0-PN
      */
     public boolean isLavaResistant() {
-        return false;
+        return definition().isLavaResistant();
     }
 
     /**
@@ -2031,7 +2115,7 @@ public abstract class Item implements Cloneable, ItemID {
      * @return whether the item should take damage when used to attack entities
      */
     public boolean noDamageOnAttack() {
-        return false;
+        return definition().isNoDamageOnAttack();
     }
 
     /**
@@ -2040,18 +2124,14 @@ public abstract class Item implements Cloneable, ItemID {
      * @return whether the item should take damage when used to break blocks
      */
     public boolean noDamageOnBreak() {
-        return false;
+        return definition().isNoDamageOnBreak();
     }
 
     /**
      * Define if item never despawns
      */
     public boolean shouldDespawn() {
-        CompoundTag p = getCustomItemProperties();
-        if (p != null && p.contains("should_despawn")) {
-            return p.getBoolean("should_despawn");
-        }
-        return true;
+        return definition().isShouldDespawn();
     }
 
 
@@ -2064,22 +2144,14 @@ public abstract class Item implements Cloneable, ItemID {
      * @return true if the item can be consumed, otherwise {@link #isEdible()}
      */
     public boolean isConsumable() {
-        return this.isEdible();
+        return definition().isConsumable() || this.isEdible();
     }
 
     public boolean isEdible() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) {
-            return def.isEdible();
-        }
-        return false;
+        return definition().isEdible();
     }
 
     public int getNutrition() {
-        CompoundTag c = getCustomItemComponent("minecraft:food");
-        if (c != null) {
-            return c.getInt("nutrition");
-        }
         return getFoodRestore();
     }
 
@@ -2088,16 +2160,10 @@ public abstract class Item implements Cloneable, ItemID {
      */
     @Deprecated
     public int getFoodRestore() {
-        return 0;
+        return definition().getNutrition();
     }
 
     public float getSaturation() {
-        CompoundTag c = getCustomItemComponent("minecraft:food");
-        if (c != null) {
-            int itemNutrition = getNutrition();
-            float itemSaturationModifier = c.getFloat("saturation_modifier");
-            return (itemNutrition * itemSaturationModifier * 2f);
-        }
         return getSaturationRestore();
     }
 
@@ -2106,7 +2172,7 @@ public abstract class Item implements Cloneable, ItemID {
      */
     @Deprecated
     public float getSaturationRestore() {
-        return 0;
+        return definition().getSaturation();
     }
 
     public float getSaturationModifier() {
@@ -2118,10 +2184,6 @@ public abstract class Item implements Cloneable, ItemID {
     }
 
     public boolean canAlwaysEat() {
-        CompoundTag c = getCustomItemComponent("minecraft:food");
-        if (c != null) {
-            return c.getBoolean("can_always_eat");
-        }
         return !isRequiresHunger();
     }
 
@@ -2130,7 +2192,7 @@ public abstract class Item implements Cloneable, ItemID {
      */
     @Deprecated
     public boolean isRequiresHunger() {
-        return true;
+        return definition().isRequiresHunger();
     }
 
 
@@ -2227,7 +2289,7 @@ public abstract class Item implements Cloneable, ItemID {
     }
 
     public boolean isArmor() {
-        return isWearable();
+        return definition().isArmor() || isWearable();
     }
 
     public @NotNull ItemArmorType getWearableType() {
@@ -2247,45 +2309,35 @@ public abstract class Item implements Cloneable, ItemID {
      * Define if the item is a Helmet
      */
     public boolean isHelmet() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.isHelmet();
-        return false;
+        return definition().isHelmet();
     }
 
     /**
      * Define if the item is a Chestplate
      */
     public boolean isChestplate() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.isChestplate();
-        return false;
+        return definition().isChestplate();
     }
 
     /**
      * Define if the item is a Leggings
      */
     public boolean isLeggings() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.isLeggings();
-        return false;
+        return definition().isLeggings();
     }
 
     /**
      * Define if the item is a Boots
      */
     public boolean isBoots() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.isBoots();
-        return false;
+        return definition().isBoots();
     }
 
     /**
      * Define the Armor value of an item
      */
     public int getArmorPoints() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.wearableProtection();
-        return 0;
+        return definition().getArmorPoints();
     }
 
     /**
@@ -2300,7 +2352,7 @@ public abstract class Item implements Cloneable, ItemID {
      * Define the Armor Toughness of an item
      */
     public int getToughness() {
-        return 0;
+        return definition().getToughness();
     }
 
     public boolean wearableOnClickAir(Player player, Vector3 directionVector) {
@@ -2368,7 +2420,7 @@ public abstract class Item implements Cloneable, ItemID {
      * @return armor knockback resistance
      */
     public float getKnockbackResistance() {
-        return 0.0f;
+        return definition().getKnockbackResistance();
     }
 
 
@@ -2380,26 +2432,14 @@ public abstract class Item implements Cloneable, ItemID {
      * Define if this item is a tool
      */
     public boolean isTool() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) {
-            return isPickaxe() || isAxe() || isShovel() || isHoe() || isSword() || isShears();
-        }
-        return false;
+        return definition().isTool();
     }
 
     /**
      * Define the attackdamage of an item
      */
     public int getAttackDamage() {
-        CompoundTag c = getCustomItemComponent("minecraft:damage");
-        if (c != null && c.contains("value")) {
-            return c.getByte("value") & 0xFF;
-        }
-        CompoundTag p = getCustomItemProperties();
-        if (p != null && p.contains("damage")) {
-            return p.getInt("damage");
-        }
-        return 1;
+        return definition().getAttackDamage();
     }
 
     public int getAttackDamage(Entity entity) {
@@ -2410,120 +2450,91 @@ public abstract class Item implements Cloneable, ItemID {
      * Define if the item is a Sword
      */
     public boolean isSword() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.isSword();
-        return false;
+        return definition().isSword();
     }
 
     /**
      * Define if the item is a Spear
      */
     public boolean isSpear() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.isSpear();
-        return false;
+        return definition().isSpear();
     }
 
     /**
      * Define if the item is a Axe
      */
     public boolean isAxe() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.isAxe();
-        return false;
+        return definition().isAxe();
     }
 
     /**
      * Define if the item is a Pickaxe
      */
     public boolean isPickaxe() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.isPickaxe();
-        return false;
+        return definition().isPickaxe();
     }
 
     /**
      * Define if the item is a Shovel
      */
     public boolean isShovel() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.isShovel();
-        return false;
+        return definition().isShovel();
     }
 
     /**
      * Define if the item is a Hoe
      */
     public boolean isHoe() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.isHoe();
-        return false;
+        return definition().isHoe();
     }
 
     /**
      * Define if the item is a Shield
      */
     public boolean isShield() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.isShield();
-        if (this instanceof ItemShield) return true;
-        return false;
+        return definition().isShield();
     }
 
     /**
      * Define if the item is a Bow
      */
     public boolean isBow() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.isBow();
-        if (this instanceof ItemBow) return true;
-        return false;
+        return definition().isBow();
     }
 
     /**
      * Define if the item is a Crossbow
      */
     public boolean isCrossbow() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.isCrossbow();
-        if (this instanceof ItemCrossbow) return true;
-        return false;
+        return definition().isCrossbow();
     }
 
     /**
      * Define if the item is a Trident
      */
     public boolean isTrident() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.isTrident();
-        if (this instanceof ItemTrident) return true;
-        return false;
+        return definition().isTrident();
     }
 
     /**
      * Define if the item is a Mace
      */
     public boolean isMace() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.isMace();
-        if (this instanceof ItemMace) return true;
-        return false;
+        return definition().isMace();
     }
 
     /**
      * Define if the item is a Shears
      */
     public boolean isShears() {
-        CustomItemDefinition def = getCustomDefinition();
-        if (def != null) return def.isShears();
-        return false;
+        return definition().isShears();
     }
 
     /**
      * Define if the item can break the shield
      */
     public boolean canBreakShield() {
-        return false;
+        return definition().isCanBreakShield();
     }
 
     /**
@@ -2739,8 +2750,8 @@ public abstract class Item implements Cloneable, ItemID {
         if (itemData.getDefinition() == null) {
             return Item.AIR;
         }
-        final ItemDefinition definition = itemData.getDefinition();
-        final Item item = Item.get(definition.getIdentifier(), itemData.getDamage(), itemData.getCount());
+        final org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition networkDefinition = itemData.getDefinition();
+        final Item item = Item.get(networkDefinition.getIdentifier(), itemData.getDamage(), itemData.getCount());
         item.setNbt(itemData.getTag() == null ? null : CompoundTag.fromNetwork(itemData.getTag()));
         final List<String> canPlaceOn = Arrays.stream(itemData.getCanPlace()).toList();
         final List<String> canDestroyOn = Arrays.stream(itemData.getCanBreak()).toList();
@@ -2762,7 +2773,7 @@ public abstract class Item implements Cloneable, ItemID {
         return item;
     }
 
-    public ItemDefinition getItemDefinition() {
+    public org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition getItemDefinition() {
         return new SimpleItemDefinition(
                 this.identifier.toString(),
                 this.getRuntimeId(),

--- a/src/main/java/org/powernukkitx/item/ItemApple.java
+++ b/src/main/java/org/powernukkitx/item/ItemApple.java
@@ -1,20 +1,17 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemApple extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(4)
+            .saturation(2.4f)
+            .build();
+
     public ItemApple() {
-        super(APPLE);
-    }
-
-    @Override
-    public int getNutrition() {
-        return 4;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 2.4F;
+        super(APPLE, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemArmor.java
+++ b/src/main/java/org/powernukkitx/item/ItemArmor.java
@@ -1,40 +1,47 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 abstract public class ItemArmor extends Item {
+    public static final ItemDefinition ARMOR = DEFAULT_DEFINITION.toBuilder()
+            .armor(true)
+            .canTakeDamage(true)
+            .maxStackSize(1)
+            .build();
 
     public ItemArmor(String id) {
-        super(id);
+        this(id, 0, 1, (String) null, ARMOR);
+    }
+
+    public ItemArmor(String id, ItemDefinition definition) {
+        this(id, 0, 1, (String) null, definition);
     }
 
     public ItemArmor(String id, Integer meta) {
-        super(id, meta);
+        this(id, meta, 1, (String) null, ARMOR);
+    }
+
+    public ItemArmor(String id, Integer meta, ItemDefinition definition) {
+        this(id, meta, 1, (String) null, definition);
     }
 
     public ItemArmor(String id, Integer meta, int count) {
-        super(id, meta, count);
+        this(id, meta, count, (String) null, ARMOR);
+    }
+
+    public ItemArmor(String id, Integer meta, int count, ItemDefinition definition) {
+        this(id, meta, count, (String) null, definition);
     }
 
     public ItemArmor(String id, Integer meta, int count, String name) {
-        super(id, meta, count, name);
+        this(id, meta, count, name, ARMOR);
     }
 
-    @Override
-    public int getMaxStackSize() {
-        return 1;
-    }
-
-    @Override
-    public boolean isArmor() {
-        return true;
-    }
-
-    @Override
-    public boolean canTakeDamage() {
-        return true;
+    public ItemArmor(String id, Integer meta, int count, String name, ItemDefinition definition) {
+        super(id, meta, count, name, definition);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemArmorStand.java
+++ b/src/main/java/org/powernukkitx/item/ItemArmorStand.java
@@ -5,6 +5,7 @@ import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockID;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.item.EntityArmorStand;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
@@ -18,18 +19,13 @@ import static org.powernukkitx.math.CompassRoseDirection.Precision.PRIMARY_INTER
 
 
 public class ItemArmorStand extends Item {
+    public static final ItemDefinition DEFINITION = Item.DEFAULT_DEFINITION.toBuilder()
+            .canBeActivated(true)
+            .maxStackSize(64)
+            .build();
+
     public ItemArmorStand() {
-        super(ARMOR_STAND);
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 64;
+        super(ARMOR_STAND, DEFINITION);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemBakedPotato.java
+++ b/src/main/java/org/powernukkitx/item/ItemBakedPotato.java
@@ -1,17 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemBakedPotato extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(5)
+            .saturation(7.2f)
+            .build();
+
     public ItemBakedPotato() {
-        super(BAKED_POTATO);
-    }
-
-    @Override
-    public int getNutrition() {
-        return 5;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 7.2F;
+        super(BAKED_POTATO, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemBanner.java
+++ b/src/main/java/org/powernukkitx/item/ItemBanner.java
@@ -1,6 +1,7 @@
 package org.powernukkitx.item;
 
 import org.powernukkitx.block.BlockStandingBanner;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.nbt.tag.ListTag;
 import org.powernukkitx.network.protocol.types.BannerPattern;
@@ -15,6 +16,10 @@ import static org.powernukkitx.block.property.CommonBlockProperties.GROUND_SIGN_
  * @author PetteriM1
  */
 public class ItemBanner extends Item {
+    public static final ItemDefinition DEFINITION = Item.DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(16)
+            .build();
+
     public ItemBanner() {
         this(0);
     }
@@ -24,18 +29,13 @@ public class ItemBanner extends Item {
     }
 
     public ItemBanner(Integer meta, int count) {
-        super(BANNER, meta, count, "Banner");
+        super(BANNER, meta, count, "Banner", DEFINITION);
     }
 
     @Override
     public void internalAdjust() {
         block = BlockStandingBanner.PROPERTIES.getBlockState(GROUND_SIGN_DIRECTION.createValue(getDamage())).toBlock();
         name = getBaseDyeColor().getName() + " Banner";
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 16;
     }
 
     public int getBaseColor() {

--- a/src/main/java/org/powernukkitx/item/ItemBannerPattern.java
+++ b/src/main/java/org/powernukkitx/item/ItemBannerPattern.java
@@ -1,35 +1,51 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.network.protocol.types.BannerPatternType;
 import org.jetbrains.annotations.ApiStatus;
 
 
 public class ItemBannerPattern extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(1)
+            .build();
+
     public ItemBannerPattern() {
-        this(0, 1);
+        this(0, 1, DEFINITION);
+    }
+
+    public ItemBannerPattern(ItemDefinition definition) {
+        this(0, 1, definition);
     }
 
     public ItemBannerPattern(Integer meta) {
-        this(meta, 1);
+        this(meta, 1, DEFINITION);
+    }
+
+    public ItemBannerPattern(Integer meta, ItemDefinition definition) {
+        this(meta, 1, definition);
     }
 
     public ItemBannerPattern(Integer meta, int count) {
-        super(BANNER_PATTERN, meta, count, "Bone");
+        this(meta, count, DEFINITION);
+    }
+
+    public ItemBannerPattern(Integer meta, int count, ItemDefinition definition) {
+        super(BANNER_PATTERN, meta, count, "Bone", definition);
     }
 
     public ItemBannerPattern(String id) {
-        super(id);
+        this(id, DEFINITION);
+    }
+
+    public ItemBannerPattern(String id, ItemDefinition definition) {
+        super(id, definition);
     }
 
     @ApiStatus.Internal
     public void internalAdjust() {
         BannerPatternType patternType = getPatternType();
         name = patternType.getName() + " Pattern";
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
     }
 
     public BannerPatternType getPatternType() {

--- a/src/main/java/org/powernukkitx/item/ItemBed.java
+++ b/src/main/java/org/powernukkitx/item/ItemBed.java
@@ -2,12 +2,16 @@ package org.powernukkitx.item;
 
 import org.powernukkitx.block.BlockBed;
 import org.powernukkitx.block.BlockID;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.utils.DyeColor;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemBed extends Item {
+    public static final ItemDefinition DEFINITION = Item.DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(1)
+            .build();
 
     public ItemBed() {
         this(0, 1);
@@ -18,16 +22,11 @@ public class ItemBed extends Item {
     }
 
     public ItemBed(Integer meta, int count) {
-        super(BlockID.BED, meta, count);
+        super(BlockID.BED, meta, count, DEFINITION);
     }
 
     public void internalAdjust() {
         name = DyeColor.getByWoolData(meta).getName() + " Bed";
         block = BlockBed.PROPERTIES.getDefaultState().toBlock();
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemBeef.java
+++ b/src/main/java/org/powernukkitx/item/ItemBeef.java
@@ -1,16 +1,14 @@
 package org.powernukkitx.item;
 
-public class ItemBeef extends ItemFood {
-    public ItemBeef() {
-        super(BEEF);
-    }
-    @Override
-    public int getNutrition() {
-        return 3;
-    }
+import org.powernukkitx.item.definition.ItemDefinition;
 
-    @Override
-    public float getSaturation() {
-        return 1.8F;
+public class ItemBeef extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(3)
+            .saturation(1.8f)
+            .build();
+
+    public ItemBeef() {
+        super(BEEF, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemBeetroot.java
+++ b/src/main/java/org/powernukkitx/item/ItemBeetroot.java
@@ -1,11 +1,16 @@
 package org.powernukkitx.item;
 
 import org.powernukkitx.block.BlockID;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemBeetroot extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(1)
+            .saturation(1.2f)
+            .build();
 
     public ItemBeetroot() {
         this(0, 1);
@@ -16,17 +21,7 @@ public class ItemBeetroot extends ItemFood {
     }
 
     public ItemBeetroot(Integer meta, int count) {
-        super(BlockID.BEETROOT, meta, count, "Beetroot");
-    }
-
-    @Override
-    public int getNutrition() {
-        return 1;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 1.2F;
+        super(BlockID.BEETROOT, meta, count, "Beetroot", DEFINITION);
     }
 
 }

--- a/src/main/java/org/powernukkitx/item/ItemBeetrootSoup.java
+++ b/src/main/java/org/powernukkitx/item/ItemBeetrootSoup.java
@@ -1,9 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemBeetrootSoup extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .maxStackSize(1)
+            .nutrition(6)
+            .saturation(7.2f)
+            .build();
 
     public ItemBeetrootSoup() {
         this(0, 1);
@@ -14,21 +21,6 @@ public class ItemBeetrootSoup extends ItemFood {
     }
 
     public ItemBeetrootSoup(Integer meta, int count) {
-        super(BEETROOT_SOUP, 0, count, "Beetroot Soup");
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
-    }
-
-    @Override
-    public int getNutrition() {
-        return 6;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 7.2F;
+        super(BEETROOT_SOUP, 0, count, "Beetroot Soup", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemBlock.java
+++ b/src/main/java/org/powernukkitx/item/ItemBlock.java
@@ -1,22 +1,37 @@
 package org.powernukkitx.item;
 
 import org.powernukkitx.block.Block;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemBlock extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder().build();
+
     public ItemBlock(Block block) {
-        this(block, 0, 1);
+        this(block, 0, 1, DEFINITION);
+    }
+
+    public ItemBlock(Block block, ItemDefinition definition) {
+        this(block, 0, 1, definition);
     }
 
     public ItemBlock(Block block, int aux) {
-        this(block, aux, 1);
+        this(block, aux, 1, DEFINITION);
+    }
+
+    public ItemBlock(Block block, int aux, ItemDefinition definition) {
+        this(block, aux, 1, definition);
     }
 
     public ItemBlock(Block block, int aux, int count) {
-        super(block, aux, count, block.getName(), true);
+        this(block, aux, count, DEFINITION);
+    }
+
+    public ItemBlock(Block block, int aux, int count, ItemDefinition definition) {
+        super(block, aux, count, block.getName(), true, definition);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemBoat.java
+++ b/src/main/java/org/powernukkitx/item/ItemBoat.java
@@ -5,6 +5,7 @@ import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockFlowingWater;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.item.EntityBoat;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.math.BlockFace;
 import org.powernukkitx.nbt.tag.CompoundTag;
@@ -18,21 +19,41 @@ import org.powernukkitx.utils.Identifier;
  * @since 2016/2/13
  */
 public class ItemBoat extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .canBeActivated(true)
+            .maxStackSize(1)
+            .build();
 
     public ItemBoat() {
-        this(0, 1);
+        this(0, 1, DEFINITION);
+    }
+
+    public ItemBoat(ItemDefinition definition) {
+        this(0, 1, definition);
     }
 
     public ItemBoat(Integer meta) {
-        this(meta, 1);
+        this(meta, 1, DEFINITION);
+    }
+
+    public ItemBoat(Integer meta, ItemDefinition definition) {
+        this(meta, 1, definition);
     }
 
     public ItemBoat(Integer meta, int count) {
-        super(BOAT, meta, count);
+        this(meta, count, DEFINITION);
+    }
+
+    public ItemBoat(Integer meta, int count, ItemDefinition definition) {
+        super(BOAT, meta, count, definition);
     }
 
     public ItemBoat(String id) {
-        super(id);
+        this(id, DEFINITION);
+    }
+
+    public ItemBoat(String id, ItemDefinition definition) {
+        super(id, definition);
     }
 
     @Override
@@ -91,11 +112,6 @@ public class ItemBoat extends Item {
         this.meta = 0;
     }
 
-    @Override
-    public boolean canBeActivated() {
-        return true;
-    }
-
     public int getBoatId() {
         return this.meta;
     }
@@ -132,10 +148,5 @@ public class ItemBoat extends Item {
 
         boat.spawnToAll();
         return true;
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemBook.java
+++ b/src/main/java/org/powernukkitx/item/ItemBook.java
@@ -1,15 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemBook extends Item {
-    public ItemBook() {
-        super(BOOK);
-    }
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .enchantAbility(1)
+            .build();
 
-    @Override
-    public int getEnchantAbility() {
-        return 1;
+    public ItemBook() {
+        super(BOOK, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemBookWritable.java
+++ b/src/main/java/org/powernukkitx/item/ItemBookWritable.java
@@ -1,5 +1,6 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.nbt.tag.ListTag;
 import com.google.common.base.Preconditions;
@@ -7,21 +8,38 @@ import com.google.common.base.Preconditions;
 import java.util.List;
 
 public abstract class ItemBookWritable extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder().build();
 
     protected ItemBookWritable(String id) {
-        super(id);
+        this(id, 0, 1, (String) null, DEFINITION);
+    }
+
+    protected ItemBookWritable(String id, ItemDefinition definition) {
+        this(id, 0, 1, (String) null, definition);
     }
 
     protected ItemBookWritable(String id, Integer meta) {
-        super(id, meta);
+        this(id, meta, 1, (String) null, DEFINITION);
+    }
+
+    protected ItemBookWritable(String id, Integer meta, ItemDefinition definition) {
+        this(id, meta, 1, (String) null, definition);
     }
 
     protected ItemBookWritable(String id, Integer meta, int count) {
-        super(id, meta, count);
+        this(id, meta, count, (String) null, DEFINITION);
+    }
+
+    protected ItemBookWritable(String id, Integer meta, int count, ItemDefinition definition) {
+        this(id, meta, count, (String) null, definition);
     }
 
     protected ItemBookWritable(String id, Integer meta, int count, String name) {
-        super(id, meta, count, name);
+        this(id, meta, count, name, DEFINITION);
+    }
+
+    protected ItemBookWritable(String id, Integer meta, int count, String name, ItemDefinition definition) {
+        super(id, meta, count, name, definition);
     }
 
     /**

--- a/src/main/java/org/powernukkitx/item/ItemBow.java
+++ b/src/main/java/org/powernukkitx/item/ItemBow.java
@@ -7,6 +7,7 @@ import org.powernukkitx.entity.projectile.EntityArrow;
 import org.powernukkitx.entity.projectile.EntityProjectile;
 import org.powernukkitx.event.entity.EntityShootBowEvent;
 import org.powernukkitx.event.entity.ProjectileLaunchEvent;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.item.enchantment.bow.EnchantmentBow;
 import org.powernukkitx.level.Sound;
@@ -24,6 +25,11 @@ import java.util.Random;
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemBow extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .bow(true)
+            .maxDurability(ItemTool.DURABILITY_BOW)
+            .usingTicks(72000)
+            .build();
 
     public ItemBow() {
         this(0, 1);
@@ -34,12 +40,7 @@ public class ItemBow extends ItemTool {
     }
 
     public ItemBow(Integer meta, int count) {
-        super(BOW, meta, count, "Bow");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_BOW;
+        super(BOW, meta, count, "Bow", DEFINITION);
     }
 
     @Override
@@ -52,11 +53,6 @@ public class ItemBow extends ItemTool {
         return player.isCreative() ||
                 player.getInventory().getContents().values().stream().filter(item -> item instanceof ItemArrow).findFirst().isPresent() ||
                 player.getOffhandInventory().getContents().values().stream().filter(item -> item instanceof ItemArrow).findFirst().isPresent();
-    }
-
-    @Override
-    public int getUsingTicks() {
-        return 72000;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemBread.java
+++ b/src/main/java/org/powernukkitx/item/ItemBread.java
@@ -1,25 +1,21 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemBread extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(5)
+            .saturation(6f)
+            .build();
 
     public ItemBread() {
         this(1);
     }
 
     public ItemBread(int count) {
-        super(BREAD, 0, count);
-    }
-
-    @Override
-    public int getNutrition() {
-        return 5;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 6F;
+        super(BREAD, 0, count, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemBrush.java
+++ b/src/main/java/org/powernukkitx/item/ItemBrush.java
@@ -1,17 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemBrush extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .canBeActivated(true)
+            .maxDurability(65)
+            .build();
+
     public ItemBrush() {
-        super(BRUSH);
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 65;
+        super(BRUSH, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemBucket.java
+++ b/src/main/java/org/powernukkitx/item/ItemBucket.java
@@ -13,6 +13,7 @@ import org.powernukkitx.entity.EntityID;
 import org.powernukkitx.entity.EntityVariant;
 import org.powernukkitx.event.player.PlayerBucketEmptyEvent;
 import org.powernukkitx.event.player.PlayerBucketFillEvent;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.level.Position;
 import org.powernukkitx.level.Sound;
@@ -33,28 +34,56 @@ import java.util.Objects;
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemBucket extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .canBeActivated(true)
+            .build();
+
     public ItemBucket() {
-        this(0, 1);
+        this(0, 1, DEFINITION);
+    }
+
+    public ItemBucket(ItemDefinition definition) {
+        this(0, 1, definition);
     }
 
     public ItemBucket(Integer meta) {
-        this(meta, 1);
+        this(meta, 1, DEFINITION);
+    }
+
+    public ItemBucket(Integer meta, ItemDefinition definition) {
+        this(meta, 1, definition);
     }
 
     public ItemBucket(Integer meta, int count) {
-        super(BUCKET, meta, count);
+        this(meta, count, DEFINITION);
+    }
+
+    public ItemBucket(Integer meta, int count, ItemDefinition definition) {
+        super(BUCKET, meta, count, definition);
     }
 
     public ItemBucket(String id) {
-        this(id, 0);
+        this(id, 0, DEFINITION);
+    }
+
+    public ItemBucket(String id, ItemDefinition definition) {
+        this(id, 0, definition);
     }
 
     public ItemBucket(String id, int count) {
-        super(id, 0, count);
+        this(id, count, (String) null, DEFINITION);
+    }
+
+    public ItemBucket(String id, int count, ItemDefinition definition) {
+        this(id, count, (String) null, definition);
     }
 
     public ItemBucket(String id, int count, String name) {
-        super(id, 0, count, name);
+        this(id, count, name, DEFINITION);
+    }
+
+    public ItemBucket(String id, int count, String name, ItemDefinition definition) {
+        super(id, 0, count, name, definition);
     }
 
     /**
@@ -133,11 +162,6 @@ public class ItemBucket extends Item {
     @Override
     public int getMaxStackSize() {
         return meta == 0 && Objects.equals(getId(), BUCKET) ? 16 : 1;
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
     }
 
     /**

--- a/src/main/java/org/powernukkitx/item/ItemBundle.java
+++ b/src/main/java/org/powernukkitx/item/ItemBundle.java
@@ -4,6 +4,7 @@ import org.powernukkitx.Player;
 import org.powernukkitx.inventory.BundleInventory;
 import org.powernukkitx.inventory.Inventory;
 import org.powernukkitx.inventory.InventoryHolder;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.math.Vector3;
@@ -19,17 +20,28 @@ import java.util.Optional;
 
 @Slf4j
 public class ItemBundle extends Item implements INBT, InventoryHolder {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(1)
+            .build();
 
     @Getter
     private Inventory holder;
     private BundleInventory inventory;
 
     public ItemBundle() {
-        this(BUNDLE);
+        this(BUNDLE, DEFINITION);
+    }
+
+    public ItemBundle(ItemDefinition definition) {
+        this(BUNDLE, definition);
     }
 
     public ItemBundle(String id) {
-        super(id);
+        this(id, DEFINITION);
+    }
+
+    public ItemBundle(String id, ItemDefinition definition) {
+        super(id, definition);
     }
 
     @Override
@@ -45,11 +57,6 @@ public class ItemBundle extends Item implements INBT, InventoryHolder {
 
     public int getBundleId() {
         return getNbt().getInt("bundle_id");
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemCarrot.java
+++ b/src/main/java/org/powernukkitx/item/ItemCarrot.java
@@ -2,11 +2,16 @@ package org.powernukkitx.item;
 
 import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockID;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemCarrot extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(3)
+            .saturation(4.8f)
+            .build();
 
     public ItemCarrot() {
         this(0, 1);
@@ -17,17 +22,7 @@ public class ItemCarrot extends ItemFood {
     }
 
     public ItemCarrot(Integer meta, int count) {
-        super(CARROT, 0, count, "Carrot");
+        super(CARROT, 0, count, "Carrot", DEFINITION);
         this.block = Block.get(BlockID.CARROTS);
-    }
-
-    @Override
-    public int getNutrition() {
-        return 3;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 4.8F;
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemCarrotOnAStick.java
+++ b/src/main/java/org/powernukkitx/item/ItemCarrotOnAStick.java
@@ -4,6 +4,7 @@ import org.powernukkitx.Player;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityLiving;
 import org.powernukkitx.entity.components.BoostableComponent;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.math.Vector3;
 
@@ -12,6 +13,12 @@ import org.powernukkitx.math.Vector3;
  * @since 21.03.17
  */
 public class ItemCarrotOnAStick extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .maxDurability(ItemTool.DURABILITY_CARROT_ON_A_STICK)
+            .maxStackSize(1)
+            .noDamageOnAttack(true)
+            .noDamageOnBreak(true)
+            .build();
 
     public ItemCarrotOnAStick() {
         this(0, 1);
@@ -22,7 +29,7 @@ public class ItemCarrotOnAStick extends ItemTool {
     }
 
     public ItemCarrotOnAStick(Integer meta, int count) {
-        super(CARROT_ON_A_STICK, meta, count, "Carrot on a Stick");
+        super(CARROT_ON_A_STICK, meta, count, "Carrot on a Stick", DEFINITION);
     }
 
     @Override
@@ -46,26 +53,6 @@ public class ItemCarrotOnAStick extends ItemTool {
         }
 
         return false;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_CARROT_ON_A_STICK;
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
-    }
-
-    @Override
-    public boolean noDamageOnAttack() {
-        return true;
-    }
-
-    @Override
-    public boolean noDamageOnBreak() {
-        return true;
     }
 }
 

--- a/src/main/java/org/powernukkitx/item/ItemChainmailBoots.java
+++ b/src/main/java/org/powernukkitx/item/ItemChainmailBoots.java
@@ -1,8 +1,17 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemChainmailBoots extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(1)
+            .boots(true)
+            .maxDurability(196)
+            .tier(Item.WEARABLE_TIER_CHAIN)
+            .build();
+
     public ItemChainmailBoots() {
-        super(CHAINMAIL_BOOTS);
+        super(CHAINMAIL_BOOTS, DEFINITION);
     }
 
     public ItemChainmailBoots(Integer meta) {
@@ -10,26 +19,6 @@ public class ItemChainmailBoots extends ItemArmor {
     }
 
     public ItemChainmailBoots(Integer meta, int count) {
-        super(CHAINMAIL_BOOTS, meta, count, "Chainmail Boots");
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_CHAIN;
-    }
-
-    @Override
-    public boolean isBoots() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 1;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 196;
+        super(CHAINMAIL_BOOTS, meta, count, "Chainmail Boots", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemChainmailChestplate.java
+++ b/src/main/java/org/powernukkitx/item/ItemChainmailChestplate.java
@@ -1,8 +1,17 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemChainmailChestplate extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(5)
+            .chestplate(true)
+            .maxDurability(241)
+            .tier(Item.WEARABLE_TIER_CHAIN)
+            .build();
+
     public ItemChainmailChestplate() {
-        super(CHAINMAIL_CHESTPLATE);
+        super(CHAINMAIL_CHESTPLATE, DEFINITION);
     }
 
     public ItemChainmailChestplate(Integer meta) {
@@ -10,26 +19,6 @@ public class ItemChainmailChestplate extends ItemArmor {
     }
 
     public ItemChainmailChestplate(Integer meta, int count) {
-        super(CHAINMAIL_CHESTPLATE, meta, count, "Chainmail Chestplate");
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_CHAIN;
-    }
-
-    @Override
-    public boolean isChestplate() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 5;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 241;
+        super(CHAINMAIL_CHESTPLATE, meta, count, "Chainmail Chestplate", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemChainmailHelmet.java
+++ b/src/main/java/org/powernukkitx/item/ItemChainmailHelmet.java
@@ -1,8 +1,17 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemChainmailHelmet extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(2)
+            .helmet(true)
+            .maxDurability(166)
+            .tier(Item.WEARABLE_TIER_CHAIN)
+            .build();
+
     public ItemChainmailHelmet() {
-        super(CHAINMAIL_HELMET);
+        super(CHAINMAIL_HELMET, DEFINITION);
     }
 
     public ItemChainmailHelmet(Integer meta) {
@@ -10,26 +19,6 @@ public class ItemChainmailHelmet extends ItemArmor {
     }
 
     public ItemChainmailHelmet(Integer meta, int count) {
-        super(CHAINMAIL_HELMET, meta, count, "Chainmail Helmet");
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_CHAIN;
-    }
-
-    @Override
-    public boolean isHelmet() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 2;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 166;
+        super(CHAINMAIL_HELMET, meta, count, "Chainmail Helmet", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemChainmailLeggings.java
+++ b/src/main/java/org/powernukkitx/item/ItemChainmailLeggings.java
@@ -1,8 +1,17 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemChainmailLeggings extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(4)
+            .leggings(true)
+            .maxDurability(226)
+            .tier(Item.WEARABLE_TIER_CHAIN)
+            .build();
+
     public ItemChainmailLeggings() {
-        super(CHAINMAIL_LEGGINGS);
+        super(CHAINMAIL_LEGGINGS, DEFINITION);
     }
 
     public ItemChainmailLeggings(Integer meta) {
@@ -10,26 +19,6 @@ public class ItemChainmailLeggings extends ItemArmor {
     }
 
     public ItemChainmailLeggings(Integer meta, int count) {
-        super(CHAINMAIL_LEGGINGS, meta, count, "Chainmail Leggings");
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_CHAIN;
-    }
-
-    @Override
-    public boolean isLeggings() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 4;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 226;
+        super(CHAINMAIL_LEGGINGS, meta, count, "Chainmail Leggings", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemChestBoat.java
+++ b/src/main/java/org/powernukkitx/item/ItemChestBoat.java
@@ -5,6 +5,7 @@ import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockFlowingWater;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.item.EntityChestBoat;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.math.BlockFace;
 import org.powernukkitx.nbt.tag.CompoundTag;
@@ -13,23 +14,44 @@ import org.powernukkitx.nbt.tag.FloatTag;
 import org.powernukkitx.nbt.tag.ListTag;
 
 public class ItemChestBoat extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .canBeActivated(true)
+            .maxStackSize(1)
+            .build();
+
     public ItemChestBoat() {
-        this(0, 1);
+        this(0, 1, DEFINITION);
+    }
+
+    public ItemChestBoat(ItemDefinition definition) {
+        this(0, 1, definition);
     }
 
     public ItemChestBoat(Integer meta) {
-        this(meta, 1);
+        this(meta, 1, DEFINITION);
+    }
+
+    public ItemChestBoat(Integer meta, ItemDefinition definition) {
+        this(meta, 1, definition);
     }
 
     //legacy chest boat , have aux
     public ItemChestBoat(Integer meta, int count) {
-        super(CHEST_BOAT, meta, count);
+        this(meta, count, DEFINITION);
+    }
+
+    public ItemChestBoat(Integer meta, int count, ItemDefinition definition) {
+        super(CHEST_BOAT, meta, count, definition);
         adjustName();
     }
 
     //chest boat item after split aux
     public ItemChestBoat(String id) {
-        super(id);
+        this(id, DEFINITION);
+    }
+
+    public ItemChestBoat(String id, ItemDefinition definition) {
+        super(id, definition);
     }
 
     @Override
@@ -52,11 +74,6 @@ public class ItemChestBoat extends Item {
             case 9 -> name = "Pale Oak Chest Boat";
             default -> name = "Chest Boat";
         }
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
     }
 
     public int getBoatId() {
@@ -95,10 +112,5 @@ public class ItemChestBoat extends Item {
 
         boat.spawnToAll();
         return true;
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemChestMinecart.java
+++ b/src/main/java/org/powernukkitx/item/ItemChestMinecart.java
@@ -5,6 +5,7 @@ import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockRail;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.item.EntityChestMinecart;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.math.BlockFace;
 import org.powernukkitx.nbt.tag.CompoundTag;
@@ -14,6 +15,11 @@ import org.powernukkitx.nbt.tag.ListTag;
 import org.powernukkitx.utils.Rail;
 
 public class ItemChestMinecart extends Item {
+    public static final ItemDefinition DEFINITION = Item.DEFAULT_DEFINITION.toBuilder()
+            .canBeActivated(true)
+            .maxStackSize(1)
+            .build();
+
     public ItemChestMinecart() {
         this(0, 1);
     }
@@ -23,12 +29,7 @@ public class ItemChestMinecart extends Item {
     }
 
     public ItemChestMinecart(Integer meta, int count) {
-        super(CHEST_MINECART, meta, count, "Minecart with Chest");
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
+        super(CHEST_MINECART, meta, count, "Minecart with Chest", DEFINITION);
     }
 
     @Override
@@ -68,10 +69,5 @@ public class ItemChestMinecart extends Item {
             return true;
         }
         return false;
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemChicken.java
+++ b/src/main/java/org/powernukkitx/item/ItemChicken.java
@@ -3,24 +3,20 @@ package org.powernukkitx.item;
 import org.powernukkitx.Player;
 import org.powernukkitx.entity.effect.Effect;
 import org.powernukkitx.entity.effect.EffectType;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 public class ItemChicken extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(2)
+            .saturation(1.2f)
+            .build();
+
     public ItemChicken() {
-        super(CHICKEN, 0, 1, "Raw Chicken");
+        super(CHICKEN, 0, 1, "Raw Chicken", DEFINITION);
     }
 
     public ItemChicken(int count) {
-        super(CHICKEN, 0, count, "Raw Chicken");
-    }
-
-    @Override
-    public int getNutrition() {
-        return 2;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 1.2F;
+        super(CHICKEN, 0, count, "Raw Chicken", DEFINITION);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemCod.java
+++ b/src/main/java/org/powernukkitx/item/ItemCod.java
@@ -1,24 +1,29 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * ItemFish
  */
 public class ItemCod extends ItemFish {
+    public static final ItemDefinition DEFINITION = ItemFish.DEFINITION.toBuilder()
+            .nutrition(2)
+            .saturation(0.4f)
+            .build();
+
     public ItemCod() {
-        super(COD, 0, 1);
+        this(COD, 0, 1, DEFINITION);
+    }
+
+    public ItemCod(ItemDefinition definition) {
+        this(COD, 0, 1, definition);
     }
 
     protected ItemCod(String id, Integer meta, int count) {
-        super(id, meta, count);
+        this(id, meta, count, DEFINITION);
     }
 
-    @Override
-    public int getNutrition() {
-        return 2;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 0.4F;
+    protected ItemCod(String id, Integer meta, int count, ItemDefinition definition) {
+        super(id, meta, count, definition);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemColorArmor.java
+++ b/src/main/java/org/powernukkitx/item/ItemColorArmor.java
@@ -1,5 +1,6 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.utils.BlockColor;
 import org.powernukkitx.utils.DyeColor;
@@ -9,21 +10,38 @@ import org.powernukkitx.utils.DyeColor;
  * @since 27.03.2016
  */
 abstract public class ItemColorArmor extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder().build();
 
     public ItemColorArmor(String id) {
-        super(id);
+        this(id, 0, 1, (String) null, DEFINITION);
+    }
+
+    public ItemColorArmor(String id, ItemDefinition definition) {
+        this(id, 0, 1, (String) null, definition);
     }
 
     public ItemColorArmor(String id, Integer meta) {
-        super(id, meta);
+        this(id, meta, 1, (String) null, DEFINITION);
+    }
+
+    public ItemColorArmor(String id, Integer meta, ItemDefinition definition) {
+        this(id, meta, 1, (String) null, definition);
     }
 
     public ItemColorArmor(String id, Integer meta, int count) {
-        super(id, meta, count);
+        this(id, meta, count, (String) null, DEFINITION);
+    }
+
+    public ItemColorArmor(String id, Integer meta, int count, ItemDefinition definition) {
+        this(id, meta, count, (String) null, definition);
     }
 
     public ItemColorArmor(String id, Integer meta, int count, String name) {
-        super(id, meta, count, name);
+        this(id, meta, count, name, DEFINITION);
+    }
+
+    public ItemColorArmor(String id, Integer meta, int count, String name, ItemDefinition definition) {
+        super(id, meta, count, name, definition);
     }
 
     /**

--- a/src/main/java/org/powernukkitx/item/ItemCookedBeef.java
+++ b/src/main/java/org/powernukkitx/item/ItemCookedBeef.java
@@ -1,17 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemCookedBeef extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(8)
+            .saturation(12.8f)
+            .build();
+
     public ItemCookedBeef() {
-        super(COOKED_BEEF);
-    }
-
-    @Override
-    public int getNutrition() {
-        return 8;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 12.8F;
+        super(COOKED_BEEF, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemCookedChicken.java
+++ b/src/main/java/org/powernukkitx/item/ItemCookedChicken.java
@@ -1,17 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemCookedChicken extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(6)
+            .saturation(7.2f)
+            .build();
+
     public ItemCookedChicken() {
-        super(COOKED_CHICKEN);
-    }
-
-    @Override
-    public int getNutrition() {
-        return 6;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 7.2F;
+        super(COOKED_CHICKEN, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemCookedCod.java
+++ b/src/main/java/org/powernukkitx/item/ItemCookedCod.java
@@ -1,17 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemCookedCod extends ItemCod {
+    public static final ItemDefinition DEFINITION = ItemCod.DEFINITION.toBuilder()
+            .nutrition(5)
+            .saturation(6f)
+            .build();
+
     public ItemCookedCod() {
-        super(COOKED_COD, 0, 1);
-    }
-
-    @Override
-    public int getNutrition() {
-        return 5;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 6F;
+        super(COOKED_COD, 0, 1, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemCookedMutton.java
+++ b/src/main/java/org/powernukkitx/item/ItemCookedMutton.java
@@ -1,17 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemCookedMutton extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(6)
+            .saturation(9.6f)
+            .build();
+
     public ItemCookedMutton() {
-        super(COOKED_MUTTON);
-    }
-
-    @Override
-    public int getNutrition() {
-        return 6;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 9.6F;
+        super(COOKED_MUTTON, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemCookedPorkchop.java
+++ b/src/main/java/org/powernukkitx/item/ItemCookedPorkchop.java
@@ -1,17 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemCookedPorkchop extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(8)
+            .saturation(12.8f)
+            .build();
+
     public ItemCookedPorkchop() {
-        super(COOKED_PORKCHOP);
-    }
-
-    @Override
-    public int getNutrition() {
-        return 8;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 12.8F;
+        super(COOKED_PORKCHOP, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemCookedRabbit.java
+++ b/src/main/java/org/powernukkitx/item/ItemCookedRabbit.java
@@ -1,17 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemCookedRabbit extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(5)
+            .saturation(6f)
+            .build();
+
     public ItemCookedRabbit() {
-        super(COOKED_RABBIT);
-    }
-
-    @Override
-    public int getNutrition() {
-        return 5;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 6F;
+        super(COOKED_RABBIT, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemCookedSalmon.java
+++ b/src/main/java/org/powernukkitx/item/ItemCookedSalmon.java
@@ -1,17 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemCookedSalmon extends ItemSalmon {
+    public static final ItemDefinition DEFINITION = ItemSalmon.DEFINITION.toBuilder()
+            .nutrition(6)
+            .saturation(9.6f)
+            .build();
+
     public ItemCookedSalmon() {
-        super(COOKED_SALMON, 0, 1);
-    }
-
-    @Override
-    public int getNutrition() {
-        return 6;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 9.6F;
+        super(COOKED_SALMON, 0, 1, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemCookie.java
+++ b/src/main/java/org/powernukkitx/item/ItemCookie.java
@@ -1,9 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemCookie extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(2)
+            .saturation(0.4f)
+            .build();
 
     public ItemCookie() {
         this(0, 1);
@@ -14,16 +20,6 @@ public class ItemCookie extends ItemFood {
     }
 
     public ItemCookie(Integer meta, int count) {
-        super(COOKIE, meta, count, "Cookie");
-    }
-
-    @Override
-    public int getNutrition() {
-        return 2;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 0.4F;
+        super(COOKIE, meta, count, "Cookie", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemCopperNautilusArmor.java
+++ b/src/main/java/org/powernukkitx/item/ItemCopperNautilusArmor.java
@@ -1,10 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author Buddelbubi
  * @since 2025/12/16
  */
 public class ItemCopperNautilusArmor extends ItemNautilusArmor {
+    public static final ItemDefinition DEFINITION = ItemNautilusArmor.DEFINITION.toBuilder()
+            .maxDurability(ItemTool.DURABILITY_COPPER)
+            .tier(ItemTool.TIER_COPPER)
+            .build();
 
     public ItemCopperNautilusArmor() {
         this(0, 1);
@@ -15,17 +21,7 @@ public class ItemCopperNautilusArmor extends ItemNautilusArmor {
     }
 
     public ItemCopperNautilusArmor(Integer meta, int count) {
-        super(COPPER_NAUTILUS_ARMOR, meta, count, "Copper Nautilus Armor");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_COPPER;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_COPPER;
+        super(COPPER_NAUTILUS_ARMOR, meta, count, "Copper Nautilus Armor", DEFINITION);
     }
 
 }

--- a/src/main/java/org/powernukkitx/item/ItemCopperSpear.java
+++ b/src/main/java/org/powernukkitx/item/ItemCopperSpear.java
@@ -1,10 +1,17 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author Buddelbubi
  * @since 2025/12/15
  */
 public class ItemCopperSpear extends ItemSpear {
+    public static final ItemDefinition DEFINITION = ItemSpear.DEFINITION.toBuilder()
+            .attackDamage(3)
+            .maxDurability(ItemTool.DURABILITY_COPPER)
+            .tier(ItemTool.TIER_COPPER)
+            .build();
 
     public ItemCopperSpear() {
         this(0, 1);
@@ -15,21 +22,6 @@ public class ItemCopperSpear extends ItemSpear {
     }
 
     public ItemCopperSpear(Integer meta, int count) {
-        super(COPPER_SPEAR, meta, count, "Copper Spear");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_COPPER;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_COPPER;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 3;
+        super(COPPER_SPEAR, meta, count, "Copper Spear", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemCrossbow.java
+++ b/src/main/java/org/powernukkitx/item/ItemCrossbow.java
@@ -8,6 +8,7 @@ import org.powernukkitx.entity.projectile.EntityProjectile;
 import org.powernukkitx.event.entity.EntityShootCrossbowEvent;
 import org.powernukkitx.event.entity.ProjectileLaunchEvent;
 import org.powernukkitx.inventory.Inventory;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.math.Vector3;
@@ -23,6 +24,12 @@ import java.util.Optional;
 
 
 public class ItemCrossbow extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .crossbow(true)
+            .maxDurability(ItemTool.DURABILITY_CROSSBOW)
+            .usingTicks(72000)
+            .build();
+
     private int loadTick;
 
     public ItemCrossbow() {
@@ -34,12 +41,7 @@ public class ItemCrossbow extends ItemTool {
     }
 
     public ItemCrossbow(Integer meta, int count) {
-        super(CROSSBOW, meta, count, "Crossbow");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_CROSSBOW;
+        super(CROSSBOW, meta, count, "Crossbow", DEFINITION);
     }
 
     public boolean onUse(Player player, int ticksUsed) {
@@ -164,11 +166,6 @@ public class ItemCrossbow extends ItemTool {
     public void removeChargedItem(Player player) {
         this.setNbt(this.getNbt().remove("chargedItem"));
         player.getInventory().setItemInMainHand(this);
-    }
-
-    @Override
-    public int getUsingTicks() {
-        return 72000;
     }
 
     public boolean onRelease(Player player, int ticksUsed) {

--- a/src/main/java/org/powernukkitx/item/ItemCustomEntitySpawnEgg.java
+++ b/src/main/java/org/powernukkitx/item/ItemCustomEntitySpawnEgg.java
@@ -6,6 +6,7 @@ import org.powernukkitx.entity.Entity;
 import org.powernukkitx.event.entity.CreatureSpawnEvent;
 import org.powernukkitx.event.entity.CreatureSpawnEvent.SpawnReason;
 import org.powernukkitx.item.customitem.CustomItemDefinition;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.level.Location;
 import org.powernukkitx.level.format.IChunk;
@@ -24,6 +25,10 @@ import java.util.concurrent.ThreadLocalRandom;
 
 @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
 public class ItemCustomEntitySpawnEgg extends Item implements SpawnEggPickable {
+    public static final ItemDefinition DEFINITION = Item.DEFAULT_DEFINITION.toBuilder()
+            .canBeActivated(true)
+            .build();
+
     private static final String SUFFIX = "_spawn_egg";
     private static final String PLACEHOLDER_ID = "pnx:auto_spawn_egg";
 
@@ -35,7 +40,7 @@ public class ItemCustomEntitySpawnEgg extends Item implements SpawnEggPickable {
     private CompoundTag entityNBT;
 
     public ItemCustomEntitySpawnEgg() {
-        super(PLACEHOLDER_ID, 0, 1);
+        super(PLACEHOLDER_ID, 0, 1, DEFINITION);
         selfHealIdentifierFromNamedTag();
     }
 
@@ -71,11 +76,6 @@ public class ItemCustomEntitySpawnEgg extends Item implements SpawnEggPickable {
         root.putCompound(ROOT_PNX_EXTRA, pnxExtra);
 
         return root;
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemDiamondAxe.java
+++ b/src/main/java/org/powernukkitx/item/ItemDiamondAxe.java
@@ -1,32 +1,17 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemDiamondAxe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(6)
+            .axe(true)
+            .canBreakShield(true)
+            .maxDurability(ItemTool.DURABILITY_DIAMOND)
+            .tier(ItemTool.TIER_DIAMOND)
+            .build();
+
     public ItemDiamondAxe() {
-        super(DIAMOND_AXE);
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_DIAMOND;
-    }
-
-    @Override
-    public boolean isAxe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_DIAMOND;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 6;
-    }
-
-    @Override
-    public boolean canBreakShield() {
-        return true;
+        super(DIAMOND_AXE, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemDiamondBoots.java
+++ b/src/main/java/org/powernukkitx/item/ItemDiamondBoots.java
@@ -1,32 +1,17 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemDiamondBoots extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(3)
+            .boots(true)
+            .maxDurability(430)
+            .tier(Item.WEARABLE_TIER_DIAMOND)
+            .toughness(2)
+            .build();
+
     public ItemDiamondBoots() {
-        super(DIAMOND_BOOTS);
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_DIAMOND;
-    }
-
-    @Override
-    public boolean isBoots() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 3;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 430;
-    }
-
-    @Override
-    public int getToughness() {
-        return 2;
+        super(DIAMOND_BOOTS, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemDiamondChestplate.java
+++ b/src/main/java/org/powernukkitx/item/ItemDiamondChestplate.java
@@ -1,6 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemDiamondChestplate extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(8)
+            .chestplate(true)
+            .maxDurability(529)
+            .tier(Item.WEARABLE_TIER_DIAMOND)
+            .toughness(2)
+            .build();
+
     public ItemDiamondChestplate() {
         this(0, 1);
     }
@@ -10,31 +20,6 @@ public class ItemDiamondChestplate extends ItemArmor {
     }
 
     public ItemDiamondChestplate(Integer meta, int count) {
-        super(DIAMOND_CHESTPLATE, meta, count, "Diamond Chestplate");
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_DIAMOND;
-    }
-
-    @Override
-    public boolean isChestplate() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 8;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 529;
-    }
-
-    @Override
-    public int getToughness() {
-        return 2;
+        super(DIAMOND_CHESTPLATE, meta, count, "Diamond Chestplate", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemDiamondHelmet.java
+++ b/src/main/java/org/powernukkitx/item/ItemDiamondHelmet.java
@@ -1,32 +1,17 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemDiamondHelmet extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(3)
+            .helmet(true)
+            .maxDurability(364)
+            .tier(Item.WEARABLE_TIER_DIAMOND)
+            .toughness(2)
+            .build();
+
     public ItemDiamondHelmet() {
-        super(DIAMOND_HELMET);
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_DIAMOND;
-    }
-
-    @Override
-    public boolean isHelmet() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 3;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 364;
-    }
-
-    @Override
-    public int getToughness() {
-        return 2;
+        super(DIAMOND_HELMET, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemDiamondHoe.java
+++ b/src/main/java/org/powernukkitx/item/ItemDiamondHoe.java
@@ -1,22 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemDiamondHoe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .hoe(true)
+            .maxDurability(ItemTool.DURABILITY_DIAMOND)
+            .tier(ItemTool.TIER_DIAMOND)
+            .build();
+
     public ItemDiamondHoe() {
-        super(DIAMOND_HOE);
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_DIAMOND;
-    }
-
-    @Override
-    public boolean isHoe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_DIAMOND;
+        super(DIAMOND_HOE, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemDiamondHorseArmor.java
+++ b/src/main/java/org/powernukkitx/item/ItemDiamondHorseArmor.java
@@ -1,12 +1,13 @@
 package org.powernukkitx.item;
 
-public class ItemDiamondHorseArmor extends Item {
-    public ItemDiamondHorseArmor() {
-        super(DIAMOND_HORSE_ARMOR);
-    }
+import org.powernukkitx.item.definition.ItemDefinition;
 
-    @Override
-    public int getMaxStackSize() {
-        return 1;
+public class ItemDiamondHorseArmor extends Item {
+    public static final ItemDefinition DEFINITION = Item.DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(1)
+            .build();
+
+    public ItemDiamondHorseArmor() {
+        super(DIAMOND_HORSE_ARMOR, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemDiamondLeggings.java
+++ b/src/main/java/org/powernukkitx/item/ItemDiamondLeggings.java
@@ -1,32 +1,17 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemDiamondLeggings extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(6)
+            .leggings(true)
+            .maxDurability(496)
+            .tier(Item.WEARABLE_TIER_DIAMOND)
+            .toughness(2)
+            .build();
+
     public ItemDiamondLeggings() {
-        super(DIAMOND_LEGGINGS);
-    }
-
-    @Override
-    public boolean isLeggings() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_DIAMOND;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 6;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 496;
-    }
-
-    @Override
-    public int getToughness() {
-        return 2;
+        super(DIAMOND_LEGGINGS, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemDiamondNautilusArmor.java
+++ b/src/main/java/org/powernukkitx/item/ItemDiamondNautilusArmor.java
@@ -1,10 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author Buddelbubi
  * @since 2025/12/16
  */
 public class ItemDiamondNautilusArmor extends ItemNautilusArmor {
+    public static final ItemDefinition DEFINITION = ItemNautilusArmor.DEFINITION.toBuilder()
+            .maxDurability(ItemTool.DURABILITY_DIAMOND)
+            .tier(ItemTool.TIER_DIAMOND)
+            .build();
 
     public ItemDiamondNautilusArmor() {
         this(0, 1);
@@ -15,17 +21,7 @@ public class ItemDiamondNautilusArmor extends ItemNautilusArmor {
     }
 
     public ItemDiamondNautilusArmor(Integer meta, int count) {
-        super(DIAMOND_NAUTILUS_ARMOR, meta, count, "Diamond Nautilus Armor");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_DIAMOND;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_DIAMOND;
+        super(DIAMOND_NAUTILUS_ARMOR, meta, count, "Diamond Nautilus Armor", DEFINITION);
     }
 
 }

--- a/src/main/java/org/powernukkitx/item/ItemDiamondPickaxe.java
+++ b/src/main/java/org/powernukkitx/item/ItemDiamondPickaxe.java
@@ -1,27 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemDiamondPickaxe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(5)
+            .maxDurability(ItemTool.DURABILITY_DIAMOND)
+            .pickaxe(true)
+            .tier(ItemTool.TIER_DIAMOND)
+            .build();
+
     public ItemDiamondPickaxe() {
-        super(DIAMOND_PICKAXE);
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_DIAMOND;
-    }
-
-    @Override
-    public boolean isPickaxe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_DIAMOND;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 5;
+        super(DIAMOND_PICKAXE, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemDiamondShovel.java
+++ b/src/main/java/org/powernukkitx/item/ItemDiamondShovel.java
@@ -1,27 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemDiamondShovel extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(4)
+            .maxDurability(ItemTool.DURABILITY_DIAMOND)
+            .shovel(true)
+            .tier(ItemTool.TIER_DIAMOND)
+            .build();
+
     public ItemDiamondShovel() {
-        super(DIAMOND_SHOVEL);
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_DIAMOND;
-    }
-
-    @Override
-    public boolean isShovel() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_DIAMOND;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 4;
+        super(DIAMOND_SHOVEL, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemDiamondSpear.java
+++ b/src/main/java/org/powernukkitx/item/ItemDiamondSpear.java
@@ -1,10 +1,17 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author Buddelbubi
  * @since 2025/12/15
  */
 public class ItemDiamondSpear extends ItemSpear {
+    public static final ItemDefinition DEFINITION = ItemSpear.DEFINITION.toBuilder()
+            .attackDamage(5)
+            .maxDurability(ItemTool.DURABILITY_DIAMOND)
+            .tier(ItemTool.TIER_DIAMOND)
+            .build();
 
     public ItemDiamondSpear() {
         this(0, 1);
@@ -15,21 +22,6 @@ public class ItemDiamondSpear extends ItemSpear {
     }
 
     public ItemDiamondSpear(Integer meta, int count) {
-        super(DIAMOND_SPEAR, meta, count, "Diamond Spear");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_DIAMOND;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_DIAMOND;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 5;
+        super(DIAMOND_SPEAR, meta, count, "Diamond Spear", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemDiamondSword.java
+++ b/src/main/java/org/powernukkitx/item/ItemDiamondSword.java
@@ -1,27 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemDiamondSword extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(7)
+            .maxDurability(ItemTool.DURABILITY_DIAMOND)
+            .sword(true)
+            .tier(ItemTool.TIER_DIAMOND)
+            .build();
+
     public ItemDiamondSword() {
-        super(DIAMOND_SWORD);
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_DIAMOND;
-    }
-
-    @Override
-    public boolean isSword() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_DIAMOND;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 7;
+        super(DIAMOND_SWORD, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemDriedKelp.java
+++ b/src/main/java/org/powernukkitx/item/ItemDriedKelp.java
@@ -1,9 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author PetteriM1
  */
 public class ItemDriedKelp extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(1)
+            .saturation(0.6f)
+            .usingTicks(17)
+            .build();
 
     public ItemDriedKelp() {
         this(0, 1);
@@ -14,21 +21,6 @@ public class ItemDriedKelp extends ItemFood {
     }
 
     public ItemDriedKelp(Integer meta, int count) {
-        super(DRIED_KELP, 0, count, "Dried Kelp");
-    }
-
-    @Override
-    public int getNutrition() {
-        return 1;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 0.6F;
-    }
-
-    @Override
-    public int getUsingTicks() {
-        return 17;
+        super(DRIED_KELP, 0, count, "Dried Kelp", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemDye.java
+++ b/src/main/java/org/powernukkitx/item/ItemDye.java
@@ -1,33 +1,60 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.utils.DyeColor;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemDye extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder().build();
+
     public ItemDye() {
-        this(0, 1);
+        this(0, 1, DEFINITION);
+    }
+
+    public ItemDye(ItemDefinition definition) {
+        this(0, 1, definition);
     }
 
     public ItemDye(Integer meta) {
-        this(meta, 1);
+        this(meta, 1, DEFINITION);
+    }
+
+    public ItemDye(Integer meta, ItemDefinition definition) {
+        this(meta, 1, definition);
     }
 
     public ItemDye(DyeColor dyeColor) {
-        this(dyeColor.getItemDyeMeta(), 1);
+        this(dyeColor.getItemDyeMeta(), 1, DEFINITION);
+    }
+
+    public ItemDye(DyeColor dyeColor, ItemDefinition definition) {
+        this(dyeColor.getItemDyeMeta(), 1, definition);
     }
 
     public ItemDye(DyeColor dyeColor, int amount) {
-        this(dyeColor.getItemDyeMeta(), amount);
+        this(dyeColor.getItemDyeMeta(), amount, DEFINITION);
+    }
+
+    public ItemDye(DyeColor dyeColor, int amount, ItemDefinition definition) {
+        this(dyeColor.getItemDyeMeta(), amount, definition);
     }
 
     public ItemDye(Integer meta, int amount) {
-        super(DYE, meta, amount, meta <= 15 ? DyeColor.getByDyeData(meta).getDyeName() : DyeColor.getByDyeData(meta).getName() + " Dye");
+        this(meta, amount, DEFINITION);
+    }
+
+    public ItemDye(Integer meta, int amount, ItemDefinition definition) {
+        super(DYE, meta, amount, meta <= 15 ? DyeColor.getByDyeData(meta).getDyeName() : DyeColor.getByDyeData(meta).getName() + " Dye", definition);
     }
 
     public ItemDye(String id) {
-        super(id);
+        this(id, DEFINITION);
+    }
+
+    public ItemDye(String id, ItemDefinition definition) {
+        super(id, definition);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemEgg.java
+++ b/src/main/java/org/powernukkitx/item/ItemEgg.java
@@ -1,27 +1,47 @@
 package org.powernukkitx.item;
 
 import org.powernukkitx.entity.ClimateVariant;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.nbt.tag.CompoundTag;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemEgg extends ProjectileItem {
+    public static final ItemDefinition DEFINITION = ProjectileItem.DEFINITION.toBuilder()
+            .maxStackSize(16)
+            .build();
 
     public ItemEgg() {
-        this(0, 1);
+        this(0, 1, DEFINITION);
+    }
+
+    public ItemEgg(ItemDefinition definition) {
+        this(0, 1, definition);
     }
 
     public ItemEgg(Integer meta) {
-        this(meta, 1);
+        this(meta, 1, DEFINITION);
+    }
+
+    public ItemEgg(Integer meta, ItemDefinition definition) {
+        this(meta, 1, definition);
     }
 
     public ItemEgg(Integer meta, int count) {
-        super(EGG, meta, count, "Egg");
+        this(meta, count, DEFINITION);
+    }
+
+    public ItemEgg(Integer meta, int count, ItemDefinition definition) {
+        super(EGG, meta, count, "Egg", definition);
     }
 
     protected ItemEgg(String id, Integer meta, int count, String name) {
-        super(id, meta, count, name);
+        this(id, meta, count, name, DEFINITION);
+    }
+
+    protected ItemEgg(String id, Integer meta, int count, String name, ItemDefinition definition) {
+        super(id, meta, count, name, definition);
     }
 
     @Override
@@ -32,11 +52,6 @@ public class ItemEgg extends ProjectileItem {
     @Override
     public float getThrowForce() {
         return 1.5f;
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 16;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemElytra.java
+++ b/src/main/java/org/powernukkitx/item/ItemElytra.java
@@ -1,9 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemElytra extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .chestplate(true)
+            .maxDurability(433)
+            .build();
 
     public ItemElytra() {
         this(0, 1);
@@ -14,21 +20,11 @@ public class ItemElytra extends ItemArmor {
     }
 
     public ItemElytra(Integer meta, int count) {
-        super(ELYTRA, meta, count, "Elytra");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 433;
+        super(ELYTRA, meta, count, "Elytra", DEFINITION);
     }
 
     @Override
     public boolean isArmor() {
         return false;
-    }
-
-    @Override
-    public boolean isChestplate() {
-        return true;
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemEnchantedBook.java
+++ b/src/main/java/org/powernukkitx/item/ItemEnchantedBook.java
@@ -1,21 +1,26 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemEnchantedBook extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .applyEnchantments(false)
+            .maxStackSize(1)
+            .build();
+
     public ItemEnchantedBook() {
-        super(ENCHANTED_BOOK);
+        this(ENCHANTED_BOOK, DEFINITION);
+    }
+
+    public ItemEnchantedBook(ItemDefinition definition) {
+        this(ENCHANTED_BOOK, definition);
     }
 
     protected ItemEnchantedBook(String id) {
-        super(id);
+        this(id, DEFINITION);
     }
 
-    @Override
-    public int getMaxStackSize() {
-        return 1;
-    }
-
-    @Override
-    public boolean applyEnchantments() {
-        return false;
+    protected ItemEnchantedBook(String id, ItemDefinition definition) {
+        super(id, definition);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemEnchantedGoldenApple.java
+++ b/src/main/java/org/powernukkitx/item/ItemEnchantedGoldenApple.java
@@ -3,26 +3,22 @@ package org.powernukkitx.item;
 import org.powernukkitx.Player;
 import org.powernukkitx.entity.effect.Effect;
 import org.powernukkitx.entity.effect.EffectType;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.math.Vector3;
 
 public class ItemEnchantedGoldenApple extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(4)
+            .saturation(2.4f)
+            .build();
+
     public ItemEnchantedGoldenApple() {
-        super(ENCHANTED_GOLDEN_APPLE);
+        super(ENCHANTED_GOLDEN_APPLE, DEFINITION);
     }
 
     @Override
     public boolean onClickAir(Player player, Vector3 directionVector) {
         return true;
-    }
-
-    @Override
-    public int getNutrition() {
-        return 4;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 2.4F;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemEndCrystal.java
+++ b/src/main/java/org/powernukkitx/item/ItemEndCrystal.java
@@ -6,6 +6,7 @@ import org.powernukkitx.block.BlockBedrock;
 import org.powernukkitx.block.BlockID;
 import org.powernukkitx.block.BlockObsidian;
 import org.powernukkitx.entity.Entity;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.math.BlockFace;
@@ -18,6 +19,9 @@ import org.powernukkitx.nbt.tag.ListTag;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class ItemEndCrystal extends Item {
+    public static final ItemDefinition DEFINITION = Item.DEFAULT_DEFINITION.toBuilder()
+            .canBeActivated(true)
+            .build();
 
     public ItemEndCrystal() {
         this(0, 1);
@@ -28,12 +32,7 @@ public class ItemEndCrystal extends Item {
     }
 
     public ItemEndCrystal(Integer meta, int count) {
-        super(END_CRYSTAL, meta, count, "End Crystal");
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
+        super(END_CRYSTAL, meta, count, "End Crystal", DEFINITION);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemEnderPearl.java
+++ b/src/main/java/org/powernukkitx/item/ItemEnderPearl.java
@@ -3,8 +3,12 @@ package org.powernukkitx.item;
 import org.powernukkitx.Player;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.projectile.EntityEnderPearl;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 public class ItemEnderPearl extends ProjectileItem {
+    public static final ItemDefinition DEFINITION = ProjectileItem.DEFINITION.toBuilder()
+            .maxStackSize(16)
+            .build();
 
     public ItemEnderPearl() {
         this(0, 1);
@@ -15,12 +19,7 @@ public class ItemEnderPearl extends ProjectileItem {
     }
 
     public ItemEnderPearl(Integer meta, int count) {
-        super(ENDER_PEARL, 0, count, "Ender Pearl");
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 16;
+        super(ENDER_PEARL, 0, count, "Ender Pearl", DEFINITION);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemFilledMap.java
+++ b/src/main/java/org/powernukkitx/item/ItemFilledMap.java
@@ -6,6 +6,7 @@ import org.powernukkitx.Player;
 import org.powernukkitx.Server;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.math.Vector3;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.plugin.InternalPlugin;
 import org.powernukkitx.utils.Utils;
@@ -27,6 +28,11 @@ import java.util.stream.Collectors;
 
 @Slf4j
 public class ItemFilledMap extends Item {
+    public static final ItemDefinition DEFINITION = Item.DEFAULT_DEFINITION.toBuilder()
+            .canBeActivated(true)
+            .maxStackSize(1)
+            .build();
+
     public static int mapCount = 0;
     // not very pretty but definitely better than before.
     private BufferedImage image;
@@ -40,7 +46,7 @@ public class ItemFilledMap extends Item {
     }
 
     public ItemFilledMap(Integer meta, int count) {
-        super(FILLED_MAP, meta, count, "Map");
+        super(FILLED_MAP, meta, count, "Map", DEFINITION);
         updateName();
         if (!hasNbt() || !getNbt().contains("map_uuid")) {
             this.setNbt(getOrCreateNbt().putLong("map_uuid", mapCount++));
@@ -182,16 +188,6 @@ public class ItemFilledMap extends Item {
         } catch (Exception ex) {
             log.warn("There was an error while generating map image", ex);
         }
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemFireCharge.java
+++ b/src/main/java/org/powernukkitx/item/ItemFireCharge.java
@@ -5,6 +5,7 @@ import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockFire;
 import org.powernukkitx.block.BlockID;
 import org.powernukkitx.event.block.BlockIgniteEvent;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.math.BlockFace;
 import org.cloudburstmc.protocol.bedrock.data.LevelEvent;
@@ -15,6 +16,9 @@ import java.util.concurrent.ThreadLocalRandom;
  * @author PetteriM1
  */
 public class ItemFireCharge extends Item {
+    public static final ItemDefinition DEFINITION = Item.DEFAULT_DEFINITION.toBuilder()
+            .canBeActivated(true)
+            .build();
 
     public ItemFireCharge() {
         this(0, 1);
@@ -25,12 +29,7 @@ public class ItemFireCharge extends Item {
     }
 
     public ItemFireCharge(Integer meta, int count) {
-        super(FIRE_CHARGE, 0, count, "Fire Charge");
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
+        super(FIRE_CHARGE, 0, count, "Fire Charge", DEFINITION);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemFireworkRocket.java
+++ b/src/main/java/org/powernukkitx/item/ItemFireworkRocket.java
@@ -5,6 +5,7 @@ import org.powernukkitx.block.Block;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.item.EntityElytraFirework;
 import org.powernukkitx.entity.item.EntityFireworksRocket;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.math.BlockFace;
 import org.powernukkitx.math.Vector3;
@@ -19,6 +20,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ItemFireworkRocket extends Item {
+    public static final ItemDefinition DEFINITION = Item.DEFAULT_DEFINITION.toBuilder()
+            .canBeActivated(true)
+            .build();
+
     public ItemFireworkRocket() {
         this(0);
     }
@@ -28,12 +33,7 @@ public class ItemFireworkRocket extends Item {
     }
 
     public ItemFireworkRocket(Integer meta, int count) {
-        super(FIREWORK_ROCKET, meta, count, "Firework Rocket");
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
+        super(FIREWORK_ROCKET, meta, count, "Firework Rocket", DEFINITION);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemFish.java
+++ b/src/main/java/org/powernukkitx/item/ItemFish.java
@@ -1,7 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public abstract class ItemFish extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder().build();
+
     protected ItemFish(String id, Integer meta, int count) {
-        super(id, meta, count);
+        this(id, meta, count, DEFINITION);
+    }
+
+    protected ItemFish(String id, Integer meta, int count, ItemDefinition definition) {
+        super(id, meta, count, definition);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemFishingRod.java
+++ b/src/main/java/org/powernukkitx/item/ItemFishingRod.java
@@ -1,6 +1,7 @@
 package org.powernukkitx.item;
 
 import org.powernukkitx.Player;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.vibration.VibrationEvent;
 import org.powernukkitx.level.vibration.VibrationType;
 import org.powernukkitx.math.Vector3;
@@ -10,6 +11,11 @@ import org.powernukkitx.math.Vector3;
  * @since 2016/1/14
  */
 public class ItemFishingRod extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .maxDurability(ItemTool.DURABILITY_FISHING_ROD)
+            .noDamageOnAttack(true)
+            .noDamageOnBreak(true)
+            .build();
 
     public ItemFishingRod() {
         this(0, 1);
@@ -20,7 +26,7 @@ public class ItemFishingRod extends ItemTool {
     }
 
     public ItemFishingRod(Integer meta, int count) {
-        super(FISHING_ROD, meta, count, "Fishing Rod");
+        super(FISHING_ROD, meta, count, "Fishing Rod", DEFINITION);
     }
 
     @Override
@@ -37,21 +43,6 @@ public class ItemFishingRod extends ItemTool {
             player.startFishing(this);
             this.meta++;
         }
-        return true;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_FISHING_ROD;
-    }
-
-    @Override
-    public boolean noDamageOnAttack() {
-        return true;
-    }
-
-    @Override
-    public boolean noDamageOnBreak() {
         return true;
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemFlintAndSteel.java
+++ b/src/main/java/org/powernukkitx/item/ItemFlintAndSteel.java
@@ -5,6 +5,7 @@ import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockFire;
 import org.powernukkitx.block.BlockID;
 import org.powernukkitx.event.block.BlockIgniteEvent;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.vibration.VibrationEvent;
@@ -14,6 +15,10 @@ import org.powernukkitx.math.BlockFace;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class ItemFlintAndSteel extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .canBeActivated(true)
+            .maxDurability(ItemTool.DURABILITY_FLINT_STEEL)
+            .build();
 
     public ItemFlintAndSteel() {
         this(0, 1);
@@ -24,12 +29,7 @@ public class ItemFlintAndSteel extends ItemTool {
     }
 
     public ItemFlintAndSteel(Integer meta, int count) {
-        super(FLINT_AND_STEEL, meta, count, "Flint and Steel");
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
+        super(FLINT_AND_STEEL, meta, count, "Flint and Steel", DEFINITION);
     }
 
     @Override
@@ -83,11 +83,6 @@ public class ItemFlintAndSteel extends ItemTool {
             }
         }
         block.getLevel().addSound(block, Sound.FIRE_IGNITE);
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_FLINT_STEEL;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemFood.java
+++ b/src/main/java/org/powernukkitx/item/ItemFood.java
@@ -1,35 +1,47 @@
 package org.powernukkitx.item;
 
 import org.powernukkitx.Player;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public abstract class ItemFood extends Item {
+    public static final ItemDefinition FOOD = DEFAULT_DEFINITION.toBuilder()
+            .edible(true)
+            .usingTicks(31)
+            .build();
+
     public ItemFood(String id) {
-        super(id);
+        this(id, 0, 1, (String) null, FOOD);
+    }
+
+    public ItemFood(String id, ItemDefinition definition) {
+        this(id, 0, 1, (String) null, definition);
     }
 
     public ItemFood(String id, Integer meta) {
-        super(id, meta);
+        this(id, meta, 1, (String) null, FOOD);
+    }
+
+    public ItemFood(String id, Integer meta, ItemDefinition definition) {
+        this(id, meta, 1, (String) null, definition);
     }
 
     public ItemFood(String id, Integer meta, int count) {
-        super(id, meta, count);
+        this(id, meta, count, (String) null, FOOD);
+    }
+
+    public ItemFood(String id, Integer meta, int count, ItemDefinition definition) {
+        this(id, meta, count, (String) null, definition);
     }
 
     public ItemFood(String id, Integer meta, int count, String name) {
-        super(id, meta, count, name);
+        this(id, meta, count, name, FOOD);
     }
 
-    @Override
-    public boolean isEdible() {
-        return true;
-    }
-
-    @Override
-    public int getUsingTicks() {
-        return 31;
+    public ItemFood(String id, Integer meta, int count, String name, ItemDefinition definition) {
+        super(id, meta, count, name, definition);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemGlassBottle.java
+++ b/src/main/java/org/powernukkitx/item/ItemGlassBottle.java
@@ -6,6 +6,7 @@ import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockBeehive;
 import org.powernukkitx.block.BlockID;
 import org.powernukkitx.entity.item.EntityAreaEffectCloud;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.vibration.VibrationEvent;
@@ -13,6 +14,9 @@ import org.powernukkitx.level.vibration.VibrationType;
 import org.powernukkitx.math.BlockFace;
 
 public class ItemGlassBottle extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .canBeActivated(true)
+            .build();
 
     public ItemGlassBottle() {
         this(0, 1);
@@ -23,12 +27,7 @@ public class ItemGlassBottle extends Item {
     }
 
     public ItemGlassBottle(Integer meta, int count) {
-        super(GLASS_BOTTLE, meta, count, "Glass Bottle");
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
+        super(GLASS_BOTTLE, meta, count, "Glass Bottle", DEFINITION);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemGlowBerries.java
+++ b/src/main/java/org/powernukkitx/item/ItemGlowBerries.java
@@ -4,6 +4,7 @@ import org.powernukkitx.Player;
 import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockCaveVines;
 import org.powernukkitx.block.property.CommonBlockProperties;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.math.BlockFace;
@@ -14,6 +15,11 @@ import java.util.concurrent.ThreadLocalRandom;
  * @author Superice666
  */
 public class ItemGlowBerries extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .canBeActivated(true)
+            .nutrition(2)
+            .saturation(0.4f)
+            .build();
 
     public ItemGlowBerries() {
         this(0, 1);
@@ -24,12 +30,7 @@ public class ItemGlowBerries extends ItemFood {
     }
 
     public ItemGlowBerries(Integer meta, int count) {
-        super(GLOW_BERRIES, 0, count, "Glow Berries");
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
+        super(GLOW_BERRIES, 0, count, "Glow Berries", DEFINITION);
     }
 
     @Override
@@ -47,15 +48,5 @@ public class ItemGlowBerries extends ItemFood {
         }
 
         return false;
-    }
-
-    @Override
-    public int getNutrition() {
-        return 2;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 0.4F;
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemGoatHorn.java
+++ b/src/main/java/org/powernukkitx/item/ItemGoatHorn.java
@@ -1,10 +1,15 @@
 package org.powernukkitx.item;
 
 import org.powernukkitx.Player;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.math.Vector3;
 
 public class ItemGoatHorn extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(1)
+            .build();
+
     protected int coolDownTick = 140;
 
     public ItemGoatHorn() {
@@ -16,14 +21,9 @@ public class ItemGoatHorn extends Item {
     }
 
     public ItemGoatHorn(Integer aux, int count) {
-        super(GOAT_HORN);
+        super(GOAT_HORN, DEFINITION);
         this.meta = aux;
         this.count = count;
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemGoldenApple.java
+++ b/src/main/java/org/powernukkitx/item/ItemGoldenApple.java
@@ -3,26 +3,22 @@ package org.powernukkitx.item;
 import org.powernukkitx.Player;
 import org.powernukkitx.entity.effect.Effect;
 import org.powernukkitx.entity.effect.EffectType;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.math.Vector3;
 
 public class ItemGoldenApple extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(4)
+            .saturation(9.6f)
+            .build();
+
     public ItemGoldenApple() {
-        super(GOLDEN_APPLE);
+        super(GOLDEN_APPLE, DEFINITION);
     }
 
     @Override
     public boolean onClickAir(Player player, Vector3 directionVector) {
         return true;
-    }
-
-    @Override
-    public int getNutrition() {
-        return 4;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 9.6F;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemGoldenAxe.java
+++ b/src/main/java/org/powernukkitx/item/ItemGoldenAxe.java
@@ -1,6 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemGoldenAxe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(3)
+            .axe(true)
+            .canBreakShield(true)
+            .maxDurability(ItemTool.DURABILITY_GOLD)
+            .tier(ItemTool.TIER_GOLD)
+            .build();
+
     public ItemGoldenAxe() {
         this(0, 1);
     }
@@ -10,31 +20,6 @@ public class ItemGoldenAxe extends ItemTool {
     }
 
     public ItemGoldenAxe(Integer meta, int count) {
-        super(GOLDEN_AXE, meta, count, "Golden Axe");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_GOLD;
-    }
-
-    @Override
-    public boolean isAxe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_GOLD;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 3;
-    }
-
-    @Override
-    public boolean canBreakShield() {
-        return true;
+        super(GOLDEN_AXE, meta, count, "Golden Axe", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemGoldenBoots.java
+++ b/src/main/java/org/powernukkitx/item/ItemGoldenBoots.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemGoldenBoots extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(1)
+            .boots(true)
+            .maxDurability(92)
+            .tier(Item.WEARABLE_TIER_GOLD)
+            .build();
+
     public ItemGoldenBoots() {
         this(0, 1);
     }
@@ -10,26 +19,6 @@ public class ItemGoldenBoots extends ItemArmor {
     }
 
     public ItemGoldenBoots(Integer meta, int count) {
-        super(GOLDEN_BOOTS, meta, count, "Golden Boots");
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_GOLD;
-    }
-
-    @Override
-    public boolean isBoots() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 1;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 92;
+        super(GOLDEN_BOOTS, meta, count, "Golden Boots", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemGoldenCarrot.java
+++ b/src/main/java/org/powernukkitx/item/ItemGoldenCarrot.java
@@ -1,17 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemGoldenCarrot extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(6)
+            .saturation(14.4f)
+            .build();
+
     public ItemGoldenCarrot() {
-        super(GOLDEN_CARROT);
-    }
-
-    @Override
-    public int getNutrition() {
-        return 6;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 14.4F;
+        super(GOLDEN_CARROT, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemGoldenChestplate.java
+++ b/src/main/java/org/powernukkitx/item/ItemGoldenChestplate.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemGoldenChestplate extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(5)
+            .chestplate(true)
+            .maxDurability(113)
+            .tier(Item.WEARABLE_TIER_GOLD)
+            .build();
+
     public ItemGoldenChestplate() {
         this(0, 1);
     }
@@ -10,26 +19,6 @@ public class ItemGoldenChestplate extends ItemArmor {
     }
 
     public ItemGoldenChestplate(Integer meta, int count) {
-        super(GOLDEN_CHESTPLATE, meta, count, "Golden Chestplate");
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_GOLD;
-    }
-
-    @Override
-    public boolean isChestplate() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 5;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 113;
+        super(GOLDEN_CHESTPLATE, meta, count, "Golden Chestplate", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemGoldenHelmet.java
+++ b/src/main/java/org/powernukkitx/item/ItemGoldenHelmet.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemGoldenHelmet extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(2)
+            .helmet(true)
+            .maxDurability(78)
+            .tier(Item.WEARABLE_TIER_GOLD)
+            .build();
+
     public ItemGoldenHelmet() {
         this(0, 1);
     }
@@ -10,26 +19,6 @@ public class ItemGoldenHelmet extends ItemArmor {
     }
 
     public ItemGoldenHelmet(Integer meta, int count) {
-        super(GOLDEN_HELMET, meta, count, "Golden Helmet");
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_GOLD;
-    }
-
-    @Override
-    public boolean isHelmet() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 2;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 78;
+        super(GOLDEN_HELMET, meta, count, "Golden Helmet", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemGoldenHoe.java
+++ b/src/main/java/org/powernukkitx/item/ItemGoldenHoe.java
@@ -1,6 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemGoldenHoe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .hoe(true)
+            .maxDurability(ItemTool.DURABILITY_GOLD)
+            .tier(ItemTool.TIER_GOLD)
+            .build();
+
     public ItemGoldenHoe() {
         this(0, 1);
     }
@@ -10,21 +18,6 @@ public class ItemGoldenHoe extends ItemTool {
     }
 
     public ItemGoldenHoe(Integer meta, int count) {
-        super(GOLDEN_HOE, meta, count, "Golden Hoe");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_GOLD;
-    }
-
-    @Override
-    public boolean isHoe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_GOLD;
+        super(GOLDEN_HOE, meta, count, "Golden Hoe", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemGoldenHorseArmor.java
+++ b/src/main/java/org/powernukkitx/item/ItemGoldenHorseArmor.java
@@ -1,12 +1,13 @@
 package org.powernukkitx.item;
 
-public class ItemGoldenHorseArmor extends Item {
-    public ItemGoldenHorseArmor() {
-        super(GOLDEN_HORSE_ARMOR);
-    }
+import org.powernukkitx.item.definition.ItemDefinition;
 
-    @Override
-    public int getMaxStackSize() {
-        return 1;
+public class ItemGoldenHorseArmor extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(1)
+            .build();
+
+    public ItemGoldenHorseArmor() {
+        super(GOLDEN_HORSE_ARMOR, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemGoldenLeggings.java
+++ b/src/main/java/org/powernukkitx/item/ItemGoldenLeggings.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemGoldenLeggings extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(3)
+            .leggings(true)
+            .maxDurability(106)
+            .tier(Item.WEARABLE_TIER_GOLD)
+            .build();
+
     public ItemGoldenLeggings() {
         this(0, 1);
     }
@@ -10,26 +19,6 @@ public class ItemGoldenLeggings extends ItemArmor {
     }
 
     public ItemGoldenLeggings(Integer meta, int count) {
-        super(GOLDEN_LEGGINGS, meta, count, "Golden Leggings");
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_GOLD;
-    }
-
-    @Override
-    public boolean isLeggings() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 3;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 106;
+        super(GOLDEN_LEGGINGS, meta, count, "Golden Leggings", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemGoldenNautilusArmor.java
+++ b/src/main/java/org/powernukkitx/item/ItemGoldenNautilusArmor.java
@@ -1,10 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author Buddelbubi
  * @since 2025/12/16
  */
 public class ItemGoldenNautilusArmor extends ItemNautilusArmor {
+    public static final ItemDefinition DEFINITION = ItemNautilusArmor.DEFINITION.toBuilder()
+            .maxDurability(ItemTool.DURABILITY_GOLD)
+            .tier(ItemTool.TIER_GOLD)
+            .build();
 
     public ItemGoldenNautilusArmor() {
         this(0, 1);
@@ -15,17 +21,7 @@ public class ItemGoldenNautilusArmor extends ItemNautilusArmor {
     }
 
     public ItemGoldenNautilusArmor(Integer meta, int count) {
-        super(GOLDEN_NAUTILUS_ARMOR, meta, count, "Golden Nautilus Armor");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_GOLD;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_GOLD;
+        super(GOLDEN_NAUTILUS_ARMOR, meta, count, "Golden Nautilus Armor", DEFINITION);
     }
 
 }

--- a/src/main/java/org/powernukkitx/item/ItemGoldenPickaxe.java
+++ b/src/main/java/org/powernukkitx/item/ItemGoldenPickaxe.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemGoldenPickaxe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(2)
+            .maxDurability(ItemTool.DURABILITY_GOLD)
+            .pickaxe(true)
+            .tier(ItemTool.TIER_GOLD)
+            .build();
+
     public ItemGoldenPickaxe() {
         this(0, 1);
     }
@@ -10,26 +19,6 @@ public class ItemGoldenPickaxe extends ItemTool {
     }
 
     public ItemGoldenPickaxe(Integer meta, int count) {
-        super(GOLDEN_PICKAXE, meta, count, "Golden Pickaxe");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_GOLD;
-    }
-
-    @Override
-    public boolean isPickaxe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_GOLD;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 2;
+        super(GOLDEN_PICKAXE, meta, count, "Golden Pickaxe", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemGoldenShovel.java
+++ b/src/main/java/org/powernukkitx/item/ItemGoldenShovel.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemGoldenShovel extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(1)
+            .maxDurability(ItemTool.DURABILITY_GOLD)
+            .shovel(true)
+            .tier(ItemTool.TIER_GOLD)
+            .build();
+
     public ItemGoldenShovel() {
         this(0, 1);
     }
@@ -10,26 +19,6 @@ public class ItemGoldenShovel extends ItemTool {
     }
 
     public ItemGoldenShovel(Integer meta, int count) {
-        super(GOLDEN_SHOVEL, meta, count, "Golden Shovel");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_GOLD;
-    }
-
-    @Override
-    public boolean isShovel() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_GOLD;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 1;
+        super(GOLDEN_SHOVEL, meta, count, "Golden Shovel", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemGoldenSpear.java
+++ b/src/main/java/org/powernukkitx/item/ItemGoldenSpear.java
@@ -1,10 +1,17 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author Buddelbubi
  * @since 2025/12/15
  */
 public class ItemGoldenSpear extends ItemSpear {
+    public static final ItemDefinition DEFINITION = ItemSpear.DEFINITION.toBuilder()
+            .attackDamage(2)
+            .maxDurability(ItemTool.DURABILITY_GOLD)
+            .tier(ItemTool.TIER_GOLD)
+            .build();
 
     public ItemGoldenSpear() {
         this(0, 1);
@@ -15,21 +22,6 @@ public class ItemGoldenSpear extends ItemSpear {
     }
 
     public ItemGoldenSpear(Integer meta, int count) {
-        super(GOLDEN_SPEAR, meta, count, "Golden Spear");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_GOLD;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_GOLD;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 2;
+        super(GOLDEN_SPEAR, meta, count, "Golden Spear", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemGoldenSword.java
+++ b/src/main/java/org/powernukkitx/item/ItemGoldenSword.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemGoldenSword extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(4)
+            .maxDurability(ItemTool.DURABILITY_GOLD)
+            .sword(true)
+            .tier(ItemTool.TIER_GOLD)
+            .build();
+
     public ItemGoldenSword() {
         this(0, 1);
     }
@@ -10,26 +19,6 @@ public class ItemGoldenSword extends ItemTool {
     }
 
     public ItemGoldenSword(Integer meta, int count) {
-        super(GOLDEN_SWORD, meta, count, "Golden Sword");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_GOLD;
-    }
-
-    @Override
-    public boolean isSword() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_GOLD;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 4;
+        super(GOLDEN_SWORD, meta, count, "Golden Sword", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemHangingSign.java
+++ b/src/main/java/org/powernukkitx/item/ItemHangingSign.java
@@ -1,16 +1,20 @@
 package org.powernukkitx.item;
 
 import org.powernukkitx.block.Block;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 
 public abstract class ItemHangingSign extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(16)
+            .build();
+
     public ItemHangingSign(String id) {
-        super(id);
-        this.block = Block.get(id);
+        this(id, DEFINITION);
     }
 
-    @Override
-    public int getMaxStackSize() {
-        return 16;
+    public ItemHangingSign(String id, ItemDefinition definition) {
+        super(id, definition);
+        this.block = Block.get(id);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemHarness.java
+++ b/src/main/java/org/powernukkitx/item/ItemHarness.java
@@ -1,14 +1,18 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class ItemHarness extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(1)
+            .build();
+
     public ItemHarness(@NotNull String id) {
-        super(id);
+        this(id, DEFINITION);
     }
 
-    @Override
-    public int getMaxStackSize() {
-        return 1;
+    public ItemHarness(@NotNull String id, ItemDefinition definition) {
+        super(id, definition);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemHoeDiamond.java
+++ b/src/main/java/org/powernukkitx/item/ItemHoeDiamond.java
@@ -1,9 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemHoeDiamond extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .hoe(true)
+            .maxDurability(ItemTool.DURABILITY_DIAMOND)
+            .tier(ItemTool.TIER_DIAMOND)
+            .build();
 
     public ItemHoeDiamond() {
         this(0, 1);
@@ -14,21 +21,6 @@ public class ItemHoeDiamond extends ItemTool {
     }
 
     public ItemHoeDiamond(Integer meta, int count) {
-        super(DIAMOND_HOE, meta, count, "Diamond Hoe");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_DIAMOND;
-    }
-
-    @Override
-    public boolean isHoe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_DIAMOND;
+        super(DIAMOND_HOE, meta, count, "Diamond Hoe", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemHoneyBottle.java
+++ b/src/main/java/org/powernukkitx/item/ItemHoneyBottle.java
@@ -2,43 +2,34 @@ package org.powernukkitx.item;
 
 import org.powernukkitx.Player;
 import org.powernukkitx.entity.effect.EffectType;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.math.Vector3;
 
 /**
  * @author joserobjr
  */
 public class ItemHoneyBottle extends ItemFood {
-    
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .maxStackSize(16)
+            .nutrition(6)
+            .saturation(1.2f)
+            .build();
+
     public ItemHoneyBottle() {
         this(0, 1);
     }
-    
+
     public ItemHoneyBottle(Integer meta) {
         this(meta, 1);
     }
-    
+
     public ItemHoneyBottle(Integer meta, int count) {
-        super(HONEY_BOTTLE, meta, count, "Honey Bottle");
+        super(HONEY_BOTTLE, meta, count, "Honey Bottle", DEFINITION);
     }
-    
-    @Override
-    public int getMaxStackSize() {
-        return 16;
-    }
-    
+
     @Override
     public boolean onClickAir(Player player, Vector3 directionVector) {
         return true;
-    }
-
-    @Override
-    public int getNutrition() {
-        return 6;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 1.2F;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemHopperMinecart.java
+++ b/src/main/java/org/powernukkitx/item/ItemHopperMinecart.java
@@ -5,6 +5,7 @@ import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockRail;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.item.EntityHopperMinecart;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.math.BlockFace;
 import org.powernukkitx.nbt.tag.CompoundTag;
@@ -14,6 +15,11 @@ import org.powernukkitx.nbt.tag.ListTag;
 import org.powernukkitx.utils.Rail;
 
 public class ItemHopperMinecart extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .canBeActivated(true)
+            .maxStackSize(1)
+            .build();
+
     public ItemHopperMinecart() {
         this(0, 1);
     }
@@ -23,12 +29,7 @@ public class ItemHopperMinecart extends Item {
     }
 
     public ItemHopperMinecart(Integer meta, int count) {
-        super(HOPPER_MINECART, meta, count, "Minecart with Hopper");
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
+        super(HOPPER_MINECART, meta, count, "Minecart with Hopper", DEFINITION);
     }
 
     @Override
@@ -68,10 +69,5 @@ public class ItemHopperMinecart extends Item {
             return true;
         }
         return false;
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemIngotNetherite.java
+++ b/src/main/java/org/powernukkitx/item/ItemIngotNetherite.java
@@ -1,8 +1,11 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
 
 public class ItemIngotNetherite extends Item {
-
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .lavaResistant(true)
+            .build();
 
     public ItemIngotNetherite() {
         this(0, 1);
@@ -13,11 +16,6 @@ public class ItemIngotNetherite extends Item {
     }
 
     public ItemIngotNetherite(Integer meta, int count) {
-        super(NETHERITE_INGOT, 0, count, "Netherite Ingot");
-    }
-
-    @Override
-    public boolean isLavaResistant() {
-        return true;
+        super(NETHERITE_INGOT, 0, count, "Netherite Ingot", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemIronAxe.java
+++ b/src/main/java/org/powernukkitx/item/ItemIronAxe.java
@@ -1,6 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemIronAxe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(5)
+            .axe(true)
+            .canBreakShield(true)
+            .maxDurability(ItemTool.DURABILITY_IRON)
+            .tier(ItemTool.TIER_IRON)
+            .build();
+
     public ItemIronAxe() {
         this(0, 1);
     }
@@ -10,31 +20,6 @@ public class ItemIronAxe extends ItemTool {
     }
 
     public ItemIronAxe(Integer meta, int count) {
-        super(IRON_AXE, meta, count, "Iron Axe");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_IRON;
-    }
-
-    @Override
-    public boolean isAxe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_IRON;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 5;
-    }
-
-    @Override
-    public boolean canBreakShield() {
-        return true;
+        super(IRON_AXE, meta, count, "Iron Axe", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemIronBoots.java
+++ b/src/main/java/org/powernukkitx/item/ItemIronBoots.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemIronBoots extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(2)
+            .boots(true)
+            .maxDurability(196)
+            .tier(Item.WEARABLE_TIER_IRON)
+            .build();
+
     public ItemIronBoots() {
         this(0, 1);
     }
@@ -10,26 +19,6 @@ public class ItemIronBoots extends ItemArmor {
     }
 
     public ItemIronBoots(Integer meta, int count) {
-        super(IRON_BOOTS, meta, count, "Iron Boots");
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_IRON;
-    }
-
-    @Override
-    public boolean isBoots() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 2;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 196;
+        super(IRON_BOOTS, meta, count, "Iron Boots", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemIronChestplate.java
+++ b/src/main/java/org/powernukkitx/item/ItemIronChestplate.java
@@ -1,6 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemIronChestplate extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(6)
+            .chestplate(true)
+            .maxDurability(241)
+            .tier(Item.WEARABLE_TIER_IRON)
+            .build();
 
     public ItemIronChestplate() {
         this(0, 1);
@@ -11,26 +19,6 @@ public class ItemIronChestplate extends ItemArmor {
     }
 
     public ItemIronChestplate(Integer meta, int count) {
-        super(IRON_CHESTPLATE, meta, count, "Iron Chestplate");
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_IRON;
-    }
-
-    @Override
-    public boolean isChestplate() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 6;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 241;
+        super(IRON_CHESTPLATE, meta, count, "Iron Chestplate", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemIronHelmet.java
+++ b/src/main/java/org/powernukkitx/item/ItemIronHelmet.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemIronHelmet extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(2)
+            .helmet(true)
+            .maxDurability(166)
+            .tier(Item.WEARABLE_TIER_IRON)
+            .build();
+
     public ItemIronHelmet() {
         this(0, 1);
     }
@@ -10,26 +19,6 @@ public class ItemIronHelmet extends ItemArmor {
     }
 
     public ItemIronHelmet(Integer meta, int count) {
-        super(IRON_HELMET, meta, count, "Iron Helmet");
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_IRON;
-    }
-
-    @Override
-    public boolean isHelmet() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 2;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 166;
+        super(IRON_HELMET, meta, count, "Iron Helmet", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemIronHoe.java
+++ b/src/main/java/org/powernukkitx/item/ItemIronHoe.java
@@ -1,6 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemIronHoe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .hoe(true)
+            .maxDurability(ItemTool.DURABILITY_IRON)
+            .tier(ItemTool.TIER_IRON)
+            .build();
+
     public ItemIronHoe() {
         this(0, 1);
     }
@@ -10,21 +18,6 @@ public class ItemIronHoe extends ItemTool {
     }
 
     public ItemIronHoe(Integer meta, int count) {
-        super(IRON_HOE, meta, count, "Iron Hoe");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_IRON;
-    }
-
-    @Override
-    public boolean isHoe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_IRON;
+        super(IRON_HOE, meta, count, "Iron Hoe", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemIronHorseArmor.java
+++ b/src/main/java/org/powernukkitx/item/ItemIronHorseArmor.java
@@ -1,12 +1,13 @@
 package org.powernukkitx.item;
 
-public class ItemIronHorseArmor extends Item {
-    public ItemIronHorseArmor() {
-        super(IRON_HORSE_ARMOR);
-    }
+import org.powernukkitx.item.definition.ItemDefinition;
 
-    @Override
-    public int getMaxStackSize() {
-        return 1;
+public class ItemIronHorseArmor extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(1)
+            .build();
+
+    public ItemIronHorseArmor() {
+        super(IRON_HORSE_ARMOR, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemIronLeggings.java
+++ b/src/main/java/org/powernukkitx/item/ItemIronLeggings.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemIronLeggings extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(5)
+            .leggings(true)
+            .maxDurability(226)
+            .tier(Item.WEARABLE_TIER_IRON)
+            .build();
+
     public ItemIronLeggings() {
         this(0, 1);
     }
@@ -10,26 +19,6 @@ public class ItemIronLeggings extends ItemArmor {
     }
 
     public ItemIronLeggings(Integer meta, int count) {
-        super(IRON_LEGGINGS, meta, count, "Iron Leggings");
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_IRON;
-    }
-
-    @Override
-    public boolean isLeggings() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 5;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 226;
+        super(IRON_LEGGINGS, meta, count, "Iron Leggings", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemIronNautilusArmor.java
+++ b/src/main/java/org/powernukkitx/item/ItemIronNautilusArmor.java
@@ -1,10 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author Buddelbubi
  * @since 2025/12/16
  */
 public class ItemIronNautilusArmor extends ItemNautilusArmor {
+    public static final ItemDefinition DEFINITION = ItemNautilusArmor.DEFINITION.toBuilder()
+            .maxDurability(ItemTool.DURABILITY_IRON)
+            .tier(ItemTool.TIER_IRON)
+            .build();
 
     public ItemIronNautilusArmor() {
         this(0, 1);
@@ -15,17 +21,7 @@ public class ItemIronNautilusArmor extends ItemNautilusArmor {
     }
 
     public ItemIronNautilusArmor(Integer meta, int count) {
-        super(IRON_NAUTILUS_ARMOR, meta, count, "Iron Nautilus Armor");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_IRON;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_IRON;
+        super(IRON_NAUTILUS_ARMOR, meta, count, "Iron Nautilus Armor", DEFINITION);
     }
 
 }

--- a/src/main/java/org/powernukkitx/item/ItemIronPickaxe.java
+++ b/src/main/java/org/powernukkitx/item/ItemIronPickaxe.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemIronPickaxe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(4)
+            .maxDurability(ItemTool.DURABILITY_IRON)
+            .pickaxe(true)
+            .tier(ItemTool.TIER_IRON)
+            .build();
+
     public ItemIronPickaxe() {
         this(0, 1);
     }
@@ -10,26 +19,6 @@ public class ItemIronPickaxe extends ItemTool {
     }
 
     public ItemIronPickaxe(Integer meta, int count) {
-        super(IRON_PICKAXE, meta, count, "Iron Pickaxe");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_IRON;
-    }
-
-    @Override
-    public boolean isPickaxe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_IRON;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 4;
+        super(IRON_PICKAXE, meta, count, "Iron Pickaxe", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemIronShovel.java
+++ b/src/main/java/org/powernukkitx/item/ItemIronShovel.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemIronShovel extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(3)
+            .maxDurability(ItemTool.DURABILITY_IRON)
+            .shovel(true)
+            .tier(ItemTool.TIER_IRON)
+            .build();
+
     public ItemIronShovel() {
         this(0, 1);
     }
@@ -10,26 +19,6 @@ public class ItemIronShovel extends ItemTool {
     }
 
     public ItemIronShovel(Integer meta, int count) {
-        super(IRON_SHOVEL, meta, count, "Iron Shovel");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_IRON;
-    }
-
-    @Override
-    public boolean isShovel() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_IRON;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 3;
+        super(IRON_SHOVEL, meta, count, "Iron Shovel", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemIronSpear.java
+++ b/src/main/java/org/powernukkitx/item/ItemIronSpear.java
@@ -1,10 +1,17 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author Buddelbubi
  * @since 2025/12/15
  */
 public class ItemIronSpear extends ItemSpear {
+    public static final ItemDefinition DEFINITION = ItemSpear.DEFINITION.toBuilder()
+            .attackDamage(4)
+            .maxDurability(ItemTool.DURABILITY_IRON)
+            .tier(ItemTool.TIER_IRON)
+            .build();
 
     public ItemIronSpear() {
         this(0, 1);
@@ -15,21 +22,6 @@ public class ItemIronSpear extends ItemSpear {
     }
 
     public ItemIronSpear(Integer meta, int count) {
-        super(IRON_SPEAR, meta, count, "Iron Spear");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_IRON;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_IRON;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 4;
+        super(IRON_SPEAR, meta, count, "Iron Spear", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemIronSword.java
+++ b/src/main/java/org/powernukkitx/item/ItemIronSword.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemIronSword extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(6)
+            .maxDurability(ItemTool.DURABILITY_IRON)
+            .sword(true)
+            .tier(ItemTool.TIER_IRON)
+            .build();
+
     public ItemIronSword() {
         this(0, 1);
     }
@@ -10,26 +19,6 @@ public class ItemIronSword extends ItemTool {
     }
 
     public ItemIronSword(Integer meta, int count) {
-        super(IRON_SWORD, meta, count, "Iron Sword");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_IRON;
-    }
-
-    @Override
-    public boolean isSword() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_IRON;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 6;
+        super(IRON_SWORD, meta, count, "Iron Sword", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemLeatherBoots.java
+++ b/src/main/java/org/powernukkitx/item/ItemLeatherBoots.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemLeatherBoots extends ItemColorArmor {
+    public static final ItemDefinition DEFINITION = ItemColorArmor.DEFINITION.toBuilder()
+            .armorPoints(1)
+            .boots(true)
+            .maxDurability(66)
+            .tier(Item.WEARABLE_TIER_LEATHER)
+            .build();
+
     public ItemLeatherBoots() {
         this(0, 1);
     }
@@ -10,26 +19,6 @@ public class ItemLeatherBoots extends ItemColorArmor {
     }
 
     public ItemLeatherBoots(Integer meta, int count) {
-        super(LEATHER_BOOTS, meta, count, "Leather Boots");
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_LEATHER;
-    }
-
-    @Override
-    public boolean isBoots() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 1;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 66;
+        super(LEATHER_BOOTS, meta, count, "Leather Boots", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemLeatherChestplate.java
+++ b/src/main/java/org/powernukkitx/item/ItemLeatherChestplate.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemLeatherChestplate extends ItemColorArmor {
+    public static final ItemDefinition DEFINITION = ItemColorArmor.DEFINITION.toBuilder()
+            .armorPoints(3)
+            .chestplate(true)
+            .maxDurability(81)
+            .tier(Item.WEARABLE_TIER_LEATHER)
+            .build();
+
     public ItemLeatherChestplate() {
         this(0, 1);
     }
@@ -10,26 +19,6 @@ public class ItemLeatherChestplate extends ItemColorArmor {
     }
 
     public ItemLeatherChestplate(Integer meta, int count) {
-        super(LEATHER_CHESTPLATE, meta, count);
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_LEATHER;
-    }
-
-    @Override
-    public boolean isChestplate() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 3;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 81;
+        super(LEATHER_CHESTPLATE, meta, count, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemLeatherHelmet.java
+++ b/src/main/java/org/powernukkitx/item/ItemLeatherHelmet.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemLeatherHelmet extends ItemColorArmor {
+    public static final ItemDefinition DEFINITION = ItemColorArmor.DEFINITION.toBuilder()
+            .armorPoints(1)
+            .helmet(true)
+            .maxDurability(56)
+            .tier(Item.WEARABLE_TIER_LEATHER)
+            .build();
+
     public ItemLeatherHelmet() {
         this(0, 1);
     }
@@ -10,26 +19,6 @@ public class ItemLeatherHelmet extends ItemColorArmor {
     }
 
     public ItemLeatherHelmet(Integer meta, int count) {
-        super(LEATHER_HELMET, meta, count);
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_LEATHER;
-    }
-
-    @Override
-    public boolean isHelmet() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 1;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 56;
+        super(LEATHER_HELMET, meta, count, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemLeatherHorseArmor.java
+++ b/src/main/java/org/powernukkitx/item/ItemLeatherHorseArmor.java
@@ -1,12 +1,13 @@
 package org.powernukkitx.item;
 
-public class ItemLeatherHorseArmor extends Item {
-    public ItemLeatherHorseArmor() {
-        super(LEATHER_HORSE_ARMOR);
-    }
+import org.powernukkitx.item.definition.ItemDefinition;
 
-    @Override
-    public int getMaxStackSize() {
-        return 1;
+public class ItemLeatherHorseArmor extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(1)
+            .build();
+
+    public ItemLeatherHorseArmor() {
+        super(LEATHER_HORSE_ARMOR, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemLeatherLeggings.java
+++ b/src/main/java/org/powernukkitx/item/ItemLeatherLeggings.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemLeatherLeggings extends ItemColorArmor {
+    public static final ItemDefinition DEFINITION = ItemColorArmor.DEFINITION.toBuilder()
+            .armorPoints(2)
+            .leggings(true)
+            .maxDurability(76)
+            .tier(Item.WEARABLE_TIER_LEATHER)
+            .build();
+
     public ItemLeatherLeggings() {
         this(0, 1);
     }
@@ -10,26 +19,6 @@ public class ItemLeatherLeggings extends ItemColorArmor {
     }
 
     public ItemLeatherLeggings(Integer meta, int count) {
-        super(LEATHER_LEGGINGS, meta, count);
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_LEATHER;
-    }
-
-    @Override
-    public boolean isLeggings() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 2;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 76;
+        super(LEATHER_LEGGINGS, meta, count, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemLingeringPotion.java
+++ b/src/main/java/org/powernukkitx/item/ItemLingeringPotion.java
@@ -1,9 +1,14 @@
 package org.powernukkitx.item;
 
 import org.powernukkitx.entity.effect.PotionType;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.nbt.tag.CompoundTag;
 
 public class ItemLingeringPotion extends ProjectileItem {
+    public static final ItemDefinition DEFINITION = ProjectileItem.DEFINITION.toBuilder()
+            .canBeActivated(true)
+            .maxStackSize(1)
+            .build();
 
     public ItemLingeringPotion() {
         this(0, 1);
@@ -14,7 +19,7 @@ public class ItemLingeringPotion extends ProjectileItem {
     }
 
     public ItemLingeringPotion(Integer meta, int count) {
-        super(LINGERING_POTION, meta, count, "Lingering Potion");
+        super(LINGERING_POTION, meta, count, "Lingering Potion", DEFINITION);
         updateName();
     }
 
@@ -31,16 +36,6 @@ public class ItemLingeringPotion extends ProjectileItem {
         } else {
             name = ItemPotion.buildName(potion, "Lingering Potion", true);
         }
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemLodestoneCompass.java
+++ b/src/main/java/org/powernukkitx/item/ItemLodestoneCompass.java
@@ -1,6 +1,7 @@
 package org.powernukkitx.item;
 
 import org.powernukkitx.Server;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.positiontracking.NamedPosition;
 
@@ -8,6 +9,10 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 
 public class ItemLodestoneCompass extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(1)
+            .build();
+
     public ItemLodestoneCompass() {
         this(0, 1);
     }
@@ -17,12 +22,7 @@ public class ItemLodestoneCompass extends Item {
     }
 
     public ItemLodestoneCompass(Integer meta, int count) {
-        super(LODESTONE_COMPASS, meta, count, "Lodestone Compass");
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
+        super(LODESTONE_COMPASS, meta, count, "Lodestone Compass", DEFINITION);
     }
 
     public void setTrackingPosition(@Nullable NamedPosition position) throws IOException {

--- a/src/main/java/org/powernukkitx/item/ItemMace.java
+++ b/src/main/java/org/powernukkitx/item/ItemMace.java
@@ -1,6 +1,7 @@
 package org.powernukkitx.item;
 
 import org.powernukkitx.entity.Entity;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.math.NukkitMath;
@@ -8,13 +9,13 @@ import org.powernukkitx.math.Vector3;
 import org.cloudburstmc.protocol.bedrock.data.LevelEvent;
 
 public class ItemMace extends ItemTool {
-    public ItemMace() {
-        super(MACE);
-    }
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .mace(true)
+            .maxDurability(501)
+            .build();
 
-    @Override
-    public int getMaxDurability() {
-        return 501;
+    public ItemMace() {
+        super(MACE, DEFINITION);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemMelonSlice.java
+++ b/src/main/java/org/powernukkitx/item/ItemMelonSlice.java
@@ -1,6 +1,13 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemMelonSlice extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(2)
+            .saturation(1.2f)
+            .build();
+
     public ItemMelonSlice() {
         this(0, 1);
     }
@@ -10,16 +17,6 @@ public class ItemMelonSlice extends ItemFood {
     }
 
     public ItemMelonSlice(Integer meta, int count) {
-        super(MELON_SLICE, meta, count, "Melon Slice");
-    }
-
-    @Override
-    public int getNutrition() {
-        return 2;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 1.2F;
+        super(MELON_SLICE, meta, count, "Melon Slice", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemMilkBucket.java
+++ b/src/main/java/org/powernukkitx/item/ItemMilkBucket.java
@@ -3,29 +3,25 @@ package org.powernukkitx.item;
 import org.powernukkitx.Player;
 import org.powernukkitx.Server;
 import org.powernukkitx.event.player.PlayerItemConsumeEvent;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.vibration.VibrationEvent;
 import org.powernukkitx.level.vibration.VibrationType;
 import org.powernukkitx.math.Vector3;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemUseMethod;
 
 public class ItemMilkBucket extends ItemBucket {
+    public static final ItemDefinition DEFINITION = ItemBucket.DEFINITION.toBuilder()
+            .consumable(true)
+            .usingTicks(31)
+            .build();
+
     public ItemMilkBucket() {
-        super(MILK_BUCKET);
+        super(MILK_BUCKET, DEFINITION);
     }
 
     @Override
     public void setDamage(int meta) {
 
-    }
-
-    @Override
-    public boolean isConsumable() {
-        return true;
-    }
-
-    @Override
-    public int getUsingTicks() {
-        return 31;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemMinecart.java
+++ b/src/main/java/org/powernukkitx/item/ItemMinecart.java
@@ -5,6 +5,7 @@ import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockRail;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.item.EntityMinecart;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.math.BlockFace;
 import org.powernukkitx.nbt.tag.CompoundTag;
@@ -17,6 +18,10 @@ import org.powernukkitx.utils.Rail;
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemMinecart extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .canBeActivated(true)
+            .maxStackSize(1)
+            .build();
 
     public ItemMinecart() {
         this(0, 1);
@@ -27,12 +32,7 @@ public class ItemMinecart extends Item {
     }
 
     public ItemMinecart(Integer meta, int count) {
-        super(MINECART, meta, count, "Minecart");
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
+        super(MINECART, meta, count, "Minecart", DEFINITION);
     }
 
     @Override
@@ -72,10 +72,5 @@ public class ItemMinecart extends Item {
             return true;
         }
         return false;
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemMushroomStew.java
+++ b/src/main/java/org/powernukkitx/item/ItemMushroomStew.java
@@ -1,11 +1,17 @@
 package org.powernukkitx.item;
 
 import org.powernukkitx.Player;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemMushroomStew extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .maxStackSize(1)
+            .nutrition(6)
+            .saturation(7.2f)
+            .build();
 
     public ItemMushroomStew() {
         this(0, 1);
@@ -16,22 +22,7 @@ public class ItemMushroomStew extends ItemFood {
     }
 
     public ItemMushroomStew(Integer meta, int count) {
-        super(MUSHROOM_STEW, 0, count, "Mushroom Stew");
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
-    }
-
-    @Override
-    public int getNutrition() {
-        return 6;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 7.2F;
+        super(MUSHROOM_STEW, 0, count, "Mushroom Stew", DEFINITION);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemMusicDisc.java
+++ b/src/main/java/org/powernukkitx/item/ItemMusicDisc.java
@@ -1,16 +1,21 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author CreeperFace
  */
 public abstract class ItemMusicDisc extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(1)
+            .build();
+
     protected ItemMusicDisc(String id) {
-        super(id);
+        this(id, DEFINITION);
     }
 
-    @Override
-    public int getMaxStackSize() {
-        return 1;
+    protected ItemMusicDisc(String id, ItemDefinition definition) {
+        super(id, definition);
     }
 
     public abstract String getSoundId();

--- a/src/main/java/org/powernukkitx/item/ItemMutton.java
+++ b/src/main/java/org/powernukkitx/item/ItemMutton.java
@@ -1,6 +1,13 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemMutton extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(2)
+            .saturation(1.2f)
+            .build();
+
     public ItemMutton() {
         this(0, 1);
     }
@@ -10,16 +17,6 @@ public class ItemMutton extends ItemFood {
     }
 
     public ItemMutton(Integer meta, int count) {
-        super(MUTTON, meta, count, "Raw Mutton");
-    }
-
-    @Override
-    public int getNutrition() {
-        return 2;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 1.2F;
+        super(MUTTON, meta, count, "Raw Mutton", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemNautilusArmor.java
+++ b/src/main/java/org/powernukkitx/item/ItemNautilusArmor.java
@@ -1,13 +1,17 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public abstract class ItemNautilusArmor extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(1)
+            .build();
 
     public ItemNautilusArmor(String id, Integer meta, int count, String name) {
-        super(id, meta, count, name);
+        this(id, meta, count, name, DEFINITION);
     }
 
-    @Override
-    public int getMaxStackSize() {
-        return 1;
+    public ItemNautilusArmor(String id, Integer meta, int count, String name, ItemDefinition definition) {
+        super(id, meta, count, name, definition);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemNetheriteAxe.java
+++ b/src/main/java/org/powernukkitx/item/ItemNetheriteAxe.java
@@ -1,6 +1,17 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemNetheriteAxe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(8)
+            .axe(true)
+            .canBreakShield(true)
+            .lavaResistant(true)
+            .maxDurability(ItemTool.DURABILITY_NETHERITE)
+            .tier(ItemTool.TIER_NETHERITE)
+            .build();
+
     public ItemNetheriteAxe() {
         this(0, 1);
     }
@@ -10,36 +21,6 @@ public class ItemNetheriteAxe extends ItemTool {
     }
 
     public ItemNetheriteAxe(Integer meta, int count) {
-        super(NETHERITE_AXE, meta, count, "Netherite Axe");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_NETHERITE;
-    }
-
-    @Override
-    public boolean isAxe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_NETHERITE;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 8;
-    }
-
-    @Override
-    public boolean isLavaResistant() {
-        return true;
-    }
-
-    @Override
-    public boolean canBreakShield() {
-        return true;
+        super(NETHERITE_AXE, meta, count, "Netherite Axe", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemNetheriteBoots.java
+++ b/src/main/java/org/powernukkitx/item/ItemNetheriteBoots.java
@@ -1,6 +1,18 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemNetheriteBoots extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(3)
+            .boots(true)
+            .knockbackResistance(0.1f)
+            .lavaResistant(true)
+            .maxDurability(481)
+            .tier(Item.WEARABLE_TIER_NETHERITE)
+            .toughness(3)
+            .build();
+
     public ItemNetheriteBoots() {
         this(0, 1);
     }
@@ -10,41 +22,6 @@ public class ItemNetheriteBoots extends ItemArmor {
     }
 
     public ItemNetheriteBoots(Integer meta, int count) {
-        super(NETHERITE_BOOTS, meta, count, "Netherite Boots");
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_NETHERITE;
-    }
-
-    @Override
-    public boolean isBoots() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 3;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 481;
-    }
-
-    @Override
-    public int getToughness() {
-        return 3;
-    }
-
-    @Override
-    public boolean isLavaResistant() {
-        return true;
-    }
-
-    @Override
-    public float getKnockbackResistance() {
-        return 0.1f;
+        super(NETHERITE_BOOTS, meta, count, "Netherite Boots", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemNetheriteChestplate.java
+++ b/src/main/java/org/powernukkitx/item/ItemNetheriteChestplate.java
@@ -1,6 +1,18 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemNetheriteChestplate extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(8)
+            .chestplate(true)
+            .knockbackResistance(0.1f)
+            .lavaResistant(true)
+            .maxDurability(592)
+            .tier(Item.WEARABLE_TIER_NETHERITE)
+            .toughness(3)
+            .build();
+
     public ItemNetheriteChestplate() {
         this(0, 1);
     }
@@ -10,41 +22,6 @@ public class ItemNetheriteChestplate extends ItemArmor {
     }
 
     public ItemNetheriteChestplate(Integer meta, int count) {
-        super(NETHERITE_CHESTPLATE, meta, count, "Netherite Chestplate");
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_NETHERITE;
-    }
-
-    @Override
-    public boolean isChestplate() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 8;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 592;
-    }
-
-    @Override
-    public int getToughness() {
-        return 3;
-    }
-
-    @Override
-    public boolean isLavaResistant() {
-        return true;
-    }
-
-    @Override
-    public float getKnockbackResistance() {
-        return 0.1f;
+        super(NETHERITE_CHESTPLATE, meta, count, "Netherite Chestplate", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemNetheriteHelmet.java
+++ b/src/main/java/org/powernukkitx/item/ItemNetheriteHelmet.java
@@ -1,6 +1,18 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemNetheriteHelmet extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(3)
+            .helmet(true)
+            .knockbackResistance(0.1f)
+            .lavaResistant(true)
+            .maxDurability(407)
+            .tier(Item.WEARABLE_TIER_NETHERITE)
+            .toughness(3)
+            .build();
+
     public ItemNetheriteHelmet() {
         this(0, 1);
     }
@@ -10,41 +22,6 @@ public class ItemNetheriteHelmet extends ItemArmor {
     }
 
     public ItemNetheriteHelmet(Integer meta, int count) {
-        super(NETHERITE_HELMET, meta, count, "Netherite Helmet");
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_NETHERITE;
-    }
-
-    @Override
-    public boolean isHelmet() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 3;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 407;
-    }
-
-    @Override
-    public int getToughness() {
-        return 3;
-    }
-
-    @Override
-    public boolean isLavaResistant() {
-        return true;
-    }
-
-    @Override
-    public float getKnockbackResistance() {
-        return 0.1f;
+        super(NETHERITE_HELMET, meta, count, "Netherite Helmet", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemNetheriteHoe.java
+++ b/src/main/java/org/powernukkitx/item/ItemNetheriteHoe.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemNetheriteHoe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(6)
+            .hoe(true)
+            .lavaResistant(true)
+            .maxDurability(ItemTool.DURABILITY_NETHERITE)
+            .tier(ItemTool.TIER_NETHERITE)
+            .build();
 
     public ItemNetheriteHoe() {
         this(0, 1);
@@ -11,31 +20,6 @@ public class ItemNetheriteHoe extends ItemTool {
     }
 
     public ItemNetheriteHoe(Integer meta, int count) {
-        super(NETHERITE_HOE, meta, count, "Netherite Hoe");
-    }
-
-    @Override
-    public boolean isHoe() {
-        return true;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 6;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_NETHERITE;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_NETHERITE;
-    }
-
-    @Override
-    public boolean isLavaResistant() {
-        return true;
+        super(NETHERITE_HOE, meta, count, "Netherite Hoe", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemNetheriteHorseArmor.java
+++ b/src/main/java/org/powernukkitx/item/ItemNetheriteHorseArmor.java
@@ -1,12 +1,13 @@
 package org.powernukkitx.item;
 
-public class ItemNetheriteHorseArmor extends Item {
-    public ItemNetheriteHorseArmor() {
-        super(NETHERITE_HORSE_ARMOR);
-    }
+import org.powernukkitx.item.definition.ItemDefinition;
 
-    @Override
-    public int getMaxStackSize() {
-        return 1;
+public class ItemNetheriteHorseArmor extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(1)
+            .build();
+
+    public ItemNetheriteHorseArmor() {
+        super(NETHERITE_HORSE_ARMOR, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemNetheriteLeggings.java
+++ b/src/main/java/org/powernukkitx/item/ItemNetheriteLeggings.java
@@ -1,6 +1,17 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemNetheriteLeggings extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(6)
+            .knockbackResistance(0.1f)
+            .lavaResistant(true)
+            .leggings(true)
+            .maxDurability(555)
+            .tier(Item.WEARABLE_TIER_NETHERITE)
+            .toughness(3)
+            .build();
 
     public ItemNetheriteLeggings() {
         this(0, 1);
@@ -11,41 +22,6 @@ public class ItemNetheriteLeggings extends ItemArmor {
     }
 
     public ItemNetheriteLeggings(Integer meta, int count) {
-        super(NETHERITE_LEGGINGS, meta, count, "Netherite Leggings");
-    }
-
-    @Override
-    public boolean isLeggings() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_NETHERITE;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 6;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 555;
-    }
-
-    @Override
-    public int getToughness() {
-        return 3;
-    }
-
-    @Override
-    public boolean isLavaResistant() {
-        return true;
-    }
-
-    @Override
-    public float getKnockbackResistance() {
-        return 0.1f;
+        super(NETHERITE_LEGGINGS, meta, count, "Netherite Leggings", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemNetheriteNautilusArmor.java
+++ b/src/main/java/org/powernukkitx/item/ItemNetheriteNautilusArmor.java
@@ -1,10 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author Buddelbubi
  * @since 2025/12/16
  */
 public class ItemNetheriteNautilusArmor extends ItemNautilusArmor {
+    public static final ItemDefinition DEFINITION = ItemNautilusArmor.DEFINITION.toBuilder()
+            .maxDurability(ItemTool.DURABILITY_NETHERITE)
+            .tier(ItemTool.TIER_NETHERITE)
+            .build();
 
     public ItemNetheriteNautilusArmor() {
         this(0, 1);
@@ -15,17 +21,6 @@ public class ItemNetheriteNautilusArmor extends ItemNautilusArmor {
     }
 
     public ItemNetheriteNautilusArmor(Integer meta, int count) {
-        super(NETHERITE_NAUTILUS_ARMOR, meta, count, "Netherite Nautilus Armor");
+        super(NETHERITE_NAUTILUS_ARMOR, meta, count, "Netherite Nautilus Armor", DEFINITION);
     }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_NETHERITE;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_NETHERITE;
-    }
-
 }

--- a/src/main/java/org/powernukkitx/item/ItemNetheritePickaxe.java
+++ b/src/main/java/org/powernukkitx/item/ItemNetheritePickaxe.java
@@ -1,6 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemNetheritePickaxe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(6)
+            .lavaResistant(true)
+            .maxDurability(ItemTool.DURABILITY_NETHERITE)
+            .pickaxe(true)
+            .tier(ItemTool.TIER_NETHERITE)
+            .build();
+
     public ItemNetheritePickaxe() {
         this(0, 1);
     }
@@ -10,31 +20,6 @@ public class ItemNetheritePickaxe extends ItemTool {
     }
 
     public ItemNetheritePickaxe(Integer meta, int count) {
-        super(NETHERITE_PICKAXE, meta, count, "Netherite Pickaxe");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_NETHERITE;
-    }
-
-    @Override
-    public boolean isPickaxe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_NETHERITE;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 6;
-    }
-
-    @Override
-    public boolean isLavaResistant() {
-        return true;
+        super(NETHERITE_PICKAXE, meta, count, "Netherite Pickaxe", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemNetheriteShovel.java
+++ b/src/main/java/org/powernukkitx/item/ItemNetheriteShovel.java
@@ -1,6 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemNetheriteShovel extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(5)
+            .lavaResistant(true)
+            .maxDurability(ItemTool.DURABILITY_NETHERITE)
+            .shovel(true)
+            .tier(ItemTool.TIER_NETHERITE)
+            .build();
+
     public ItemNetheriteShovel() {
         this(0, 1);
     }
@@ -10,31 +20,6 @@ public class ItemNetheriteShovel extends ItemTool {
     }
 
     public ItemNetheriteShovel(Integer meta, int count) {
-        super(NETHERITE_SHOVEL, meta, count, "Netherite Shovel");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_NETHERITE;
-    }
-
-    @Override
-    public boolean isShovel() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_NETHERITE;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 5;
-    }
-
-    @Override
-    public boolean isLavaResistant() {
-        return true;
+        super(NETHERITE_SHOVEL, meta, count, "Netherite Shovel", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemNetheriteSpear.java
+++ b/src/main/java/org/powernukkitx/item/ItemNetheriteSpear.java
@@ -1,10 +1,17 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author Buddelbubi
  * @since 2025/12/15
  */
 public class ItemNetheriteSpear extends ItemSpear {
+    public static final ItemDefinition DEFINITION = ItemSpear.DEFINITION.toBuilder()
+            .attackDamage(6)
+            .maxDurability(ItemTool.DURABILITY_NETHERITE)
+            .tier(ItemTool.TIER_NETHERITE)
+            .build();
 
     public ItemNetheriteSpear() {
         this(0, 1);
@@ -15,21 +22,6 @@ public class ItemNetheriteSpear extends ItemSpear {
     }
 
     public ItemNetheriteSpear(Integer meta, int count) {
-        super(NETHERITE_SPEAR, meta, count, "Netherite Spear");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_NETHERITE;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_NETHERITE;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 6;
+        super(NETHERITE_SPEAR, meta, count, "Netherite Spear", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemNetheriteSword.java
+++ b/src/main/java/org/powernukkitx/item/ItemNetheriteSword.java
@@ -1,6 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemNetheriteSword extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(8)
+            .lavaResistant(true)
+            .maxDurability(ItemTool.DURABILITY_NETHERITE)
+            .sword(true)
+            .tier(ItemTool.TIER_NETHERITE)
+            .build();
+
     public ItemNetheriteSword() {
         this(0, 1);
     }
@@ -10,31 +20,6 @@ public class ItemNetheriteSword extends ItemTool {
     }
 
     public ItemNetheriteSword(Integer meta, int count) {
-        super(NETHERITE_SWORD, meta, count, "Netherite Sword");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_NETHERITE;
-    }
-
-    @Override
-    public boolean isSword() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_NETHERITE;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 8;
-    }
-
-    @Override
-    public boolean isLavaResistant() {
-        return true;
+        super(NETHERITE_SWORD, meta, count, "Netherite Sword", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemOminousBottle.java
+++ b/src/main/java/org/powernukkitx/item/ItemOminousBottle.java
@@ -4,6 +4,7 @@ import org.powernukkitx.Player;
 import org.powernukkitx.entity.effect.Effect;
 import org.powernukkitx.entity.effect.EffectType;
 import org.powernukkitx.event.player.PlayerItemConsumeEvent;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.vibration.VibrationEvent;
 import org.powernukkitx.level.vibration.VibrationType;
 import org.powernukkitx.math.Vector3;
@@ -11,6 +12,10 @@ import org.cloudburstmc.protocol.bedrock.data.SoundEvent;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemUseMethod;
 
 public class ItemOminousBottle extends Item {
+    public static final ItemDefinition DEFINITION = Item.DEFAULT_DEFINITION.toBuilder()
+            .consumable(true)
+            .usingTicks(31)
+            .build();
 
     private static final String TAG_OMINOUS_BOTTLE_AMPLIFIER = "OminousBottleAmplifier";
     private static final int BAD_OMEN_DURATION = 100 * 60 * 20;
@@ -24,22 +29,12 @@ public class ItemOminousBottle extends Item {
     }
 
     public ItemOminousBottle(Integer meta, int count) {
-        super(OMINOUS_BOTTLE, meta, count);
+        super(OMINOUS_BOTTLE, meta, count, DEFINITION);
     }
 
     @Override
     public boolean onClickAir(Player player, Vector3 directionVector) {
         return true;
-    }
-
-    @Override
-    public boolean isConsumable() {
-        return true;
-    }
-
-    @Override
-    public int getUsingTicks() {
-        return 31;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemPainting.java
+++ b/src/main/java/org/powernukkitx/item/ItemPainting.java
@@ -4,6 +4,7 @@ import org.powernukkitx.Player;
 import org.powernukkitx.block.Block;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.item.EntityPainting;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.level.vibration.VibrationEvent;
@@ -23,6 +24,10 @@ import java.util.concurrent.ThreadLocalRandom;
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemPainting extends Item {
+    public static final ItemDefinition DEFINITION = Item.DEFAULT_DEFINITION.toBuilder()
+            .canBeActivated(true)
+            .build();
+
     private static final int[] DIRECTION = {2, 3, 4, 5};
     private static final int[] RIGHT = {4, 5, 3, 2};
     private static final double OFFSET = 0.53125;
@@ -36,12 +41,7 @@ public class ItemPainting extends Item {
     }
 
     public ItemPainting(Integer meta, int count) {
-        super(PAINTING, 0, count, "Painting");
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
+        super(PAINTING, 0, count, "Painting", DEFINITION);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemPoisonousPotato.java
+++ b/src/main/java/org/powernukkitx/item/ItemPoisonousPotato.java
@@ -5,8 +5,13 @@ import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockID;
 import org.powernukkitx.entity.effect.Effect;
 import org.powernukkitx.entity.effect.EffectType;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 public class ItemPoisonousPotato extends ItemPotato {
+    public static final ItemDefinition DEFINITION = ItemPotato.DEFINITION.toBuilder()
+            .nutrition(2)
+            .saturation(1.2f)
+            .build();
 
     public ItemPoisonousPotato() {
         this(0, 1);
@@ -17,7 +22,7 @@ public class ItemPoisonousPotato extends ItemPotato {
     }
 
     public ItemPoisonousPotato(Integer meta, int count) {
-        super(POISONOUS_POTATO, meta, count, "Poisonous Potato");
+        super(POISONOUS_POTATO, meta, count, "Poisonous Potato", DEFINITION);
         this.block = Block.get(BlockID.POTATOES);
     }
 
@@ -27,15 +32,5 @@ public class ItemPoisonousPotato extends ItemPotato {
             player.addEffect(Effect.get(EffectType.POISON).setDuration(80));
         }
         return super.onEaten(player);
-    }
-
-    @Override
-    public int getNutrition() {
-        return 2;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 1.2F;
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemPorkchop.java
+++ b/src/main/java/org/powernukkitx/item/ItemPorkchop.java
@@ -1,6 +1,13 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemPorkchop extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(3)
+            .saturation(1.8f)
+            .build();
+
     public ItemPorkchop() {
         this(0, 1);
     }
@@ -10,16 +17,6 @@ public class ItemPorkchop extends ItemFood {
     }
 
     public ItemPorkchop(Integer meta, int count) {
-        super(PORKCHOP, meta, count, "Raw Porkchop");
-    }
-
-    @Override
-    public int getNutrition() {
-        return 3;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 1.8F;
+        super(PORKCHOP, meta, count, "Raw Porkchop", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemPotato.java
+++ b/src/main/java/org/powernukkitx/item/ItemPotato.java
@@ -2,32 +2,39 @@ package org.powernukkitx.item;
 
 import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockID;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemPotato extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(1)
+            .saturation(0.6f)
+            .build();
 
     public ItemPotato() {
-        this(POTATO, 0, 1, "Potato");
+        this(POTATO, 0, 1, "Potato", DEFINITION);
+    }
+
+    public ItemPotato(ItemDefinition definition) {
+        this(POTATO, 0, 1, "Potato", definition);
     }
 
     public ItemPotato(Integer meta) {
-        this(POTATO, meta, 1,"Potato");
+        this(POTATO, meta, 1, "Potato", DEFINITION);
+    }
+
+    public ItemPotato(Integer meta, ItemDefinition definition) {
+        this(POTATO, meta, 1, "Potato", definition);
     }
 
     public ItemPotato(String id, Integer meta, int count, String name) {
-        super(id, meta, count, name);
+        this(id, meta, count, name, DEFINITION);
+    }
+
+    public ItemPotato(String id, Integer meta, int count, String name, ItemDefinition definition) {
+        super(id, meta, count, name, definition);
         this.block = Block.get(BlockID.POTATOES);
-    }
-
-    @Override
-    public int getNutrition() {
-        return 1;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 0.6F;
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemPotion.java
+++ b/src/main/java/org/powernukkitx/item/ItemPotion.java
@@ -4,6 +4,7 @@ import org.powernukkitx.Player;
 import org.powernukkitx.entity.effect.PotionApplicationMode;
 import org.powernukkitx.entity.effect.PotionType;
 import org.powernukkitx.event.player.PlayerItemConsumeEvent;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.vibration.VibrationEvent;
 import org.powernukkitx.level.vibration.VibrationType;
 import org.powernukkitx.math.Vector3;
@@ -13,6 +14,11 @@ import org.cloudburstmc.protocol.bedrock.data.inventory.ItemUseMethod;
 import javax.annotation.Nullable;
 
 public class ItemPotion extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .consumable(true)
+            .maxStackSize(1)
+            .usingTicks(31)
+            .build();
 
     public ItemPotion() {
         this(0, 1);
@@ -23,7 +29,7 @@ public class ItemPotion extends Item {
     }
 
     public ItemPotion(Integer meta, int count) {
-        super(POTION, meta, count, "Potion");
+        super(POTION, meta, count, "Potion", DEFINITION);
         updateName();
     }
 
@@ -76,23 +82,8 @@ public class ItemPotion extends Item {
     }
 
     @Override
-    public int getMaxStackSize() {
-        return 1;
-    }
-
-    @Override
-    public boolean isConsumable() {
-        return true;
-    }
-
-    @Override
     public boolean onClickAir(Player player, Vector3 directionVector) {
         return true;
-    }
-
-    @Override
-    public int getUsingTicks() {
-        return 31;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemPotterySherd.java
+++ b/src/main/java/org/powernukkitx/item/ItemPotterySherd.java
@@ -1,12 +1,24 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 
 public abstract class ItemPotterySherd extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder().build();
+
     public ItemPotterySherd(String id) {
-        super(id);
+        this(id, DEFINITION);
+    }
+
+    public ItemPotterySherd(String id, ItemDefinition definition) {
+        super(id, definition);
     }
 
     public ItemPotterySherd(String id, int count) {
-        super(id, 0, count);
+        this(id, count, DEFINITION);
+    }
+
+    public ItemPotterySherd(String id, int count, ItemDefinition definition) {
+        super(id, 0, count, definition);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemPufferfish.java
+++ b/src/main/java/org/powernukkitx/item/ItemPufferfish.java
@@ -3,12 +3,18 @@ package org.powernukkitx.item;
 import org.powernukkitx.Player;
 import org.powernukkitx.entity.effect.Effect;
 import org.powernukkitx.entity.effect.EffectType;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 /**
  * @author Snake1999
  * @since 2016/1/14
  */
 public class ItemPufferfish extends ItemFish {
+    public static final ItemDefinition DEFINITION = ItemFish.DEFINITION.toBuilder()
+            .nutrition(1)
+            .saturation(0.2f)
+            .build();
+
     public ItemPufferfish() {
         this(0, 1);
     }
@@ -18,17 +24,7 @@ public class ItemPufferfish extends ItemFish {
     }
 
     public ItemPufferfish(Integer meta, int count) {
-        super(PUFFERFISH, meta, count);
-    }
-
-    @Override
-    public int getNutrition() {
-        return 1;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 0.2F;
+        super(PUFFERFISH, meta, count, DEFINITION);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemPumpkinPie.java
+++ b/src/main/java/org/powernukkitx/item/ItemPumpkinPie.java
@@ -1,9 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemPumpkinPie extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(8)
+            .saturation(4.8f)
+            .build();
 
     public ItemPumpkinPie() {
         this(0, 1);
@@ -14,16 +20,6 @@ public class ItemPumpkinPie extends ItemFood {
     }
 
     public ItemPumpkinPie(Integer meta, int count) {
-        super(PUMPKIN_PIE, meta, count, "Pumpkin Pie");
-    }
-
-    @Override
-    public int getNutrition() {
-        return 8;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 4.8F;
+        super(PUMPKIN_PIE, meta, count, "Pumpkin Pie", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemRabbit.java
+++ b/src/main/java/org/powernukkitx/item/ItemRabbit.java
@@ -1,6 +1,13 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemRabbit extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(3)
+            .saturation(1.8f)
+            .build();
+
     public ItemRabbit() {
         this(0, 1);
     }
@@ -10,16 +17,6 @@ public class ItemRabbit extends ItemFood {
     }
 
     public ItemRabbit(Integer meta, int count) {
-        super(RABBIT, meta, count, "Raw Rabbit");
-    }
-
-    @Override
-    public int getNutrition() {
-        return 3;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 1.8F;
+        super(RABBIT, meta, count, "Raw Rabbit", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemRabbitStew.java
+++ b/src/main/java/org/powernukkitx/item/ItemRabbitStew.java
@@ -1,12 +1,18 @@
 package org.powernukkitx.item;
 
 import org.powernukkitx.Player;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 /**
  * @author Snake1999
  * @since 2016/1/14
  */
 public class ItemRabbitStew extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .maxStackSize(1)
+            .nutrition(10)
+            .saturation(12f)
+            .build();
 
     public ItemRabbitStew() {
         this(0, 1);
@@ -17,22 +23,7 @@ public class ItemRabbitStew extends ItemFood {
     }
 
     public ItemRabbitStew(Integer meta, int count) {
-        super(RABBIT_STEW, meta, count, "Rabbit Stew");
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
-    }
-
-    @Override
-    public int getNutrition() {
-        return 10;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 12F;
+        super(RABBIT_STEW, meta, count, "Rabbit Stew", DEFINITION);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemRottenFlesh.java
+++ b/src/main/java/org/powernukkitx/item/ItemRottenFlesh.java
@@ -3,12 +3,17 @@ package org.powernukkitx.item;
 import org.powernukkitx.Player;
 import org.powernukkitx.entity.effect.Effect;
 import org.powernukkitx.entity.effect.EffectType;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 /**
  * @author Snake1999
  * @since 2016/1/14
  */
 public class ItemRottenFlesh extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(4)
+            .saturation(0.8f)
+            .build();
 
     public ItemRottenFlesh() {
         this(0, 1);
@@ -19,17 +24,7 @@ public class ItemRottenFlesh extends ItemFood {
     }
 
     public ItemRottenFlesh(Integer meta, int count) {
-        super(ROTTEN_FLESH, meta, count, "Rotten Flesh");
-    }
-
-    @Override
-    public int getNutrition() {
-        return 4;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 0.8F;
+        super(ROTTEN_FLESH, meta, count, "Rotten Flesh", DEFINITION);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemSaddle.java
+++ b/src/main/java/org/powernukkitx/item/ItemSaddle.java
@@ -1,6 +1,12 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemSaddle extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(1)
+            .build();
+
     public ItemSaddle() {
         this(0, 1);
     }
@@ -10,11 +16,6 @@ public class ItemSaddle extends Item {
     }
 
     public ItemSaddle(Integer meta, int count) {
-        super(SADDLE, meta, count, "Saddle");
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
+        super(SADDLE, meta, count, "Saddle", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemSalmon.java
+++ b/src/main/java/org/powernukkitx/item/ItemSalmon.java
@@ -1,25 +1,30 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author Snake1999
  * @since 2016/1/14
  */
 public class ItemSalmon extends ItemFish {
+    public static final ItemDefinition DEFINITION = ItemFish.DEFINITION.toBuilder()
+            .nutrition(2)
+            .saturation(0.4f)
+            .build();
+
     public ItemSalmon() {
-        super(SALMON, 0, 1);
+        this(SALMON, 0, 1, DEFINITION);
+    }
+
+    public ItemSalmon(ItemDefinition definition) {
+        this(SALMON, 0, 1, definition);
     }
 
     protected ItemSalmon(String id, Integer meta, int count) {
-        super(id, meta, count);
+        this(id, meta, count, DEFINITION);
     }
 
-    @Override
-    public int getNutrition() {
-        return 2;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 0.4F;
+    protected ItemSalmon(String id, Integer meta, int count, ItemDefinition definition) {
+        super(id, meta, count, definition);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemScrapNetherite.java
+++ b/src/main/java/org/powernukkitx/item/ItemScrapNetherite.java
@@ -1,8 +1,11 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
 
 public class ItemScrapNetherite extends Item {
-
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .lavaResistant(true)
+            .build();
 
     public ItemScrapNetherite() {
         this(0, 1);
@@ -13,11 +16,6 @@ public class ItemScrapNetherite extends Item {
     }
 
     public ItemScrapNetherite(Integer meta, int count) {
-        super(NETHERITE_SCRAP, 0, count, "Netherite Scrap");
-    }
-
-    @Override
-    public boolean isLavaResistant() {
-        return true;
+        super(NETHERITE_SCRAP, 0, count, "Netherite Scrap", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemShears.java
+++ b/src/main/java/org/powernukkitx/item/ItemShears.java
@@ -1,9 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemShears extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .maxDurability(ItemTool.DURABILITY_SHEARS)
+            .shears(true)
+            .build();
 
     public ItemShears() {
         this(0, 1);
@@ -14,16 +20,6 @@ public class ItemShears extends ItemTool {
     }
 
     public ItemShears(Integer meta, int count) {
-        super(SHEARS, meta, count, "Shears");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_SHEARS;
-    }
-
-    @Override
-    public boolean isShears() {
-        return true;
+        super(SHEARS, meta, count, "Shears", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemShield.java
+++ b/src/main/java/org/powernukkitx/item/ItemShield.java
@@ -1,11 +1,18 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.utils.DyeColor;
 import org.jetbrains.annotations.Nullable;
 
 
 public class ItemShield extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .maxDurability(DURABILITY_SHIELD)
+            .maxStackSize(1)
+            .shield(true)
+            .build();
+
     public ItemShield() {
         this(0, 1);
     }
@@ -15,7 +22,7 @@ public class ItemShield extends ItemTool {
     }
 
     public ItemShield(Integer meta, int count) {
-        super(SHIELD, meta, count, "Shield");
+        super(SHIELD, meta, count, "Shield", DEFINITION);
     }
 
     /**
@@ -27,7 +34,7 @@ public class ItemShield extends ItemTool {
      * @param name  the name
      */
     protected ItemShield(String id, Integer meta, int count, String name) {
-        super(id, meta, count, name);
+        super(id, meta, count, name, DEFINITION);
     }
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
@@ -67,16 +74,6 @@ public class ItemShield extends ItemTool {
         }
         tag.putInt("Base", banner.getBaseColor());
         this.setNbt(tag);
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return DURABILITY_SHIELD;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemSign.java
+++ b/src/main/java/org/powernukkitx/item/ItemSign.java
@@ -2,13 +2,22 @@ package org.powernukkitx.item;
 
 import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockID;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 /**
  * Make sure to keep the mapping between the sign and standing_sign blocks correct: the item is specified via this.block and the block via toItem.
  */
 public abstract class ItemSign extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(16)
+            .build();
+
     protected ItemSign(String id) {
-        super(id);
+        this(id, DEFINITION);
+    }
+
+    protected ItemSign(String id, ItemDefinition definition) {
+        super(id, definition);
         if (id.equals(DARK_OAK_SIGN)) {
             this.block = Block.get(BlockID.DARKOAK_STANDING_SIGN);
         } else if (id.equals(OAK_SIGN)) {
@@ -16,10 +25,5 @@ public abstract class ItemSign extends Item {
         } else {
             this.block = Block.get(id.replace("_sign", "_standing_sign"));
         }
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 16;
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemSnowball.java
+++ b/src/main/java/org/powernukkitx/item/ItemSnowball.java
@@ -7,6 +7,7 @@ import org.powernukkitx.Player;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityQueryOptions;
 import org.powernukkitx.entity.passive.EntityHappyGhast;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.math.AxisAlignedBB;
 import org.powernukkitx.math.Vector3;
@@ -15,6 +16,9 @@ import org.powernukkitx.math.Vector3;
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemSnowball extends ProjectileItem {
+    public static final ItemDefinition DEFINITION = ProjectileItem.DEFINITION.toBuilder()
+            .maxStackSize(16)
+            .build();
 
     public ItemSnowball() {
         this(0, 1);
@@ -25,12 +29,7 @@ public class ItemSnowball extends ProjectileItem {
     }
 
     public ItemSnowball(Integer meta, int count) {
-        super(SNOWBALL, 0, count, "Snowball");
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 16;
+        super(SNOWBALL, 0, count, "Snowball", DEFINITION);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemSpawnEgg.java
+++ b/src/main/java/org/powernukkitx/item/ItemSpawnEgg.java
@@ -5,6 +5,7 @@ import org.powernukkitx.block.Block;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.event.entity.CreatureSpawnEvent;
 import org.powernukkitx.event.entity.CreatureSpawnEvent.SpawnReason;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.level.Location;
 import org.powernukkitx.level.format.IChunk;
@@ -23,22 +24,41 @@ import java.util.concurrent.ThreadLocalRandom;
  * @author MagicDroidX (Nukkit Project)
  */
 public class ItemSpawnEgg extends Item implements SpawnEggPickable {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .canBeActivated(true)
+            .build();
 
     public ItemSpawnEgg() {
-        this(0, 1);
+        this(0, 1, DEFINITION);
+    }
+
+    public ItemSpawnEgg(ItemDefinition definition) {
+        this(0, 1, definition);
     }
 
     public ItemSpawnEgg(Integer meta) {
-        this(meta, 1);
+        this(meta, 1, DEFINITION);
+    }
+
+    public ItemSpawnEgg(Integer meta, ItemDefinition definition) {
+        this(meta, 1, definition);
     }
 
     public ItemSpawnEgg(Integer meta, int count) {
-        super(SPAWN_EGG, meta, count, "Spawn Egg");
+        this(meta, count, DEFINITION);
+    }
+
+    public ItemSpawnEgg(Integer meta, int count, ItemDefinition definition) {
+        super(SPAWN_EGG, meta, count, "Spawn Egg", definition);
         updateName();
     }
 
     public ItemSpawnEgg(String id) {
-        super(id, 0, 1);
+        this(id, DEFINITION);
+    }
+
+    public ItemSpawnEgg(String id, ItemDefinition definition) {
+        super(id, 0, 1, definition);
     }
 
     protected CompoundTag entityNBT;
@@ -56,11 +76,6 @@ public class ItemSpawnEgg extends Item implements SpawnEggPickable {
         } else {
             name = entityName + " Spawn Egg";
         }
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemSpear.java
+++ b/src/main/java/org/powernukkitx/item/ItemSpear.java
@@ -6,6 +6,7 @@ import org.powernukkitx.entity.EntityLiving;
 import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.event.entity.EntityDamageEvent;
 import org.powernukkitx.event.player.PlayerSpearStabEvent;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.level.Location;
@@ -21,18 +22,21 @@ import org.jetbrains.annotations.Nullable;
  * @since 16/31/2025
  */
 public abstract class ItemSpear extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .spear(true)
+            .usingTicks(72000)
+            .build();
 
     public float MINIMUM_SPEED = 0.13f;
     public int MINIMUM_LUNGE_FOOD = 6;
     public int BASE_LUNGE_EXHAUST = 4;
 
     public ItemSpear(String id, Integer meta, int count, String name) {
-        super(id, meta, count, name);
+        this(id, meta, count, name, DEFINITION);
     }
 
-    @Override
-    public boolean isSpear() {
-        return true;
+    public ItemSpear(String id, Integer meta, int count, String name, ItemDefinition definition) {
+        super(id, meta, count, name, definition);
     }
 
     public void onSpearStab(Player player, float movementSpeed) {
@@ -150,11 +154,6 @@ public abstract class ItemSpear extends ItemTool {
             return false;
         }
         return enchantmentLevel > 0;
-    }
-
-    @Override
-    public int getUsingTicks() {
-        return 72000;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemSpiderEye.java
+++ b/src/main/java/org/powernukkitx/item/ItemSpiderEye.java
@@ -3,12 +3,17 @@ package org.powernukkitx.item;
 import org.powernukkitx.Player;
 import org.powernukkitx.entity.effect.Effect;
 import org.powernukkitx.entity.effect.EffectType;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 /**
  * @author Snake1999
  * @since 2016/1/14
  */
 public class ItemSpiderEye extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(2)
+            .saturation(3.2f)
+            .build();
 
     public ItemSpiderEye() {
         this(0, 1);
@@ -19,17 +24,7 @@ public class ItemSpiderEye extends ItemFood {
     }
 
     public ItemSpiderEye(Integer meta, int count) {
-        super(SPIDER_EYE, meta, count, "Spider Eye");
-    }
-
-    @Override
-    public int getNutrition() {
-        return 2;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 3.2F;
+        super(SPIDER_EYE, meta, count, "Spider Eye", DEFINITION);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemSplashPotion.java
+++ b/src/main/java/org/powernukkitx/item/ItemSplashPotion.java
@@ -1,9 +1,15 @@
 package org.powernukkitx.item;
 
 import org.powernukkitx.entity.effect.PotionType;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.nbt.tag.CompoundTag;
 
 public class ItemSplashPotion extends ProjectileItem {
+    public static final ItemDefinition DEFINITION = ProjectileItem.DEFINITION.toBuilder()
+            .canBeActivated(true)
+            .maxStackSize(1)
+            .build();
+
     public ItemSplashPotion() {
         this(0, 1);
     }
@@ -13,7 +19,7 @@ public class ItemSplashPotion extends ProjectileItem {
     }
 
     public ItemSplashPotion(Integer meta, int count) {
-        super(SPLASH_POTION, meta, count, "Splash Potion");
+        super(SPLASH_POTION, meta, count, "Splash Potion", DEFINITION);
         updateName();
     }
 
@@ -30,16 +36,6 @@ public class ItemSplashPotion extends ProjectileItem {
         } else {
             name = ItemPotion.buildName(potion, "Splash Potion", true);
         }
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemSpyglass.java
+++ b/src/main/java/org/powernukkitx/item/ItemSpyglass.java
@@ -1,11 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author LT_Name
  */
 
 public class ItemSpyglass extends Item {
-
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(1)
+            .build();
 
     public ItemSpyglass() {
         this(0, 1);
@@ -16,11 +20,6 @@ public class ItemSpyglass extends Item {
     }
 
     public ItemSpyglass(Integer meta, int count) {
-        super(SPYGLASS, meta, count, "Spyglass");
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
+        super(SPYGLASS, meta, count, "Spyglass", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemStoneAxe.java
+++ b/src/main/java/org/powernukkitx/item/ItemStoneAxe.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemStoneAxe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(4)
+            .axe(true)
+            .canBreakShield(true)
+            .maxDurability(ItemTool.DURABILITY_STONE)
+            .tier(ItemTool.TIER_STONE)
+            .build();
 
     public ItemStoneAxe() {
         this(0, 1);
@@ -11,31 +20,6 @@ public class ItemStoneAxe extends ItemTool {
     }
 
     public ItemStoneAxe(Integer meta, int count) {
-        super(STONE_AXE, meta, count, "Stone Axe");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_STONE;
-    }
-
-    @Override
-    public boolean isAxe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_STONE;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 4;
-    }
-
-    @Override
-    public boolean canBreakShield() {
-        return true;
+        super(STONE_AXE, meta, count, "Stone Axe", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemStoneHoe.java
+++ b/src/main/java/org/powernukkitx/item/ItemStoneHoe.java
@@ -1,6 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemStoneHoe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .hoe(true)
+            .maxDurability(ItemTool.DURABILITY_STONE)
+            .tier(ItemTool.TIER_STONE)
+            .build();
+
     public ItemStoneHoe() {
         this(0, 1);
     }
@@ -10,21 +18,6 @@ public class ItemStoneHoe extends ItemTool {
     }
 
     public ItemStoneHoe(Integer meta, int count) {
-        super(STONE_HOE, meta, count, "Stone Hoe");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_STONE;
-    }
-
-    @Override
-    public boolean isHoe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_STONE;
+        super(STONE_HOE, meta, count, "Stone Hoe", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemStonePickaxe.java
+++ b/src/main/java/org/powernukkitx/item/ItemStonePickaxe.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemStonePickaxe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(3)
+            .maxDurability(ItemTool.DURABILITY_STONE)
+            .pickaxe(true)
+            .tier(ItemTool.TIER_STONE)
+            .build();
+
     public ItemStonePickaxe() {
         this(0, 1);
     }
@@ -10,26 +19,6 @@ public class ItemStonePickaxe extends ItemTool {
     }
 
     public ItemStonePickaxe(Integer meta, int count) {
-        super(STONE_PICKAXE, meta, count, "Stone Pickaxe");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_STONE;
-    }
-
-    @Override
-    public boolean isPickaxe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_STONE;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 3;
+        super(STONE_PICKAXE, meta, count, "Stone Pickaxe", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemStoneShovel.java
+++ b/src/main/java/org/powernukkitx/item/ItemStoneShovel.java
@@ -1,6 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemStoneShovel extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(2)
+            .maxDurability(ItemTool.DURABILITY_STONE)
+            .shovel(true)
+            .tier(ItemTool.TIER_STONE)
+            .build();
 
     public ItemStoneShovel() {
         this(0, 1);
@@ -11,26 +19,6 @@ public class ItemStoneShovel extends ItemTool {
     }
 
     public ItemStoneShovel(Integer meta, int count) {
-        super(STONE_SHOVEL, meta, count, "Stone Shovel");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_STONE;
-    }
-
-    @Override
-    public boolean isShovel() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_STONE;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 2;
+        super(STONE_SHOVEL, meta, count, "Stone Shovel", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemStoneSpear.java
+++ b/src/main/java/org/powernukkitx/item/ItemStoneSpear.java
@@ -1,10 +1,17 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author Buddelbubi
  * @since 2025/12/15
  */
 public class ItemStoneSpear extends ItemSpear {
+    public static final ItemDefinition DEFINITION = ItemSpear.DEFINITION.toBuilder()
+            .attackDamage(3)
+            .maxDurability(ItemTool.DURABILITY_STONE)
+            .tier(ItemTool.TIER_STONE)
+            .build();
 
     public ItemStoneSpear() {
         this(0, 1);
@@ -15,21 +22,6 @@ public class ItemStoneSpear extends ItemSpear {
     }
 
     public ItemStoneSpear(Integer meta, int count) {
-        super(STONE_SPEAR, meta, count, "Stone Spear");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_STONE;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_STONE;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 3;
+        super(STONE_SPEAR, meta, count, "Stone Spear", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemStoneSword.java
+++ b/src/main/java/org/powernukkitx/item/ItemStoneSword.java
@@ -1,6 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemStoneSword extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(5)
+            .maxDurability(ItemTool.DURABILITY_STONE)
+            .sword(true)
+            .tier(ItemTool.TIER_STONE)
+            .build();
 
     public ItemStoneSword() {
         this(0, 1);
@@ -11,26 +19,6 @@ public class ItemStoneSword extends ItemTool {
     }
 
     public ItemStoneSword(Integer meta, int count) {
-        super(STONE_SWORD, meta, count, "Stone Sword");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_STONE;
-    }
-
-    @Override
-    public boolean isSword() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_STONE;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 5;
+        super(STONE_SWORD, meta, count, "Stone Sword", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemSuspiciousStew.java
+++ b/src/main/java/org/powernukkitx/item/ItemSuspiciousStew.java
@@ -3,34 +3,25 @@ package org.powernukkitx.item;
 import org.powernukkitx.Player;
 import org.powernukkitx.entity.effect.Effect;
 import org.powernukkitx.entity.effect.EffectType;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 public class ItemSuspiciousStew extends ItemFood {
-    
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .maxStackSize(1)
+            .nutrition(6)
+            .saturation(7.2f)
+            .build();
+
     public ItemSuspiciousStew() {
         this(0, 1);
     }
-    
+
     public ItemSuspiciousStew(Integer meta) {
         this(meta, 1);
     }
-    
+
     public ItemSuspiciousStew(Integer meta, int count) {
-        super(SUSPICIOUS_STEW, meta, count, "Suspicious Stew");
-    }
-    
-    @Override
-    public int getMaxStackSize() {
-        return 1;
-    }
-
-    @Override
-    public int getNutrition() {
-        return 6;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 7.2F;
+        super(SUSPICIOUS_STEW, meta, count, "Suspicious Stew", DEFINITION);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemSweetBerries.java
+++ b/src/main/java/org/powernukkitx/item/ItemSweetBerries.java
@@ -1,8 +1,13 @@
 package org.powernukkitx.item;
 
 import org.powernukkitx.block.BlockSweetBerryBush;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 public class ItemSweetBerries extends ItemFood {
+    public static final ItemDefinition DEFINITION = FOOD.toBuilder()
+            .nutrition(2)
+            .saturation(0.4f)
+            .build();
 
     public ItemSweetBerries() {
         this(0, 1);
@@ -13,17 +18,7 @@ public class ItemSweetBerries extends ItemFood {
     }
 
     public ItemSweetBerries(Integer meta, int count) {
-        super(SWEET_BERRIES, meta, count, "Sweet Berries");
+        super(SWEET_BERRIES, meta, count, "Sweet Berries", DEFINITION);
         this.block = new BlockSweetBerryBush();
-    }
-
-    @Override
-    public int getNutrition() {
-        return 2;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 0.4F;
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemTntMinecart.java
+++ b/src/main/java/org/powernukkitx/item/ItemTntMinecart.java
@@ -5,6 +5,7 @@ import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockRail;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.item.EntityTntMinecart;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.math.BlockFace;
 import org.powernukkitx.nbt.tag.CompoundTag;
@@ -14,6 +15,10 @@ import org.powernukkitx.nbt.tag.ListTag;
 import org.powernukkitx.utils.Rail;
 
 public class ItemTntMinecart extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .canBeActivated(true)
+            .maxStackSize(1)
+            .build();
 
     public ItemTntMinecart() {
         this(0, 1);
@@ -24,12 +29,7 @@ public class ItemTntMinecart extends Item {
     }
 
     public ItemTntMinecart(Integer meta, int count) {
-        super(TNT_MINECART, meta, count, "Minecart with TNT");
-    }
-
-    @Override
-    public boolean canBeActivated() {
-        return true;
+        super(TNT_MINECART, meta, count, "Minecart with TNT", DEFINITION);
     }
 
     @Override
@@ -69,10 +69,5 @@ public class ItemTntMinecart extends Item {
             return true;
         }
         return false;
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemTool.java
+++ b/src/main/java/org/powernukkitx/item/ItemTool.java
@@ -1,5 +1,6 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.jetbrains.annotations.NotNull;
 
 import static org.powernukkitx.utils.Utils.dynamic;
@@ -8,6 +9,12 @@ import static org.powernukkitx.utils.Utils.dynamic;
  * @author MagicDroidX (Nukkit Project)
  */
 public abstract class ItemTool extends Item {
+    public static final ItemDefinition TOOL = DEFAULT_DEFINITION.toBuilder()
+            .tool(true)
+            .canTakeDamage(true)
+            .maxStackSize(1)
+            .build();
+
     public static final int TIER_WOODEN = 1;
     public static final int TIER_GOLD = 2;
     public static final int TIER_STONE = 3;
@@ -81,34 +88,35 @@ public abstract class ItemTool extends Item {
     }
 
     public ItemTool(String id) {
-        this(id, 0, 1, null);
+        this(id, 0, 1, (String) null, TOOL);
+    }
+
+    public ItemTool(String id, ItemDefinition definition) {
+        this(id, 0, 1, (String) null, definition);
     }
 
     public ItemTool(String id, Integer meta) {
-        this(id, meta, 1, null);
+        this(id, meta, 1, (String) null, TOOL);
+    }
+
+    public ItemTool(String id, Integer meta, ItemDefinition definition) {
+        this(id, meta, 1, (String) null, definition);
     }
 
     public ItemTool(String id, Integer meta, int count) {
-        this(id, meta, count, null);
+        this(id, meta, count, (String) null, TOOL);
+    }
+
+    public ItemTool(String id, Integer meta, int count, ItemDefinition definition) {
+        this(id, meta, count, (String) null, definition);
     }
 
     public ItemTool(String id, Integer meta, int count, String name) {
-        super(id, meta, count, name);
+        this(id, meta, count, name, TOOL);
     }
 
-    @Override
-    public boolean isTool() {
-        return true;
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
-    }
-
-    @Override
-    public boolean canTakeDamage() {
-        return true;
+    public ItemTool(String id, Integer meta, int count, String name, ItemDefinition definition) {
+        super(id, meta, count, name, definition);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemTotemOfUndying.java
+++ b/src/main/java/org/powernukkitx/item/ItemTotemOfUndying.java
@@ -1,12 +1,13 @@
 package org.powernukkitx.item;
 
-public class ItemTotemOfUndying extends Item {
-    public ItemTotemOfUndying() {
-        super(TOTEM_OF_UNDYING);
-    }
+import org.powernukkitx.item.definition.ItemDefinition;
 
-    @Override
-    public int getMaxStackSize() {
-        return 1;
+public class ItemTotemOfUndying extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(1)
+            .build();
+
+    public ItemTotemOfUndying() {
+        super(TOTEM_OF_UNDYING, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemTrident.java
+++ b/src/main/java/org/powernukkitx/item/ItemTrident.java
@@ -6,6 +6,7 @@ import org.powernukkitx.entity.projectile.EntityProjectile;
 import org.powernukkitx.entity.projectile.EntityThrownTrident;
 import org.powernukkitx.event.entity.EntityShootBowEvent;
 import org.powernukkitx.event.entity.ProjectileLaunchEvent;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.math.Vector3;
@@ -18,6 +19,12 @@ import org.powernukkitx.nbt.tag.ListTag;
  * @author PetteriM1
  */
 public class ItemTrident extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(9)
+            .maxDurability(ItemTool.DURABILITY_TRIDENT)
+            .trident(true)
+            .usingTicks(72000)
+            .build();
 
     public ItemTrident() {
         this(0, 1);
@@ -28,27 +35,12 @@ public class ItemTrident extends ItemTool {
     }
 
     public ItemTrident(Integer meta, int count) {
-        super(TRIDENT, meta, count, "Trident");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_TRIDENT;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 9;
+        super(TRIDENT, meta, count, "Trident", DEFINITION);
     }
 
     @Override
     public boolean onClickAir(Player player, Vector3 directionVector) {
         return true;
-    }
-
-    @Override
-    public int getUsingTicks() {
-        return 72000;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemTropicalFish.java
+++ b/src/main/java/org/powernukkitx/item/ItemTropicalFish.java
@@ -1,17 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemTropicalFish extends ItemFish {
+    public static final ItemDefinition DEFINITION = ItemFish.DEFINITION.toBuilder()
+            .nutrition(1)
+            .saturation(0.2f)
+            .build();
+
     public ItemTropicalFish() {
-        super(TROPICAL_FISH, 0, 1);
-    }
-
-    @Override
-    public int getNutrition() {
-        return 1;
-    }
-
-    @Override
-    public float getSaturation() {
-        return 0.2F;
+        super(TROPICAL_FISH, 0, 1, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemTurtleHelmet.java
+++ b/src/main/java/org/powernukkitx/item/ItemTurtleHelmet.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemTurtleHelmet extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(2)
+            .helmet(true)
+            .maxDurability(276)
+            .tier(Item.WEARABLE_TIER_OTHER)
+            .toughness(2)
+            .build();
 
     public ItemTurtleHelmet() {
         this(0, 1);
@@ -11,32 +20,7 @@ public class ItemTurtleHelmet extends ItemArmor {
     }
 
     public ItemTurtleHelmet(Integer meta, int count) {
-        super(TURTLE_HELMET, meta, count, "Turtle Shell");
-    }
-
-    @Override
-    public int getTier() {
-        return Item.WEARABLE_TIER_OTHER;
-    }
-
-    @Override
-    public boolean isHelmet() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 2;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 276;
-    }
-
-    @Override
-    public int getToughness() {
-        return 2;
+        super(TURTLE_HELMET, meta, count, "Turtle Shell", DEFINITION);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemUnknown.java
+++ b/src/main/java/org/powernukkitx/item/ItemUnknown.java
@@ -1,16 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemUnknown extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(64)
+            .build();
 
     public ItemUnknown(String originalId, int meta, int count, byte[] tags) {
-        super(originalId, meta, count);
+        super(originalId, meta, count, DEFINITION);
         if (tags != null && tags.length > 0) {
             this.setNbtBytes(tags);
         }
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 64;
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemWarpedFungusOnAStick.java
+++ b/src/main/java/org/powernukkitx/item/ItemWarpedFungusOnAStick.java
@@ -22,6 +22,7 @@ import org.powernukkitx.Player;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityLiving;
 import org.powernukkitx.entity.components.BoostableComponent;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.math.Vector3;
 
@@ -31,6 +32,12 @@ import org.powernukkitx.math.Vector3;
  */
 
 public class ItemWarpedFungusOnAStick extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .maxDurability(ItemTool.DURABILITY_WARPED_FUNGUS_ON_A_STICK)
+            .maxStackSize(1)
+            .noDamageOnAttack(true)
+            .noDamageOnBreak(true)
+            .build();
 
     public ItemWarpedFungusOnAStick() {
         this(0, 1);
@@ -41,7 +48,7 @@ public class ItemWarpedFungusOnAStick extends ItemTool {
     }
 
     public ItemWarpedFungusOnAStick(Integer meta, int count) {
-        super(WARPED_FUNGUS_ON_A_STICK, meta, count, "Warped Fungus on a Stick");
+        super(WARPED_FUNGUS_ON_A_STICK, meta, count, "Warped Fungus on a Stick", DEFINITION);
     }
 
     @Override
@@ -65,25 +72,5 @@ public class ItemWarpedFungusOnAStick extends ItemTool {
         }
 
         return false;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_WARPED_FUNGUS_ON_A_STICK;
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 1;
-    }
-
-    @Override
-    public boolean noDamageOnAttack() {
-        return true;
-    }
-
-    @Override
-    public boolean noDamageOnBreak() {
-        return true;
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemWindCharge.java
+++ b/src/main/java/org/powernukkitx/item/ItemWindCharge.java
@@ -3,10 +3,14 @@ package org.powernukkitx.item;
 import org.powernukkitx.Player;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.projectile.EntityWindCharge;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 import static org.powernukkitx.entity.EntityID.WIND_CHARGE_PROJECTILE;
 
 public class ItemWindCharge extends ProjectileItem {
+    public static final ItemDefinition DEFINITION = ProjectileItem.DEFINITION.toBuilder()
+            .maxStackSize(64)
+            .build();
 
     public ItemWindCharge() {
         this(0, 1);
@@ -17,12 +21,7 @@ public class ItemWindCharge extends ProjectileItem {
     }
 
     public ItemWindCharge(Integer meta, int count) {
-        super(WIND_CHARGE, 0, count, "Wind Charge");
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 64;
+        super(WIND_CHARGE, 0, count, "Wind Charge", DEFINITION);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/ItemWolfArmor.java
+++ b/src/main/java/org/powernukkitx/item/ItemWolfArmor.java
@@ -1,12 +1,13 @@
 package org.powernukkitx.item;
 
-public class ItemWolfArmor extends ItemColorArmor {
-     public ItemWolfArmor() {
-         super(WOLF_ARMOR);
-     }
+import org.powernukkitx.item.definition.ItemDefinition;
 
-    @Override
-    public int getMaxDurability() {
-        return 64;
-    }
+public class ItemWolfArmor extends ItemColorArmor {
+    public static final ItemDefinition DEFINITION = ItemColorArmor.DEFINITION.toBuilder()
+            .maxDurability(64)
+            .build();
+
+     public ItemWolfArmor() {
+         super(WOLF_ARMOR, DEFINITION);
+     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemWoodenAxe.java
+++ b/src/main/java/org/powernukkitx/item/ItemWoodenAxe.java
@@ -1,6 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemWoodenAxe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(3)
+            .axe(true)
+            .canBreakShield(true)
+            .maxDurability(ItemTool.DURABILITY_WOODEN)
+            .tier(ItemTool.TIER_WOODEN)
+            .build();
+
     public ItemWoodenAxe() {
         this(0, 1);
     }
@@ -10,31 +20,6 @@ public class ItemWoodenAxe extends ItemTool {
     }
 
     public ItemWoodenAxe(Integer meta, int count) {
-        super(WOODEN_AXE, meta, count, "Wooden Axe");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_WOODEN;
-    }
-
-    @Override
-    public boolean isAxe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_WOODEN;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 3;
-    }
-
-    @Override
-    public boolean canBreakShield() {
-        return true;
+        super(WOODEN_AXE, meta, count, "Wooden Axe", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemWoodenHoe.java
+++ b/src/main/java/org/powernukkitx/item/ItemWoodenHoe.java
@@ -1,6 +1,13 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemWoodenHoe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .hoe(true)
+            .maxDurability(ItemTool.DURABILITY_WOODEN)
+            .tier(ItemTool.TIER_WOODEN)
+            .build();
 
     public ItemWoodenHoe() {
         this(0, 1);
@@ -11,21 +18,6 @@ public class ItemWoodenHoe extends ItemTool {
     }
 
     public ItemWoodenHoe(Integer meta, int count) {
-        super(WOODEN_HOE, meta, count, "Wooden Hoe");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_WOODEN;
-    }
-
-    @Override
-    public boolean isHoe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_WOODEN;
+        super(WOODEN_HOE, meta, count, "Wooden Hoe", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemWoodenPickaxe.java
+++ b/src/main/java/org/powernukkitx/item/ItemWoodenPickaxe.java
@@ -1,6 +1,15 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemWoodenPickaxe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(2)
+            .maxDurability(ItemTool.DURABILITY_WOODEN)
+            .pickaxe(true)
+            .tier(ItemTool.TIER_WOODEN)
+            .build();
+
     public ItemWoodenPickaxe() {
         this(0, 1);
     }
@@ -10,26 +19,6 @@ public class ItemWoodenPickaxe extends ItemTool {
     }
 
     public ItemWoodenPickaxe(Integer meta, int count) {
-        super(WOODEN_PICKAXE, meta, count, "Wooden Pickaxe");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_WOODEN;
-    }
-
-    @Override
-    public boolean isPickaxe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_WOODEN;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 2;
+        super(WOODEN_PICKAXE, meta, count, "Wooden Pickaxe", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemWoodenShovel.java
+++ b/src/main/java/org/powernukkitx/item/ItemWoodenShovel.java
@@ -1,6 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemWoodenShovel extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(1)
+            .maxDurability(ItemTool.DURABILITY_WOODEN)
+            .shovel(true)
+            .tier(ItemTool.TIER_WOODEN)
+            .build();
 
     public ItemWoodenShovel() {
         this(0, 1);
@@ -11,26 +19,6 @@ public class ItemWoodenShovel extends ItemTool {
     }
 
     public ItemWoodenShovel(Integer meta, int count) {
-        super(WOODEN_SHOVEL, meta, count, "Wooden Shovel");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_WOODEN;
-    }
-
-    @Override
-    public boolean isShovel() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_WOODEN;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 1;
+        super(WOODEN_SHOVEL, meta, count, "Wooden Shovel", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemWoodenSpear.java
+++ b/src/main/java/org/powernukkitx/item/ItemWoodenSpear.java
@@ -1,10 +1,17 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * @author Buddelbubi
  * @since 2025/12/15
  */
 public class ItemWoodenSpear extends ItemSpear {
+    public static final ItemDefinition DEFINITION = ItemSpear.DEFINITION.toBuilder()
+            .attackDamage(2)
+            .maxDurability(ItemTool.DURABILITY_WOODEN)
+            .tier(ItemTool.TIER_WOODEN)
+            .build();
 
     public ItemWoodenSpear() {
         this(0, 1);
@@ -15,21 +22,6 @@ public class ItemWoodenSpear extends ItemSpear {
     }
 
     public ItemWoodenSpear(Integer meta, int count) {
-        super(WOODEN_SPEAR, meta, count, "Wooden Spear");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_WOODEN;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_WOODEN;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 2;
+        super(WOODEN_SPEAR, meta, count, "Wooden Spear", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemWoodenSword.java
+++ b/src/main/java/org/powernukkitx/item/ItemWoodenSword.java
@@ -1,6 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 public class ItemWoodenSword extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(4)
+            .maxDurability(ItemTool.DURABILITY_WOODEN)
+            .sword(true)
+            .tier(ItemTool.TIER_WOODEN)
+            .build();
 
     public ItemWoodenSword() {
         this(0, 1);
@@ -11,26 +19,6 @@ public class ItemWoodenSword extends ItemTool {
     }
 
     public ItemWoodenSword(Integer meta, int count) {
-        super(WOODEN_SWORD, meta, count, "Wooden Sword");
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_WOODEN;
-    }
-
-    @Override
-    public boolean isSword() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return ItemTool.TIER_WOODEN;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 4;
+        super(WOODEN_SWORD, meta, count, "Wooden Sword", DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemWritableBook.java
+++ b/src/main/java/org/powernukkitx/item/ItemWritableBook.java
@@ -1,15 +1,16 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
+
 /**
  * alias BookAndQuill
  */
 public class ItemWritableBook extends ItemBookWritable {
-    public ItemWritableBook() {
-        super(WRITABLE_BOOK);
-    }
+    public static final ItemDefinition DEFINITION = ItemBookWritable.DEFINITION.toBuilder()
+            .maxStackSize(1)
+            .build();
 
-    @Override
-    public int getMaxStackSize() {
-        return 1;
+    public ItemWritableBook() {
+        super(WRITABLE_BOOK, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/ItemWrittenBook.java
+++ b/src/main/java/org/powernukkitx/item/ItemWrittenBook.java
@@ -1,9 +1,14 @@
 package org.powernukkitx.item;
 
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.nbt.tag.ListTag;
 
 public class ItemWrittenBook extends ItemBookWritable {
+    public static final ItemDefinition DEFINITION = ItemBookWritable.DEFINITION.toBuilder()
+            .maxStackSize(16)
+            .build();
+
     public static final int GENERATION_ORIGINAL = 0;
     public static final int GENERATION_COPY = 1;
     public static final int GENERATION_COPY_OF_COPY = 2;
@@ -18,12 +23,7 @@ public class ItemWrittenBook extends ItemBookWritable {
     }
 
     public ItemWrittenBook(Integer meta, int count) {
-        super(Item.WRITTEN_BOOK, 0, count, "Written Book");
-    }
-
-    @Override
-    public int getMaxStackSize() {
-        return 16;
+        super(Item.WRITTEN_BOOK, 0, count, "Written Book", DEFINITION);
     }
 
     public Item writeBook(String author, String title, String[] pages) {

--- a/src/main/java/org/powernukkitx/item/ProjectileItem.java
+++ b/src/main/java/org/powernukkitx/item/ProjectileItem.java
@@ -4,6 +4,7 @@ import org.powernukkitx.Player;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.projectile.EntityProjectile;
 import org.powernukkitx.event.entity.ProjectileLaunchEvent;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.math.Vector3;
 import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.nbt.tag.DoubleTag;
@@ -15,9 +16,14 @@ import org.cloudburstmc.protocol.bedrock.data.SoundEvent;
  * @author CreeperFace
  */
 public abstract class ProjectileItem extends Item {
+    public static final ItemDefinition DEFINITION = DEFAULT_DEFINITION.toBuilder().build();
 
     public ProjectileItem(String id, Integer meta, int count, String name) {
-        super(id, meta, count, name);
+        this(id, meta, count, name, DEFINITION);
+    }
+
+    public ProjectileItem(String id, Integer meta, int count, String name, ItemDefinition definition) {
+        super(id, meta, count, name, definition);
     }
 
     abstract public String getProjectileEntityType();

--- a/src/main/java/org/powernukkitx/item/armor/copper/ItemCopperBoots.java
+++ b/src/main/java/org/powernukkitx/item/armor/copper/ItemCopperBoots.java
@@ -1,34 +1,18 @@
 package org.powernukkitx.item.armor.copper;
 
 import org.powernukkitx.item.ItemArmor;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 public class ItemCopperBoots extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(1)
+            .boots(true)
+            .maxDurability(143)
+            .tier(WEARABLE_TIER_COPPER)
+            .toughness(2)
+            .build();
+
     public ItemCopperBoots() {
-        super(COPPER_BOOTS);
-    }
-
-    @Override
-    public int getTier() {
-        return WEARABLE_TIER_COPPER;
-    }
-
-    @Override
-    public boolean isBoots() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 1;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 143;
-    }
-
-    @Override
-    public int getToughness() {
-        return 2;
+        super(COPPER_BOOTS, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/armor/copper/ItemCopperChestplate.java
+++ b/src/main/java/org/powernukkitx/item/armor/copper/ItemCopperChestplate.java
@@ -1,34 +1,18 @@
 package org.powernukkitx.item.armor.copper;
 
 import org.powernukkitx.item.ItemArmor;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 public class ItemCopperChestplate extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(4)
+            .chestplate(true)
+            .maxDurability(177)
+            .tier(WEARABLE_TIER_COPPER)
+            .toughness(2)
+            .build();
+
     public ItemCopperChestplate() {
-        super(COPPER_CHESTPLATE);
-    }
-
-    @Override
-    public int getTier() {
-        return WEARABLE_TIER_COPPER;
-    }
-
-    @Override
-    public boolean isChestplate() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 4;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 177;
-    }
-
-    @Override
-    public int getToughness() {
-        return 2;
+        super(COPPER_CHESTPLATE, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/armor/copper/ItemCopperHelmet.java
+++ b/src/main/java/org/powernukkitx/item/armor/copper/ItemCopperHelmet.java
@@ -1,34 +1,18 @@
 package org.powernukkitx.item.armor.copper;
 
 import org.powernukkitx.item.ItemArmor;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 public class ItemCopperHelmet extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(2)
+            .helmet(true)
+            .maxDurability(122)
+            .tier(WEARABLE_TIER_COPPER)
+            .toughness(2)
+            .build();
+
     public ItemCopperHelmet() {
-        super(COPPER_HELMET);
-    }
-
-    @Override
-    public int getTier() {
-        return WEARABLE_TIER_COPPER;
-    }
-
-    @Override
-    public boolean isHelmet() {
-        return true;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 2;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 122;
-    }
-
-    @Override
-    public int getToughness() {
-        return 2;
+        super(COPPER_HELMET, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/armor/copper/ItemCopperHorseArmor.java
+++ b/src/main/java/org/powernukkitx/item/armor/copper/ItemCopperHorseArmor.java
@@ -1,14 +1,14 @@
 package org.powernukkitx.item.armor.copper;
 
 import org.powernukkitx.item.Item;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 public class ItemCopperHorseArmor extends Item {
-    public ItemCopperHorseArmor() {
-        super(COPPER_HORSE_ARMOR);
-    }
+    public static final ItemDefinition DEFINITION = Item.DEFAULT_DEFINITION.toBuilder()
+            .maxStackSize(1)
+            .build();
 
-    @Override
-    public int getMaxStackSize() {
-        return 1;
+    public ItemCopperHorseArmor() {
+        super(COPPER_HORSE_ARMOR, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/armor/copper/ItemCopperLeggings.java
+++ b/src/main/java/org/powernukkitx/item/armor/copper/ItemCopperLeggings.java
@@ -1,34 +1,18 @@
 package org.powernukkitx.item.armor.copper;
 
 import org.powernukkitx.item.ItemArmor;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 public class ItemCopperLeggings extends ItemArmor {
+    public static final ItemDefinition DEFINITION = ARMOR.toBuilder()
+            .armorPoints(3)
+            .leggings(true)
+            .maxDurability(166)
+            .tier(WEARABLE_TIER_COPPER)
+            .toughness(2)
+            .build();
+
     public ItemCopperLeggings() {
-        super(COPPER_LEGGINGS);
-    }
-
-    @Override
-    public boolean isLeggings() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return WEARABLE_TIER_COPPER;
-    }
-
-    @Override
-    public int getArmorPoints() {
-        return 3;
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return 166;
-    }
-
-    @Override
-    public int getToughness() {
-        return 2;
+        super(COPPER_LEGGINGS, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/customitem/CustomItemDefinition.java
+++ b/src/main/java/org/powernukkitx/item/customitem/CustomItemDefinition.java
@@ -9,6 +9,7 @@ import org.powernukkitx.item.customitem.data.RenderOffsets;
 import org.powernukkitx.item.utils.DiggerEntry;
 import org.powernukkitx.item.utils.ItemArmorType;
 import org.powernukkitx.item.utils.ItemEnchantSlot;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.item.utils.RepairEntry;
 import org.powernukkitx.item.utils.ShooterAmmo;
 import org.powernukkitx.nbt.tag.CompoundTag;
@@ -1846,5 +1847,69 @@ public record CustomItemDefinition(String identifier, CompoundTag nbt) implement
 
     public CompoundTag getNbt() {
         return this.nbt;
+    }
+
+    /**
+     * Folds this component-driven definition onto {@code base}, so that a custom item exposes its
+     * behaviour through the same {@link ItemDefinition} every other item uses.
+     */
+    public ItemDefinition toItemDefinition(@NotNull ItemDefinition base) {
+        ItemDefinition.ItemDefinitionBuilder<?, ?> b = base.toBuilder()
+                .canTakeDamage(canTakeDamage())
+                .maxDurability(maxDurability())
+                .damageChanceMin(damageChanceMin())
+                .damageChanceMax(damageChanceMax())
+                .edible(isEdible())
+                .helmet(isHelmet())
+                .chestplate(isChestplate())
+                .leggings(isLeggings())
+                .boots(isBoots())
+                .armorPoints(wearableProtection())
+                .sword(isSword())
+                .spear(isSpear())
+                .axe(isAxe())
+                .pickaxe(isPickaxe())
+                .shovel(isShovel())
+                .hoe(isHoe())
+                .shears(isShears())
+                .shield(isShield())
+                .bow(isBow())
+                .crossbow(isCrossbow())
+                .trident(isTrident())
+                .mace(isMace())
+                .tool(isPickaxe() || isAxe() || isShovel() || isHoe() || isSword() || isShears());
+
+        CompoundTag stackSize = getComponent("minecraft:max_stack_size");
+        if (stackSize != null) {
+            b.maxStackSize(stackSize.getByte("value") & 0xFF);
+        }
+
+        CompoundTag useModifiers = getComponent("minecraft:use_modifiers");
+        if (useModifiers != null) {
+            b.useDuration(useModifiers.getFloat("use_duration"));
+            b.movementModifier(useModifiers.getFloat("movement_modifier"));
+        }
+
+        CompoundTag food = getComponent("minecraft:food");
+        if (food != null) {
+            int nutrition = food.getInt("nutrition");
+            b.nutrition(nutrition);
+            b.saturation(nutrition * food.getFloat("saturation_modifier") * 2f);
+            b.requiresHunger(!food.getBoolean("can_always_eat"));
+        }
+
+        CompoundTag properties = getItemProperties();
+        CompoundTag damage = getComponent("minecraft:damage");
+        if (damage != null && damage.contains("value")) {
+            b.attackDamage(damage.getByte("value") & 0xFF);
+        } else if (properties != null && properties.contains("damage")) {
+            b.attackDamage(properties.getInt("damage"));
+        }
+
+        if (properties != null && properties.contains("should_despawn")) {
+            b.shouldDespawn(properties.getBoolean("should_despawn"));
+        }
+
+        return b.build();
     }
 }

--- a/src/main/java/org/powernukkitx/item/customitem/ItemCustomTool.java
+++ b/src/main/java/org/powernukkitx/item/customitem/ItemCustomTool.java
@@ -2,6 +2,7 @@ package org.powernukkitx.item.customitem;
 
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemTool;
+import org.powernukkitx.item.definition.ItemDefinition;
 import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.registry.Registries;
 import org.jetbrains.annotations.NotNull;
@@ -14,13 +15,12 @@ import org.jetbrains.annotations.NotNull;
  */
 @Deprecated
 public abstract class ItemCustomTool extends ItemTool implements CustomItem {
-    public ItemCustomTool(@NotNull String id) {
-        super(id);
-    }
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .maxDurability(DURABILITY_WOODEN)
+            .build();
 
-    @Override
-    public int getMaxDurability() {
-        return DURABILITY_WOODEN;
+    public ItemCustomTool(@NotNull String id) {
+        super(id, DEFINITION);
     }
 
     /**

--- a/src/main/java/org/powernukkitx/item/definition/ItemDefinition.java
+++ b/src/main/java/org/powernukkitx/item/definition/ItemDefinition.java
@@ -1,0 +1,57 @@
+package org.powernukkitx.item.definition;
+
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder(toBuilder = true)
+@Getter
+public class ItemDefinition {
+    boolean canTakeDamage;
+    boolean unbreakable;
+    boolean lavaResistant;
+    boolean fertilizer;
+    boolean applyEnchantments;
+    boolean canBeActivated;
+    boolean canBreakShield;
+    boolean noDamageOnAttack;
+    boolean noDamageOnBreak;
+    boolean shouldDespawn;
+    boolean edible;
+    boolean consumable;
+    boolean requiresHunger;
+    boolean tool;
+    boolean sword;
+    boolean spear;
+    boolean axe;
+    boolean pickaxe;
+    boolean shovel;
+    boolean hoe;
+    boolean shears;
+    boolean shield;
+    boolean bow;
+    boolean crossbow;
+    boolean trident;
+    boolean mace;
+    boolean armor;
+    boolean helmet;
+    boolean chestplate;
+    boolean leggings;
+    boolean boots;
+
+    int maxStackSize;
+    int maxDurability;
+    int damageChanceMin;
+    int damageChanceMax;
+    int tier;
+    int enchantAbility;
+    int attackDamage;
+    int armorPoints;
+    int toughness;
+    int nutrition;
+    int usingTicks;
+
+    float saturation;
+    float knockbackResistance;
+    float useDuration;
+    float movementModifier;
+}

--- a/src/main/java/org/powernukkitx/item/tools/copper/ItemCopperAxe.java
+++ b/src/main/java/org/powernukkitx/item/tools/copper/ItemCopperAxe.java
@@ -1,34 +1,18 @@
 package org.powernukkitx.item.tools.copper;
 
 import org.powernukkitx.item.ItemTool;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 public class ItemCopperAxe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(4)
+            .axe(true)
+            .canBreakShield(true)
+            .maxDurability(ItemTool.DURABILITY_COPPER)
+            .tier(WEARABLE_TIER_COPPER)
+            .build();
+
     public ItemCopperAxe() {
-        super(COPPER_AXE);
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_COPPER;
-    }
-
-    @Override
-    public boolean isAxe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return WEARABLE_TIER_COPPER;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 4;
-    }
-
-    @Override
-    public boolean canBreakShield() {
-        return true;
+        super(COPPER_AXE, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/tools/copper/ItemCopperHoe.java
+++ b/src/main/java/org/powernukkitx/item/tools/copper/ItemCopperHoe.java
@@ -1,24 +1,16 @@
 package org.powernukkitx.item.tools.copper;
 
 import org.powernukkitx.item.ItemTool;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 public class ItemCopperHoe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .hoe(true)
+            .maxDurability(ItemTool.DURABILITY_COPPER)
+            .tier(WEARABLE_TIER_COPPER)
+            .build();
+
     public ItemCopperHoe() {
-        super(COPPER_HOE);
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_COPPER;
-    }
-
-    @Override
-    public boolean isHoe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return WEARABLE_TIER_COPPER;
+        super(COPPER_HOE, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/tools/copper/ItemCopperPickaxe.java
+++ b/src/main/java/org/powernukkitx/item/tools/copper/ItemCopperPickaxe.java
@@ -1,29 +1,17 @@
 package org.powernukkitx.item.tools.copper;
 
 import org.powernukkitx.item.ItemTool;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 public class ItemCopperPickaxe extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(4)
+            .maxDurability(ItemTool.DURABILITY_COPPER)
+            .pickaxe(true)
+            .tier(WEARABLE_TIER_COPPER)
+            .build();
+
     public ItemCopperPickaxe() {
-        super(COPPER_PICKAXE);
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_COPPER;
-    }
-
-    @Override
-    public boolean isPickaxe() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return WEARABLE_TIER_COPPER;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 4;
+        super(COPPER_PICKAXE, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/tools/copper/ItemCopperShovel.java
+++ b/src/main/java/org/powernukkitx/item/tools/copper/ItemCopperShovel.java
@@ -1,29 +1,17 @@
 package org.powernukkitx.item.tools.copper;
 
 import org.powernukkitx.item.ItemTool;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 public class ItemCopperShovel extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(4)
+            .maxDurability(ItemTool.DURABILITY_COPPER)
+            .shovel(true)
+            .tier(WEARABLE_TIER_COPPER)
+            .build();
+
     public ItemCopperShovel() {
-        super(COPPER_SHOVEL);
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_COPPER;
-    }
-
-    @Override
-    public boolean isShovel() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return WEARABLE_TIER_COPPER;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 4;
+        super(COPPER_SHOVEL, DEFINITION);
     }
 }

--- a/src/main/java/org/powernukkitx/item/tools/copper/ItemCopperSword.java
+++ b/src/main/java/org/powernukkitx/item/tools/copper/ItemCopperSword.java
@@ -1,29 +1,17 @@
 package org.powernukkitx.item.tools.copper;
 
 import org.powernukkitx.item.ItemTool;
+import org.powernukkitx.item.definition.ItemDefinition;
 
 public class ItemCopperSword extends ItemTool {
+    public static final ItemDefinition DEFINITION = TOOL.toBuilder()
+            .attackDamage(4)
+            .maxDurability(ItemTool.DURABILITY_COPPER)
+            .sword(true)
+            .tier(WEARABLE_TIER_COPPER)
+            .build();
+
     public ItemCopperSword() {
-        super(COPPER_SWORD);
-    }
-
-    @Override
-    public int getMaxDurability() {
-        return ItemTool.DURABILITY_COPPER;
-    }
-
-    @Override
-    public boolean isSword() {
-        return true;
-    }
-
-    @Override
-    public int getTier() {
-        return WEARABLE_TIER_COPPER;
-    }
-
-    @Override
-    public int getAttackDamage() {
-        return 4;
+        super(COPPER_SWORD, DEFINITION);
     }
 }


### PR DESCRIPTION
## What does this PR do?

Moves the constant per-item overrides (max stack size, durability, tier, tool/armor
flags, food values and so on) out of the ~600 `Item` subclasses and into a single
`ItemDefinition` value object, built with a Lombok `@SuperBuilder`. Custom items fold
their `CustomItemDefinition` onto that same object, so component-driven and hardcoded
behaviour are read through one place instead of two.

## Why?

Phase 2 of the item/block override refactor (#2279). Phase 1 did the same for blocks in #2275,
and this applies that system to items.

## Type of change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Performance
- [x] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** aea2e74d0
- **Bedrock client version:** 1.26.40
- **Plugins loaded:** Nothing

**Steps performed and results:**

- [ ] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

Source-compatible for almost everything, with one exception worth calling out:

- `Item` now has both `Item(String, int, int, String)` and
  `Item(String, int, int, ItemDefinition)`. An out-of-tree subclass calling
  `super(id, meta, count, null)` with a bare `null` will no longer compile and needs a
  cast. The same applies to `ItemTool`, `ItemArmor`, `ItemFood` and the other base
  classes that gained definition-taking overloads.
- Overriding the migrated getters still works; the definition is only the default.
- **One deliberate behaviour change:** for a custom item whose `minecraft:food`
  component sets `can_always_eat: true`, the deprecated `isRequiresHunger()` now
  returns `false` instead of `true`. The old pair was self-contradictory
  (`canAlwaysEat() == true` while `isRequiresHunger() == true`). Its only caller is
  `canAlwaysEat()`, whose result is unchanged, so nothing observable moves.

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| Claude Opus 5 | Filling some of this PR description, CustomItemDefinition Javadoc |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
