### PR TITLE
perf: stop materialising empty chunk sections on send

### DIFF
--- a/src/main/java/org/powernukkitx/level/format/leveldb/LevelDBProvider.java
+++ b/src/main/java/org/powernukkitx/level/format/leveldb/LevelDBProvider.java
@@ -26,7 +26,9 @@ import org.powernukkitx.utils.SemVersion;
 import org.powernukkitx.utils.collection.nb.Long2ObjectNonBlockingMap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.Unpooled;
 import it.unimi.dsi.fastutil.Pair;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import lombok.extern.slf4j.Slf4j;
@@ -57,6 +59,7 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceArray;
 
 /**
  * @author CoolLoong (PNX Project)
@@ -75,6 +78,23 @@ public class LevelDBProvider implements LevelProvider {
     protected final String path;
     protected CompoundTag worldDynamicProperties;
     protected boolean worldDynamicPropertiesDirty = false;
+    /**
+     * Network bytes an absent section serialises to, indexed by section Y offset into the byte
+     * range. Sized from {@link Byte} because {@link ChunkSection#y()} is a {@code byte} that the
+     * wire format writes as a single signed byte, so a taller dimension cannot widen this without
+     * changing the section format first.
+     * <p>
+     * Shared by every level: the bytes depend only on the section Y, so two dimensions at the
+     * same Y - and two worlds of the same dimension - produce identical output. See
+     * {@link #emptySectionPayload(int)}.
+     */
+    private static final AtomicReferenceArray<byte[]> EMPTY_SECTION_PAYLOADS =
+            new AtomicReferenceArray<>(1 << Byte.SIZE);
+    /**
+     * Network bytes the biome palette of an absent section serialises to. One value for the whole
+     * server: unlike the section payload this does not encode the section Y.
+     */
+    private static volatile byte[] emptyBiomePayload;
 
     /**
      * @return int The nether coordinate scale for the world
@@ -321,28 +341,34 @@ public class LevelDBProvider implements LevelProvider {
                     }
                 }
                 int total = subChunkCount + 1;
+                final int minSectionY = unsafeChunk.getDimensionData().getMinSectionY();
                 //write block
                 if (level != null && level.isAntiXrayEnabled()) {
                     for (int i = 0; i < total; i++) {
                         if (sections[i] == null) {
-                            sections[i] = new ChunkSection((byte) (i + getDimensionData().getMinSectionY()));
+                            sections[i] = new ChunkSection((byte) (i + minSectionY));
                         }
-                        assert sections[i] != null;
                         sections[i].writeObfuscatedToBuf(level, byteBuf);
                     }
                 } else {
                     for (int i = 0; i < total; i++) {
-                        if (sections[i] == null) {
-                            sections[i] = new ChunkSection((byte) (i + getDimensionData().getMinSectionY()));
+                        final ChunkSection section = sections[i];
+                        if (section != null) {
+                            section.writeToBuf(byteBuf);
+                        } else {
+                            byteBuf.writeBytes(emptySectionPayload(i + minSectionY));
                         }
-                        assert sections[i] != null;
-                        sections[i].writeToBuf(byteBuf);
                     }
                 }
 
                 // Write biomes
                 for (int i = 0; i < total; i++) {
-                    sections[i].biomes().writeToNetwork(byteBuf, Integer::intValue);
+                    final ChunkSection section = sections[i];
+                    if (section != null) {
+                        section.biomes().writeToNetwork(byteBuf, Integer::intValue);
+                    } else {
+                        byteBuf.writeBytes(emptyBiomePayload());
+                    }
                 }
 
                 writeBorderBlockData(byteBuf, chunk);
@@ -379,6 +405,61 @@ public class LevelDBProvider implements LevelProvider {
             }
         });
         return Pair.of(data.get(), subChunkCountRef.get());
+    }
+
+    /**
+     * The serialised form of a section the chunk does not have.
+     * <p>
+     * A chunk send used to fill each empty slot with a real {@link ChunkSection} and store it
+     * back into the chunk, so every chunk ever sent to a player permanently held block palettes,
+     * a biome palette and two light arrays for each of its empty sections. A heap dump of a busy
+     * server showed 23.8 of a possible 24 sections materialised per chunk, the resulting
+     * {@code int[]} and {@code byte[]} being most of the heap.
+     * <p>
+     * An empty section always serialises to the same bytes for a given section index, so they are
+     * produced once from a real {@link ChunkSection} - rather than by hand, which would duplicate
+     * the wire format - and reused. That removes both the retention and the per-send allocation.
+     * <p>
+     * Anti-xray does not use this: obfuscation keeps per-section state and rewrites the palette,
+     * so that path still materialises absent sections exactly as it always has.
+     *
+     * @param sectionY the section's Y, as written into the payload
+     * @return bytes to append, which the caller must not modify
+     */
+    private static byte[] emptySectionPayload(int sectionY) {
+        final byte y = (byte) sectionY;
+        final int slot = y - Byte.MIN_VALUE;
+        byte[] payload = EMPTY_SECTION_PAYLOADS.get(slot);
+        if (payload == null) {
+            final ByteBuf scratch = Unpooled.buffer();
+            try {
+                new ChunkSection(y).writeToBuf(scratch);
+                payload = ByteBufUtil.getBytes(scratch);
+            } finally {
+                scratch.release();
+            }
+            EMPTY_SECTION_PAYLOADS.compareAndSet(slot, null, payload);
+            payload = EMPTY_SECTION_PAYLOADS.get(slot);
+        }
+        return payload;
+    }
+
+    /**
+     * @return the biome bytes of an absent section, which the caller must not modify
+     */
+    private static byte[] emptyBiomePayload() {
+        byte[] payload = emptyBiomePayload;
+        if (payload == null) {
+            final ByteBuf scratch = Unpooled.buffer();
+            try {
+                new ChunkSection((byte) 0).biomes().writeToNetwork(scratch, Integer::intValue);
+                payload = ByteBufUtil.getBytes(scratch);
+            } finally {
+                scratch.release();
+            }
+            emptyBiomePayload = payload;
+        }
+        return payload;
     }
 
     private void writeBorderBlockData(ByteBuf byteBuf, IChunk chunk) {


### PR DESCRIPTION
<!--
  Read CONTRIBUTING.md before submitting:
  https://github.com/PowerNukkitX/PowerNukkitX/blob/master/CONTRIBUTING.md

  PRs that leave this template unfilled, or fill it with generated filler,
  are closed without review. Delete the HTML comments as you go.

  SECURITY: never report a vulnerability in a public PR. See SECURITY.md.
-->

## What does this PR do?

<!-- In your own words. One or two sentences. No LLM-written descriptions. -->

Introduces level-independent payloads for empty sections.

## Why?

<!-- What problem does this solve? Link the issue: Closes #123 -->

Chunk sends were mutating the chunk to avoid a null check - that mutation was retained for ever (revealed by heap dumps)

## Type of change

<!-- Tick what applies. -->

- [ ] Bug Fix
- [ ] New Feature
- [X] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** PR build
- **Bedrock client version:** 1.26.33
- **Plugins loaded:** None

**Steps performed and results:**

1. Joined ingame
2. Verified the world still looks the same

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [X] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

Measured with standalone harness against the shadow jar

```
== correctness: cached bytes vs freshly serialised ==
  section payloads identical across 3 rounds: true
  payload size = 2065 B, biome payload = 1027 B
  biome payload identical: true
== y is encoded, so payloads must differ per index ==
  distinct payloads: 24 of 24
== payload depends only on section Y, not on dimension ==
  same Y gives same bytes: true
== biome payload is Y-independent ==
  one global biome payload is safe: true
== byte range covers every representable section Y ==
  Byte.MIN_VALUE slot = 0, Byte.MAX_VALUE slot = 255, array size = 256
== cost per empty section ==
  old: allocate ChunkSection + writeToBuf      3279,3 ns/op    15692,3 B/op
  new: writeBytes(cached)                       851,7 ns/op     4384,0 B/op
# Test by claude
```

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
| Claude Opus 5 | Research, javadoc and benchmark/harness (not part of this PR) |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
