### PR TITLE
perf: update tick-chunk coverage incrementally

### DIFF
--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -89,6 +89,9 @@ import org.powernukkitx.utils.collection.nb.Long2ObjectNonBlockingMap;
 import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2LongMap;
+import it.unimi.dsi.fastutil.ints.Int2LongOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntArrayFIFOQueue;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
@@ -406,19 +409,30 @@ public class Level implements Metadatable {
     /** Resolved chunk set for tick-all mode ({@code chunksPerTicks < 0}); see tickAllChunksCached. */
     private IChunk[] cachedTickChunks;
     /**
-     * Distinct chunk positions of this level's loaders. Refilled at the top of every tick-all
-     * pass and consumed by the rebuild that pass may trigger, so it is only meaningful inside
-     * {@link #tickAllChunksCached}.
+     * Chunk hash to the number of chunk loaders whose tick radius covers it, maintained
+     * incrementally as loaders move rather than rebuilt from scratch. Purely geometric: it says
+     * nothing about whether a chunk is loaded, which is applied later by
+     * {@link #resolveTickChunks}. That separation is what lets a chunk loading or unloading
+     * invalidate only the resolved array instead of forcing a full re-expansion.
      */
-    private final LongOpenHashSet loaderChunkPositions = new LongOpenHashSet();
-    /** The loader chunk positions {@link #cachedTickChunks} was built from. */
-    private final LongOpenHashSet cachedTickChunksLoaderPositions = new LongOpenHashSet();
+    private final Long2IntOpenHashMap loaderCoverage = new Long2IntOpenHashMap();
+    /** {@link #loaderCoveragePosition} value meaning "this loader contributes no coverage yet". */
+    private static final long COVERAGE_ABSENT = Long.MIN_VALUE;
+    /**
+     * Loader id to the chunk position its {@link #loaderCoverage} contribution was applied for.
+     * Absent loaders report {@link #COVERAGE_ABSENT} rather than fastutil's default of zero,
+     * which is indistinguishable from a real position - {@code chunkHash(0, 0)} is also zero.
+     */
+    private final Int2LongOpenHashMap loaderCoveragePosition = newCoveragePositionMap();
+    /** Scratch for {@link #refreshLoaderCoverage}, so the radius work happens off the loaders monitor. */
+    private final LongArrayList coverageRemovals = new LongArrayList();
+    private final LongArrayList coverageAdditions = new LongArrayList();
     /** Set on chunk load/unload (any thread) so the tick-all cache rebuilds next tick. */
     private volatile boolean tickChunkCacheDirty = true;
     /**
      * {@link TickingAreaManager#getVersion()} the {@link #tickingAreaChunkHashes} were built
-     * from. Owned by appendTickingAreaChunks; the tick-all cache check reads it too, which is
-     * safe because appendTickingAreaChunks runs inside the cache rebuild.
+     * from. Owned by {@link #refreshTickingAreaHashes}; the tick-all cache check reads it too,
+     * which is safe because that refresh runs inside the resolve it triggers.
      */
     private long tickingAreaHashesVersion = -1;
     /**
@@ -1805,6 +1819,8 @@ public class Level implements Metadatable {
         if (this.chunksPerTicks == 0 || (this.loaders.isEmpty() && !hasTickingAreas)) {
             this.chunkTickList.clear();
             this.cachedTickChunks = null;
+            this.loaderCoverage.clear();
+            this.loaderCoveragePosition.clear();
             return;
         }
 
@@ -1893,19 +1909,12 @@ public class Level implements Metadatable {
      * border, a chunk loaded or unloaded, or ticking areas changed.
      */
     private void tickAllChunksCached(TickingAreaManager areaManager, boolean hasTickingAreas, long areaVersion, int tickSpeed) {
-        this.loaderChunkPositions.clear();
-        synchronized (this.loaders) {
-            for (ChunkLoader loader : this.loaders.values()) {
-                this.loaderChunkPositions.add(Level.chunkHash((int) loader.getX() >> 4, (int) loader.getZ() >> 4));
-            }
-        }
+        boolean coverageChanged = refreshLoaderCoverage();
         if (this.cachedTickChunks == null || this.tickChunkCacheDirty
                 || areaVersion != this.tickingAreaHashesVersion
-                || !this.loaderChunkPositions.equals(this.cachedTickChunksLoaderPositions)) {
+                || coverageChanged) {
             this.tickChunkCacheDirty = false;
-            this.cachedTickChunksLoaderPositions.clear();
-            this.cachedTickChunksLoaderPositions.addAll(this.loaderChunkPositions);
-            rebuildTickAllChunkCache(areaManager, hasTickingAreas, areaVersion);
+            resolveTickChunks(areaManager, hasTickingAreas, areaVersion);
         }
         for (IChunk chunk : this.cachedTickChunks) {
             if (!chunk.isLoaded()) {
@@ -1915,38 +1924,91 @@ public class Level implements Metadatable {
         }
     }
 
-    private void rebuildTickAllChunkCache(TickingAreaManager areaManager, boolean hasTickingAreas, long areaVersion) {
-        this.chunkTickList.clear();
-        LevelProvider provider = requireProvider();
-        LongIterator positions = this.loaderChunkPositions.longIterator();
-        while (positions.hasNext()) {
-            long position = positions.nextLong();
-            int chunkX = getHashX(position);
-            int chunkZ = getHashZ(position);
-            for (int dx = -this.chunkTickRadius; dx <= this.chunkTickRadius; dx++) {
-                for (int dz = -this.chunkTickRadius; dz <= this.chunkTickRadius; dz++) {
-                    long hash = Level.chunkHash(chunkX + dx, chunkZ + dz);
-                    if (provider.isChunkLoaded(hash)) {
-                        this.chunkTickList.put(hash, -1);
+    private static Int2LongOpenHashMap newCoveragePositionMap() {
+        Int2LongOpenHashMap map = new Int2LongOpenHashMap();
+        map.defaultReturnValue(COVERAGE_ABSENT);
+        return map;
+    }
+
+    private boolean refreshLoaderCoverage() {
+        this.coverageRemovals.clear();
+        this.coverageAdditions.clear();
+        synchronized (this.loaders) {
+            for (Int2ObjectMap.Entry<ChunkLoader> entry : this.loaders.int2ObjectEntrySet()) {
+                ChunkLoader loader = entry.getValue();
+                long position = Level.chunkHash((int) loader.getX() >> 4, (int) loader.getZ() >> 4);
+                long previous = this.loaderCoveragePosition.put(entry.getIntKey(), position);
+                if (previous == position) {
+                    continue;
+                }
+                if (previous != COVERAGE_ABSENT) {
+                    this.coverageRemovals.add(previous);
+                }
+                this.coverageAdditions.add(position);
+            }
+            if (this.loaderCoveragePosition.size() != this.loaders.size()) {
+                ObjectIterator<Int2LongMap.Entry> iterator = this.loaderCoveragePosition.int2LongEntrySet().iterator();
+                while (iterator.hasNext()) {
+                    Int2LongMap.Entry entry = iterator.next();
+                    if (!this.loaders.containsKey(entry.getIntKey())) {
+                        this.coverageRemovals.add(entry.getLongValue());
+                        iterator.remove();
                     }
                 }
             }
         }
-        appendTickingAreaChunks(areaManager, hasTickingAreas, areaVersion);
+        if (this.coverageRemovals.isEmpty() && this.coverageAdditions.isEmpty()) {
+            return false;
+        }
+        for (int i = 0; i < this.coverageRemovals.size(); i++) {
+            applyCoverage(this.coverageRemovals.getLong(i), -1);
+        }
+        for (int i = 0; i < this.coverageAdditions.size(); i++) {
+            applyCoverage(this.coverageAdditions.getLong(i), 1);
+        }
+        return true;
+    }
 
-        List<IChunk> resolved = new ArrayList<>(this.chunkTickList.size());
-        for (Long2IntMap.Entry entry : this.chunkTickList.long2IntEntrySet()) {
-            long index = entry.getLongKey();
-            if (!(this.tickingAreaChunkHashes != null && this.tickingAreaChunkHashes.contains(index))
-                    && !areNeighboringChunksLoaded(index)) {
-                continue;
-            }
-            IChunk chunk = this.getChunk(getHashX(index), getHashZ(index), false);
-            if (chunk != null) {
-                resolved.add(chunk);
+    /**
+     * Adds or withdraws one loader's tick-radius square from {@link #loaderCoverage}. A chunk
+     * drops out only once no loader covers it, so overlapping loaders cannot uncover each other.
+     *
+     * @param centre the loader's chunk position
+     * @param delta  {@code 1} to add coverage, {@code -1} to withdraw it
+     */
+    private void applyCoverage(long centre, int delta) {
+        int chunkX = getHashX(centre);
+        int chunkZ = getHashZ(centre);
+        for (int dx = -this.chunkTickRadius; dx <= this.chunkTickRadius; dx++) {
+            long xPart = ((long) (chunkX + dx)) << 32;
+            for (int dz = -this.chunkTickRadius; dz <= this.chunkTickRadius; dz++) {
+                long hash = xPart | ((chunkZ + dz) & 0xffffffffL);
+                if (this.loaderCoverage.addTo(hash, delta) + delta <= 0) {
+                    this.loaderCoverage.remove(hash);
+                }
             }
         }
-        this.chunkTickList.clear();
+    }
+
+    /** Turns the covered chunk hashes, plus any ticking areas, into the array the tick iterates. */
+    private void resolveTickChunks(TickingAreaManager areaManager, boolean hasTickingAreas, long areaVersion) {
+        refreshTickingAreaHashes(areaManager, hasTickingAreas, areaVersion);
+
+        List<IChunk> resolved = new ArrayList<>(this.loaderCoverage.size());
+        LongIterator covered = this.loaderCoverage.keySet().iterator();
+        while (covered.hasNext()) {
+            addResolvedTickChunk(covered.nextLong(), resolved);
+        }
+        if (this.tickingAreaChunkHashes != null) {
+            LongIterator areaChunks = this.tickingAreaChunkHashes.iterator();
+            while (areaChunks.hasNext()) {
+                long index = areaChunks.nextLong();
+                if (!this.loaderCoverage.containsKey(index)) {
+                    addResolvedTickChunk(index, resolved);
+                }
+            }
+        }
+
         IChunk[] target = this.cachedTickChunks;
         if (target == null || target.length != resolved.size()) {
             target = new IChunk[resolved.size()];
@@ -1954,7 +2016,27 @@ public class Level implements Metadatable {
         this.cachedTickChunks = resolved.toArray(target);
     }
 
-    private void appendTickingAreaChunks(TickingAreaManager areaManager, boolean hasTickingAreas, long areaVersion) {
+    /**
+     * Adds a covered chunk to the tick set if it is loaded, and either sits in a ticking area or
+     * has its neighbours loaded.
+     * <p>
+     * Coverage is geometric, so unloaded chunks reach here; the single {@code getChunk} lookup
+     * runs first to reject them before the four-lookup neighbour check.
+     */
+    private void addResolvedTickChunk(long index, List<IChunk> resolved) {
+        IChunk chunk = this.getChunk(getHashX(index), getHashZ(index), false);
+        if (chunk == null) {
+            return;
+        }
+        if (!(this.tickingAreaChunkHashes != null && this.tickingAreaChunkHashes.contains(index))
+                && !areNeighboringChunksLoaded(index)) {
+            return;
+        }
+        resolved.add(chunk);
+    }
+
+    /** Rebuilds {@link #tickingAreaChunkHashes} when the ticking-area version moved. */
+    private void refreshTickingAreaHashes(TickingAreaManager areaManager, boolean hasTickingAreas, long areaVersion) {
         if (!hasTickingAreas) {
             this.tickingAreaChunkHashes = null;
             this.tickingAreaHashesVersion = areaVersion;
@@ -1972,6 +2054,13 @@ public class Level implements Metadatable {
                 }
             }
             this.tickingAreaChunkHashes = hashes;
+        }
+    }
+
+    private void appendTickingAreaChunks(TickingAreaManager areaManager, boolean hasTickingAreas, long areaVersion) {
+        refreshTickingAreaHashes(areaManager, hasTickingAreas, areaVersion);
+        if (this.tickingAreaChunkHashes == null) {
+            return;
         }
         LevelProvider provider = requireProvider();
         for (long hash : this.tickingAreaChunkHashes) {


### PR DESCRIPTION
<!--
  Read CONTRIBUTING.md before submitting:
  https://github.com/PowerNukkitX/PowerNukkitX/blob/master/CONTRIBUTING.md

  PRs that leave this template unfilled, or fill it with generated filler,
  are closed without review. Delete the HTML comments as you go.

  SECURITY: never report a vulnerability in a public PR. See SECURITY.md.
-->

## What does this PR do?

Only rebuilds what changed

## Why?

<!-- What problem does this solve? Link the issue: Closes #123 -->

Rebuild cost of tick-chunk coverage was scaled with player count rather than with what changed

## Type of change

<!-- Tick what applies. -->

- [ ] Bug Fix
- [ ] New Feature
- [X] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** This PR
- **Bedrock client version:** 1.26.33
- **Plugins loaded:** None

**Steps performed and results:**

1. Joined world
2. Set randomTickSpeed to 100
3. Checked if leaves decay (once when in ticking distance, once when outside)
4. Checked if ticking areas keep the area ticked when outside the ticking distance

Tests standalone on new branch; pushing soon with other JMH benchmarks

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [X] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

Modelled in a standalone JMH benchmark:

| loaders | full re-expansion | incremental |
|--|--|--|
| 32 | - | 2.99 ± 0.21 µs |
| 180 | 173.17 ± 2.81 µs | 1.90 ± 0.03 µs |
| 400 | - | 1.98 ± 0.33 µs |

Cost stops scaling with loader count because the work is two squares rather than N now.
Benchmark is also pessimistic: Applies and then reverses the move so each invocation starts clean - real single move is roughly half.

Impact modest: Focuses on scalability rather than TPS (at 400 loaders, was 1.4% of the 50ms tick budget before this change)


## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
| Claude Opus 5 | JMH-Benchmarking different scenarios |
| Claude Opus 5 | Drafted some code and reviewed it (e.g. concurrency and `applyCoverage(...)`) |
| Claude Opus 5 | Javadoc |
| Claude Opus 5 | Testing |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
