### PR TITLE
fix: respawn at world spawn and resync viewers

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -1516,6 +1516,36 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         return this.server.getNameBans().isBanned(this.getName());
     }
 
+    /**
+     * Resolves where this player would come back to life if they respawned right now, applying the same fallbacks
+     * as {@link #respawn()} but none of its side effects - no respawn anchor charge is consumed, no
+     * {@link PlayerRespawnEvent} is fired, no spawn point is rewritten and no message is sent.
+     * <p>
+     * The spawn point falls back to the default level spawn when its level has been unloaded, and when a
+     * {@link SpawnPointType#BLOCK} spawn point no longer points at a valid respawn block - a broken bed or a depleted
+     * respawn anchor. {@code respawn()} remains the authority: a plugin listening to {@link PlayerRespawnEvent} can
+     * still move the player elsewhere, so the value returned here is a prediction, not a guarantee.
+     * <p>
+     * Reads block state and may load the spawn point's chunk, so call it from the thread that ticks that level.
+     *
+     * @return the predicted respawn position, never null
+     */
+    @NotNull
+    public Position getRespawnPosition() {
+        Pair<Position, SpawnPointType> spawnPair = this.getSpawn();
+        Position spawnPos = spawnPair.left();
+        if (spawnPos == null || spawnPos.level == null || spawnPos.level.getProvider() == null) {
+            return this.getServer().getDefaultLevel().getSpawnLocation();
+        }
+        if (spawnPair.right() == SpawnPointType.BLOCK) {
+            Block spawnBlock = spawnPos.getLevelBlock();
+            if (spawnBlock == null || !isValidRespawnBlock(spawnBlock)) {
+                return this.getServer().getDefaultLevel().getSpawnLocation();
+            }
+        }
+        return spawnPos;
+    }
+
     protected void respawn() {
         //the player can't respawn if the server is hardcore
         if (this.server.isHardcore()) {
@@ -1585,6 +1615,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         this.inventory.sendArmorContents(this);
         this.offhandInventory.sendContents(this);
         this.teleport(Location.fromObject(respawnPos.add(0, this.getEyeHeight(), 0), respawnPos.level), TeleportCause.PLAYER_SPAWN);
+        this.despawnFromAll();
         this.spawnToAll();
     }
 
@@ -3353,7 +3384,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
             log.warn("{} attempted to send an empty message", name);
             return;
         }
-        
+
         final MessageOnly messageOnly = new MessageOnly();
         messageOnly.setMessage(this.server.getLanguage().tr(message));
 

--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -4908,8 +4908,12 @@ public class Level implements Metadatable {
     }
 
     public Position getSafeSpawn(Vector3 spawn, int horizontalMaxOffset, boolean allowWaterUnder, boolean checkHighest) {
-        if (spawn == null)
-            spawn = (horizontalMaxOffset == 0) ? this.getSpawnLocation().add(0.5, 0, 0.5) : this.getFuzzySpawnLocation();
+        if (spawn == null) {
+            Vector3 worldSpawn = this.getSpawnLocation().add(0.5, 0, 0.5);
+            if (horizontalMaxOffset == 0 || standable(worldSpawn, allowWaterUnder))
+                return Position.fromObject(worldSpawn, this);
+            spawn = this.getFuzzySpawnLocation();
+        }
         if (spawn == null)
             return null;
         if (standable(spawn, allowWaterUnder) || horizontalMaxOffset == 0)

--- a/src/main/java/org/powernukkitx/network/process/handler/RespawnHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/RespawnHandler.java
@@ -2,6 +2,7 @@ package org.powernukkitx.network.process.handler;
 
 import org.powernukkitx.Player;
 import org.powernukkitx.Server;
+import org.powernukkitx.level.Position;
 import org.powernukkitx.network.process.PacketHandler;
 import org.powernukkitx.network.process.PlayerSessionHolder;
 import org.cloudburstmc.protocol.bedrock.data.PlayerRespawnState;
@@ -18,8 +19,15 @@ public class RespawnHandler implements PacketHandler<RespawnPacket> {
         if (!packet.getState().equals(PlayerRespawnState.CLIENT_READY_TO_SPAWN) || player.isAlive()) {
             return;
         }
+        Position spawn = player.getRespawnPosition();
+        if (spawn.getLevel() != player.getLevel()) {
+            // RespawnPacket carries no dimension, so a position in another level would be applied to the dimension
+            // Player#respawn then handles the dimension change
+            spawn = player.getPosition();
+        }
+
         final RespawnPacket respawnPacket = new RespawnPacket();
-        respawnPacket.setPosition(player.getPosition().toNetwork());
+        respawnPacket.setPosition(spawn.toNetwork());
         respawnPacket.setState(PlayerRespawnState.READY_TO_SPAWN);
         respawnPacket.setPlayerRuntimeId(player.getId());
 


### PR DESCRIPTION
<!--
  Read CONTRIBUTING.md before submitting:
  https://github.com/PowerNukkitX/PowerNukkitX/blob/master/CONTRIBUTING.md

  PRs that leave this template unfilled, or fill it with generated filler,
  are closed without review. Delete the HTML comments as you go.

  SECURITY: never report a vulnerability in a public PR. See SECURITY.md.
-->

## What does this PR do?

<!-- In your own words. One or two sentences. No LLM-written descriptions. -->

- `getSafeSpawn(...)` tries exact world spawn first and falls back to `getFuzzySpawnLocation()` only when not standable
- New method `getRespawnPosition()`
  - Unloaded spawn level -> default spawn
  - related block broken (bed, respawn anchor) -> default spawn
- `respawn()` now calls `despawnFromAll()` before `spawnToAll()`
  - stale entries in `hasSpawned` caused invisible players

## Why?

<!-- What problem does this solve? Link the issue: Closes #123 -->

- Incorrect Respawn Location: The player respawns at an unintended location instead of the set worldspawn.
- Desync / Invisibility Bug: The respawned player is invisible to other players. (Note: Moving to another world and coming back fixes the invisibility, but this needs to be fixed properly.)

## Type of change

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** Unrelated
- **Bedrock client version:** 1.26.33
- **Plugins loaded:** None

**Steps performed and results:**

1. Die
2. Respawn at world spawn

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [X] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model         | What it did                                                                                                                                                                                                 |
|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Claude Opus 5 | Research: traced the death → respawn path (`Player#respawn`, `RespawnHandler`, `Level#getSafeSpawn`, `Entity#spawnTo`/`hasSpawned`) to locate the two root causes                                              |
| Claude Opus 5 | Code: The new `Player#getRespawnPosition`, and the position/level fix in `RespawnHandler` |
| Claude Opus 5 | Javadoc for `Player#getRespawnPosition` and the inline comments in the diff                                                                                                                                   |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
