### PR TITLE
ci: add Minecraft version to publish metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,7 @@ jobs:
       is_draft: ${{ steps.meta.outputs.is_draft }}
       is_prerelease: ${{ steps.meta.outputs.is_prerelease }}
       title: ${{ steps.meta.outputs.title }}
+      minecraft_version: ${{ steps.mc_version.outputs.minecraft_version }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -101,6 +102,21 @@ jobs:
           PNX_REPO_USERNAME: ${{ secrets.PNX_REPO_USERNAME }}
           PNX_REPO_PASSWORD: ${{ secrets.PNX_REPO_PASSWORD }}
 
+      - name: Extract Minecraft version from Server.getVersion()
+        id: mc_version
+        run: |
+          cat > /tmp/McVersion.java << 'JAVA'
+          import org.cloudburstmc.protocol.bedrock.codec.v1001.Bedrock_v1001;
+          public class McVersion {
+              public static void main(String[] args) {
+                  System.out.println(Bedrock_v1001.CODEC.getMinecraftVersion());
+              }
+          }
+          JAVA
+          javac -cp build/powernukkitx.jar /tmp/McVersion.java -d /tmp
+          MINECRAFT_VERSION=$(java -cp "/tmp:build/powernukkitx.jar" McVersion)
+          echo "minecraft_version=$MINECRAFT_VERSION" >> $GITHUB_OUTPUT
+
       - uses: actions/upload-artifact@v7
         with:
           name: powernukkitx.jar
@@ -128,6 +144,7 @@ jobs:
         run: |
           PROTOCOL_VERSION=$(sed -En 's/.*CODEC = Bedrock_v([0-9]+)\.CODEC.*/\1/p' src/main/java/org/powernukkitx/network/NetworkConstants.java | head -n 1)
           API_VERSION=$(sed -n 's/.*API_VERSION = dynamic("\([^"]*\)").*/\1/p' src/main/java/org/powernukkitx/PowerNukkitX.java)
+          MINECRAFT_VERSION="${{ needs.publish.outputs.minecraft_version }}"
           if [ -z "$PROTOCOL_VERSION" ]; then
             echo "Unable to extract protocol version from NetworkConstants.java" >&2
             exit 1
@@ -136,8 +153,13 @@ jobs:
             echo "Unable to extract API version from Nukkit.java" >&2
             exit 1
           fi
+          if [ -z "$MINECRAFT_VERSION" ]; then
+            echo "Unable to extract Minecraft version from Server.getVersion()" >&2
+            exit 1
+          fi
           echo "protocol_version=$PROTOCOL_VERSION" >> $GITHUB_OUTPUT
           echo "api_version=$API_VERSION" >> $GITHUB_OUTPUT
+          echo "minecraft_version=$MINECRAFT_VERSION" >> $GITHUB_OUTPUT
 
       - uses: actions/download-artifact@v8
         with:
@@ -150,6 +172,7 @@ jobs:
           TAG="${{ needs.publish.outputs.tag }}"
           PROTOCOL_VERSION="${{ steps.versions.outputs.protocol_version }}"
           API_VERSION="${{ steps.versions.outputs.api_version }}"
+          MINECRAFT_VERSION="${{ steps.versions.outputs.minecraft_version }}"
 
           mkdir -p changelogs
           FILE="changelogs/${TAG}.md"
@@ -165,6 +188,7 @@ jobs:
           |----------|-------|
           | PowerNukkitX Version | $TAG |
           | API Version | $API_VERSION |
+          | Minecraft Version | $MINECRAFT_VERSION |
           | Protocol Version | $PROTOCOL_VERSION |
 
           EOF
@@ -240,6 +264,7 @@ jobs:
           TAG="${{ needs.publish.outputs.tag }}"
           API_VERSION="${{ steps.versions.outputs.api_version }}"
           PROTOCOL_VERSION="${{ steps.versions.outputs.protocol_version }}"
+          MINECRAFT_VERSION="${{ steps.versions.outputs.minecraft_version }}"
 
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
@@ -250,6 +275,7 @@ jobs:
             git commit -m "docs: add changelog for PowerNukkitX ${TAG} [skip ci]
 
           Release ${TAG}
+          - Minecraft: ${MINECRAFT_VERSION}
           - Protocol: ${PROTOCOL_VERSION}
           - API: ${API_VERSION}
           - See the full changelog at changelogs/${TAG}.md"
@@ -264,6 +290,7 @@ jobs:
           IS_PRERELEASE="${{ needs.publish.outputs.is_prerelease }}"
           PROTOCOL_VERSION="${{ steps.versions.outputs.protocol_version }}"
           API_VERSION="${{ steps.versions.outputs.api_version }}"
+          MINECRAFT_VERSION="${{ steps.versions.outputs.minecraft_version }}"
 
           cat > release-notes.md << EOF
 
@@ -273,6 +300,7 @@ jobs:
           |---|---|
           | **PowerNukkitX Version** | $TAG |
           | **API Version** | $API_VERSION |
+          | **Minecraft Version** | $MINECRAFT_VERSION |
           | **Protocol Version** | $PROTOCOL_VERSION |
 
           ---

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,11 +105,16 @@ jobs:
       - name: Extract Minecraft version from Server.getVersion()
         id: mc_version
         run: |
-          cat > /tmp/McVersion.java << 'JAVA'
-          import org.cloudburstmc.protocol.bedrock.codec.v1001.Bedrock_v1001;
+          CODEC_VERSION=$(sed -En 's/.*CODEC = (Bedrock_v[0-9]+)\.CODEC.*/\1/p' src/main/java/org/powernukkitx/network/NetworkConstants.java | head -n 1)
+          if [ -z "$CODEC_VERSION" ]; then
+            echo "Unable to extract codec version from NetworkConstants.java" >&2
+            exit 1
+          fi
+          cat > /tmp/McVersion.java << JAVA
+          import org.cloudburstmc.protocol.bedrock.codec.${CODEC_VERSION};
           public class McVersion {
               public static void main(String[] args) {
-                  System.out.println(Bedrock_v1001.CODEC.getMinecraftVersion());
+                  System.out.println(${CODEC_VERSION}.CODEC.getMinecraftVersion());
               }
           }
           JAVA

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,24 +102,23 @@ jobs:
           PNX_REPO_USERNAME: ${{ secrets.PNX_REPO_USERNAME }}
           PNX_REPO_PASSWORD: ${{ secrets.PNX_REPO_PASSWORD }}
 
-      - name: Extract Minecraft version from Server.getVersion()
+      - name: Extract Minecraft version from the built jar
         id: mc_version
         run: |
-          CODEC_VERSION=$(sed -En 's/.*CODEC = (Bedrock_v[0-9]+)\.CODEC.*/\1/p' src/main/java/org/powernukkitx/network/NetworkConstants.java | head -n 1)
-          if [ -z "$CODEC_VERSION" ]; then
-            echo "Unable to extract codec version from NetworkConstants.java" >&2
-            exit 1
-          fi
-          cat > /tmp/McVersion.java << JAVA
-          import org.cloudburstmc.protocol.bedrock.codec.${CODEC_VERSION};
+          # Asking the codec itself keeps this working across protocol bumps, since nothing here
+          # names a version. Stderr is left alone so any startup noise stays visible in the log.
+          cat > /tmp/McVersion.java << 'JAVA'
           public class McVersion {
               public static void main(String[] args) {
-                  System.out.println(${CODEC_VERSION}.CODEC.getMinecraftVersion());
+                  System.out.println(org.powernukkitx.network.NetworkConstants.CODEC.getMinecraftVersion());
               }
           }
           JAVA
-          javac -cp build/powernukkitx.jar /tmp/McVersion.java -d /tmp
-          MINECRAFT_VERSION=$(java -cp "/tmp:build/powernukkitx.jar" McVersion)
+          MINECRAFT_VERSION=$(java -cp build/powernukkitx.jar /tmp/McVersion.java)
+          if ! echo "$MINECRAFT_VERSION" | grep -Eq '^[0-9]+(\.[0-9]+)+$'; then
+            echo "Unexpected Minecraft version from NetworkConstants.CODEC: '$MINECRAFT_VERSION'" >&2
+            exit 1
+          fi
           echo "minecraft_version=$MINECRAFT_VERSION" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v7
@@ -159,7 +158,7 @@ jobs:
             exit 1
           fi
           if [ -z "$MINECRAFT_VERSION" ]; then
-            echo "Unable to extract Minecraft version from Server.getVersion()" >&2
+            echo "Minecraft version missing from the publish job outputs" >&2
             exit 1
           fi
           echo "protocol_version=$PROTOCOL_VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!--
  Read CONTRIBUTING.md before submitting:
  https://github.com/PowerNukkitX/PowerNukkitX/blob/master/CONTRIBUTING.md

  PRs that leave this template unfilled, or fill it with generated filler,
  are closed without review. Delete the HTML comments as you go.

  SECURITY: never report a vulnerability in a public PR. See SECURITY.md.
-->

## What does this PR do?

Update the publish workflow to extract the Minecraft version from the built server jar and expose it as a job output. The release pipeline now validates and propagates this value into generated changelogs, release notes, and the automated changelog commit message alongside API and protocol versions.

## Why?

Allows you to see the Minecraft version directly in the release notes 

## Type of change

<!-- Tick what applies. -->

- [ ] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [x] Documentation
- [ ] Build / CI / dependencies