### PR TITLE
feat: Add support for custom cameras registration

### DIFF
--- a/src/main/java/org/powernukkitx/camera/CustomCameraDefinition.java
+++ b/src/main/java/org/powernukkitx/camera/CustomCameraDefinition.java
@@ -1,0 +1,458 @@
+package org.powernukkitx.camera;
+
+import org.cloudburstmc.math.vector.Vector2f;
+import org.cloudburstmc.math.vector.Vector3f;
+import org.cloudburstmc.protocol.bedrock.data.camera.CameraAudioListener;
+import org.cloudburstmc.protocol.bedrock.data.camera.CameraPreset;
+import org.cloudburstmc.protocol.common.util.OptionalBoolean;
+
+import java.util.Objects;
+
+/**
+ * Defines a custom camera preset.
+ *
+ * <p>The runtime ID and protocol definition are assigned when the camera is
+ * registered in {@link CustomCameraRegistry}.</p>
+ * 
+ * @author Curse
+ */
+public record CustomCameraDefinition(String identifier, CameraPreset preset) {
+    public CustomCameraDefinition {
+        Objects.requireNonNull(identifier, "identifier");
+        Objects.requireNonNull(preset, "preset");
+
+        validateIdentifier(identifier);
+
+        if (!identifier.equals(preset.getName())) {
+            throw new IllegalArgumentException(
+                    "Camera preset name does not match definition identifier: "
+                            + identifier
+            );
+        }
+    }
+
+    /**
+     * Creates a custom camera builder.
+     *
+     * @param identifier namespaced camera identifier
+     * @return camera definition builder
+     */
+    public static Builder builder(String identifier) {
+        return new Builder(identifier);
+    }
+
+    private static void validateIdentifier(String identifier) {
+        if (identifier.isBlank()) {
+            throw new IllegalArgumentException("Camera identifier cannot be blank");
+        }
+
+        int separator = identifier.indexOf(':');
+
+        if (separator <= 0 || separator == identifier.length() - 1) {
+            throw new IllegalArgumentException("Camera identifier must use namespace:name format: " + identifier);
+        }
+
+        String namespace = identifier.substring(0, separator);
+
+        if ("minecraft".equals(namespace)) {
+            throw new IllegalArgumentException("Custom camera presets cannot use the minecraft namespace: " + identifier);
+        }
+    }
+
+    /**
+     * Builder for custom camera presets.
+     */
+    public static final class Builder {
+        private final String identifier;
+
+        private String inheritFrom;
+        private Vector3f position;
+        private Float pitch;
+        private Float yaw;
+        private Vector2f viewOffset;
+        private Vector3f entityOffset;
+        private Float radius;
+        private Float rotationSpeed;
+        private CameraAudioListener listener;
+        private OptionalBoolean snapToTarget = OptionalBoolean.empty();
+        private OptionalBoolean continueTargeting = OptionalBoolean.empty();
+        private Vector2f horizontalRotationLimit;
+        private Vector2f verticalRotationLimit;
+        private Float blockListeningRadius;
+
+        private Builder(String identifier) {
+            Objects.requireNonNull(identifier, "identifier");
+            validateIdentifier(identifier);
+
+            this.identifier = identifier;
+        }
+
+        /**
+         * Sets the camera preset inherited by this custom preset.
+         *
+         * @param inheritFrom parent camera preset identifier
+         * @return this builder
+         */
+        public Builder inheritFrom(String inheritFrom) {
+            if (inheritFrom == null || inheritFrom.isBlank()) {
+                throw new IllegalArgumentException("Inherited camera identifier cannot be blank");
+            }
+
+            this.inheritFrom = inheritFrom;
+            return this;
+        }
+
+        /**
+         * Inherits from the vanilla free camera.
+         *
+         * @return this builder
+         */
+        public Builder inheritFromFree() {
+            return this.inheritFrom("minecraft:free");
+        }
+
+        /**
+         * Inherits from the vanilla first-person camera.
+         *
+         * @return this builder
+         */
+        public Builder inheritFromFirstPerson() {
+            return this.inheritFrom("minecraft:first_person");
+        }
+
+        /**
+         * Inherits from the vanilla third-person camera.
+         *
+         * @return this builder
+         */
+        public Builder inheritFromThirdPerson() {
+            return this.inheritFrom("minecraft:third_person");
+        }
+
+        /**
+         * Inherits from the vanilla front-facing third-person camera.
+         *
+         * @return this builder
+         */
+        public Builder inheritFromThirdPersonFront() {
+            return this.inheritFrom("minecraft:third_person_front");
+        }
+
+        /**
+         * Inherits from the vanilla fixed-boom camera.
+         *
+         * @return this builder
+         */
+        public Builder inheritFromFixedBoom() {
+            return this.inheritFrom("minecraft:fixed_boom");
+        }
+
+        /**
+         * Inherits from the vanilla follow-orbit camera.
+         *
+         * @return this builder
+         */
+        public Builder inheritFromFollowOrbit() {
+            return this.inheritFrom("minecraft:follow_orbit");
+        }
+
+        /**
+         * Sets the default camera position.
+         *
+         * @param x x coordinate
+         * @param y y coordinate
+         * @param z z coordinate
+         * @return this builder
+         */
+        public Builder position(float x, float y, float z) {
+            this.position = Vector3f.from(x, y, z);
+            return this;
+        }
+
+        /**
+         * Sets the default camera position.
+         *
+         * @param position camera position
+         * @return this builder
+         */
+        public Builder position(Vector3f position) {
+            this.position = Objects.requireNonNull(position, "position");
+            return this;
+        }
+
+        /**
+         * Sets the default camera rotation.
+         *
+         * @param pitch camera pitch
+         * @param yaw camera yaw
+         * @return this builder
+         */
+        public Builder rotation(float pitch, float yaw) {
+            this.pitch = pitch;
+            this.yaw = yaw;
+            return this;
+        }
+
+        /**
+         * Sets the default camera pitch.
+         *
+         * @param pitch camera pitch
+         * @return this builder
+         */
+        public Builder pitch(float pitch) {
+            this.pitch = pitch;
+            return this;
+        }
+
+        /**
+         * Sets the default camera yaw.
+         *
+         * @param yaw camera yaw
+         * @return this builder
+         */
+        public Builder yaw(float yaw) {
+            this.yaw = yaw;
+            return this;
+        }
+
+        /**
+         * Sets the player-relative view offset.
+         *
+         * @param x horizontal view offset
+         * @param y vertical view offset
+         * @return this builder
+         */
+        public Builder viewOffset(float x, float y) {
+            this.viewOffset = Vector2f.from(x, y);
+            return this;
+        }
+
+        /**
+         * Sets the player-relative view offset.
+         *
+         * @param viewOffset view offset
+         * @return this builder
+         */
+        public Builder viewOffset(Vector2f viewOffset) {
+            this.viewOffset = Objects.requireNonNull(
+                    viewOffset,
+                    "viewOffset"
+            );
+            return this;
+        }
+
+        /**
+         * Sets the target entity-relative camera offset.
+         *
+         * @param x x offset
+         * @param y y offset
+         * @param z z offset
+         * @return this builder
+         */
+        public Builder entityOffset(float x, float y, float z) {
+            this.entityOffset = Vector3f.from(x, y, z);
+            return this;
+        }
+
+        /**
+         * Sets the target entity-relative camera offset.
+         *
+         * @param entityOffset entity offset
+         * @return this builder
+         */
+        public Builder entityOffset(Vector3f entityOffset) {
+            this.entityOffset = Objects.requireNonNull(entityOffset, "entityOffset");
+            return this;
+        }
+
+        /**
+         * Sets the follow-orbit camera radius.
+         *
+         * @param radius camera radius
+         * @return this builder
+         */
+        public Builder radius(float radius) {
+            if (radius < 0.0f) {
+                throw new IllegalArgumentException("Camera radius cannot be negative");
+            }
+
+            this.radius = radius;
+            return this;
+        }
+
+        /**
+         * Sets the camera rotation speed.
+         *
+         * @param rotationSpeed rotation speed
+         * @return this builder
+         */
+        public Builder rotationSpeed(float rotationSpeed) {
+            if (rotationSpeed < 0.0f) {
+                throw new IllegalArgumentException("Camera rotation speed cannot be negative");
+            }
+
+            this.rotationSpeed = rotationSpeed;
+            return this;
+        }
+
+        /**
+         * Sets the camera audio listener mode.
+         *
+         * @param listener audio listener mode
+         * @return this builder
+         */
+        public Builder listener(CameraAudioListener listener) {
+            this.listener = Objects.requireNonNull(listener, "listener");
+            return this;
+        }
+
+        /**
+         * Sets whether the camera immediately snaps toward its target.
+         *
+         * @param snapToTarget whether to snap to the target
+         * @return this builder
+         */
+        public Builder snapToTarget(boolean snapToTarget) {
+            this.snapToTarget = OptionalBoolean.of(snapToTarget);
+            return this;
+        }
+
+        /**
+         * Sets whether the camera continues following its target.
+         *
+         * @param continueTargeting whether targeting continues
+         * @return this builder
+         */
+        public Builder continueTargeting(boolean continueTargeting) {
+            this.continueTargeting = OptionalBoolean.of(continueTargeting);
+            return this;
+        }
+
+        /**
+         * Sets the horizontal camera rotation limits.
+         *
+         * @param minimum minimum horizontal rotation
+         * @param maximum maximum horizontal rotation
+         * @return this builder
+         */
+        public Builder horizontalRotationLimit(float minimum, float maximum) {
+            if (minimum > maximum) {
+                throw new IllegalArgumentException("Minimum horizontal rotation cannot exceed maximum");
+            }
+
+            this.horizontalRotationLimit = Vector2f.from(minimum, maximum);
+            return this;
+        }
+
+        /**
+         * Sets the vertical camera rotation limits.
+         *
+         * @param minimum minimum vertical rotation
+         * @param maximum maximum vertical rotation
+         * @return this builder
+         */
+        public Builder verticalRotationLimit(float minimum, float maximum) {
+            if (minimum > maximum) {
+                throw new IllegalArgumentException("Minimum vertical rotation cannot exceed maximum");
+            }
+
+            this.verticalRotationLimit = Vector2f.from(minimum, maximum);
+            return this;
+        }
+
+        /**
+         * Sets the block listening radius used by the camera audio listener.
+         *
+         * @param blockListeningRadius block listening radius
+         * @return this builder
+         */
+        public Builder blockListeningRadius(float blockListeningRadius) {
+            if (blockListeningRadius < 0.0f) {
+                throw new IllegalArgumentException("Block listening radius cannot be negative");
+            }
+
+            this.blockListeningRadius = blockListeningRadius;
+            return this;
+        }
+
+        /**
+         * Builds the custom camera definition.
+         *
+         * @return custom camera definition
+         */
+        public CustomCameraDefinition build() {
+            CameraPreset.CameraPresetBuilder presetBuilder =
+                    CameraPreset.builder()
+                            .name(this.identifier);
+
+            if (this.inheritFrom != null) {
+                presetBuilder.inheritFrom(this.inheritFrom);
+            }
+
+            if (this.position != null) {
+                presetBuilder.pos(this.position);
+            }
+
+            if (this.pitch != null) {
+                presetBuilder.pitch(this.pitch);
+            }
+
+            if (this.yaw != null) {
+                presetBuilder.yaw(this.yaw);
+            }
+
+            if (this.viewOffset != null) {
+                presetBuilder.viewOffset(this.viewOffset);
+            }
+
+            if (this.entityOffset != null) {
+                presetBuilder.entityOffset(this.entityOffset);
+            }
+
+            if (this.radius != null) {
+                presetBuilder.radius(this.radius);
+            }
+
+            if (this.rotationSpeed != null) {
+                presetBuilder.rotationSpeed(this.rotationSpeed);
+            }
+
+            if (this.listener != null) {
+                presetBuilder.listener(this.listener);
+            }
+
+            if (this.snapToTarget.isPresent()) {
+                presetBuilder.snapToTarget(this.snapToTarget);
+            }
+
+            if (this.continueTargeting.isPresent()) {
+                presetBuilder.continueTargeting(
+                        this.continueTargeting
+                );
+            }
+
+            if (this.horizontalRotationLimit != null) {
+                presetBuilder.horizontalRotationLimit(
+                        this.horizontalRotationLimit
+                );
+            }
+
+            if (this.verticalRotationLimit != null) {
+                presetBuilder.verticalRotationLimit(
+                        this.verticalRotationLimit
+                );
+            }
+
+            if (this.blockListeningRadius != null) {
+                presetBuilder.blockListeningRadius(
+                        this.blockListeningRadius
+                );
+            }
+
+            return new CustomCameraDefinition(
+                    this.identifier,
+                    presetBuilder.build()
+            );
+        }
+    }
+}

--- a/src/main/java/org/powernukkitx/camera/CustomCameraDefinition.java
+++ b/src/main/java/org/powernukkitx/camera/CustomCameraDefinition.java
@@ -5,6 +5,7 @@ import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.protocol.bedrock.data.camera.CameraAudioListener;
 import org.cloudburstmc.protocol.bedrock.data.camera.CameraPreset;
 import org.cloudburstmc.protocol.common.util.OptionalBoolean;
+import org.powernukkitx.registry.CameraRegistry;
 
 import java.util.Objects;
 
@@ -12,8 +13,8 @@ import java.util.Objects;
  * Defines a custom camera preset.
  *
  * <p>The runtime ID and protocol definition are assigned when the camera is
- * registered in {@link CustomCameraRegistry}.</p>
- * 
+ * registered in {@link CameraRegistry}.</p>
+ *
  * @author Curse
  */
 public record CustomCameraDefinition(String identifier, CameraPreset preset) {

--- a/src/main/java/org/powernukkitx/camera/CustomCameraRegistry.java
+++ b/src/main/java/org/powernukkitx/camera/CustomCameraRegistry.java
@@ -1,0 +1,197 @@
+package org.powernukkitx.camera;
+
+import org.cloudburstmc.protocol.bedrock.data.camera.CameraPreset;
+import org.cloudburstmc.protocol.common.DefinitionRegistry;
+import org.cloudburstmc.protocol.common.NamedDefinition;
+import org.cloudburstmc.protocol.common.SimpleDefinitionRegistry;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Registry containing vanilla and custom camera presets.
+ * 
+ * @author Curse
+ */
+public final class CustomCameraRegistry {
+    private final List<CameraPreset> presets = new ArrayList<>();
+    private final List<NamedDefinition> definitions = new ArrayList<>();
+    private final Map<String, NamedDefinition> definitionsByName = new HashMap<>();
+    private final Map<String, CustomCameraDefinition> customDefinitions = new HashMap<>();
+    private volatile DefinitionRegistry<NamedDefinition> definitionRegistry =
+        SimpleDefinitionRegistry.<NamedDefinition>builder().build();
+
+    /**
+     * Registers a camera preset directly.
+     *
+     * @param preset camera preset
+     * @return shared registered definition
+     */
+    public synchronized NamedDefinition register(CameraPreset preset) {
+        Objects.requireNonNull(preset, "preset");
+
+        String identifier = preset.getName();
+        this.validateIdentifier(identifier);
+        this.checkDuplicate(identifier);
+
+        return this.registerInternal(identifier, preset, null);
+    }
+
+    /**
+     * Registers a custom camera definition.
+     *
+     * @param customDefinition custom camera definition
+     * @return shared registered definition
+     */
+    public synchronized NamedDefinition register(CustomCameraDefinition customDefinition) {
+        Objects.requireNonNull(customDefinition, "customDefinition");
+
+        String identifier = customDefinition.identifier();
+        this.validateIdentifier(identifier);
+        this.checkDuplicate(identifier);
+
+        return this.registerInternal(
+                identifier,
+                customDefinition.preset(),
+                customDefinition
+        );
+    }
+
+    /**
+     * Returns every registered camera preset in runtime-ID order.
+     *
+     * @return immutable camera preset list
+     */
+    public synchronized List<CameraPreset> getAll() {
+        return List.copyOf(this.presets);
+    }
+
+    /**
+     * Returns every registered protocol definition in runtime-ID order.
+     *
+     * @return immutable list of registered camera definitions
+     */
+    public synchronized List<NamedDefinition> getAllDefinitions() {
+        return List.copyOf(this.definitions);
+    }
+
+    /**
+     * Returns the protocol definition registry used by the codec helper.
+     *
+     * @return camera definition registry
+     */
+    public DefinitionRegistry<NamedDefinition> getDefinitions() {
+        return this.definitionRegistry;
+    }
+
+    /**
+     * Gets a shared registered definition by identifier.
+     *
+     * @param identifier camera identifier
+     * @return registered definition or {@code null}
+     */
+    public synchronized NamedDefinition getDefinition(String identifier) {
+        return this.definitionsByName.get(identifier);
+    }
+
+    /**
+     * Gets a shared registered definition by runtime ID.
+     *
+     * @param runtimeId camera runtime ID
+     * @return registered definition or {@code null}
+     */
+    public NamedDefinition getDefinition(int runtimeId) {
+        return this.definitionRegistry.getDefinition(runtimeId);
+    }
+
+    /**
+     * Gets a registered custom camera definition.
+     *
+     * <p>Vanilla presets registered directly as {@link CameraPreset} do not
+     * have a corresponding {@link CustomCameraDefinition}.</p>
+     *
+     * @param identifier custom camera identifier
+     * @return custom camera definition or {@code null}
+     */
+    public synchronized CustomCameraDefinition getCustomDefinition(String identifier) {
+        return this.customDefinitions.get(identifier);
+    }
+
+    /**
+     * Checks whether a camera identifier is registered.
+     *
+     * @param identifier camera identifier
+     * @return {@code true} when registered
+     */
+    public synchronized boolean contains(String identifier) {
+        return this.definitionsByName.containsKey(identifier);
+    }
+
+    /**
+     * Returns the number of registered camera presets.
+     *
+     * @return number of presets
+     */
+    public synchronized int size() {
+        return this.presets.size();
+    }
+
+    private NamedDefinition registerInternal(String identifier, CameraPreset preset, CustomCameraDefinition customDefinition) {
+        int runtimeId = this.presets.size();
+
+        NamedDefinition definition = new CameraPresetDefinition(identifier, runtimeId);
+
+        this.presets.add(preset);
+        this.definitions.add(definition);
+        this.definitionsByName.put(identifier, definition);
+
+        if (customDefinition != null) {
+            this.customDefinitions.put(identifier, customDefinition);
+        }
+
+        this.rebuildDefinitions();
+
+        return definition;
+    }
+
+    private void rebuildDefinitions() {
+        this.definitionRegistry =
+                SimpleDefinitionRegistry
+                        .<NamedDefinition>builder()
+                        .addAll(this.definitions)
+                        .build();
+    }
+
+    private void checkDuplicate(String identifier) {
+        if (this.definitionsByName.containsKey(identifier)) {
+            throw new IllegalArgumentException("Camera preset is already registered: " + identifier);
+        }
+    }
+
+    private void validateIdentifier(String identifier) {
+        if (identifier == null || identifier.isBlank()) {
+            throw new IllegalArgumentException("Camera preset identifier cannot be blank");
+        }
+
+        int separator = identifier.indexOf(':');
+
+        if (separator <= 0 || separator == identifier.length() - 1) {
+            throw new IllegalArgumentException("Camera preset identifier must use namespace:name format: " + identifier);
+        }
+    }
+
+    private record CameraPresetDefinition(String identifier, int runtimeId) implements NamedDefinition {
+        @Override
+        public String getIdentifier() {
+            return this.identifier;
+        }
+
+        @Override
+        public int getRuntimeId() {
+            return this.runtimeId;
+        }
+    }
+}

--- a/src/main/java/org/powernukkitx/registry/CameraRegistry.java
+++ b/src/main/java/org/powernukkitx/registry/CameraRegistry.java
@@ -1,9 +1,10 @@
-package org.powernukkitx.camera;
+package org.powernukkitx.registry;
 
 import org.cloudburstmc.protocol.bedrock.data.camera.CameraPreset;
 import org.cloudburstmc.protocol.common.DefinitionRegistry;
 import org.cloudburstmc.protocol.common.NamedDefinition;
 import org.cloudburstmc.protocol.common.SimpleDefinitionRegistry;
+import org.powernukkitx.camera.CustomCameraDefinition;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -12,11 +13,11 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Registry containing vanilla and custom camera presets.
- * 
+ * Registry containing built-in and custom camera presets.
+ *
  * @author Curse
  */
-public final class CustomCameraRegistry {
+public final class CameraRegistry {
     private final List<CameraPreset> presets = new ArrayList<>();
     private final List<NamedDefinition> definitions = new ArrayList<>();
     private final Map<String, NamedDefinition> definitionsByName = new HashMap<>();

--- a/src/main/java/org/powernukkitx/registry/Registries.java
+++ b/src/main/java/org/powernukkitx/registry/Registries.java
@@ -9,6 +9,7 @@ public final class Registries {
     public static final BlockRegistry BLOCK = new BlockRegistry();
     public static final ItemRegistry ITEM = new ItemRegistry();
     public static final CreativeItemRegistry CREATIVE = new CreativeItemRegistry();
+    public static final CameraRegistry CAMERA = new CameraRegistry();
     public static final BiomeRegistry BIOME = new BiomeRegistry();
     public static final FuelRegistry FUEL = new FuelRegistry();
     public static final GeneratorRegistry GENERATOR = new GeneratorRegistry();

--- a/src/main/java/org/powernukkitx/utils/DefaultCameraPresets.java
+++ b/src/main/java/org/powernukkitx/utils/DefaultCameraPresets.java
@@ -6,95 +6,143 @@ import org.cloudburstmc.protocol.bedrock.data.camera.CameraPreset;
 import org.cloudburstmc.protocol.common.DefinitionRegistry;
 import org.cloudburstmc.protocol.common.NamedDefinition;
 import org.cloudburstmc.protocol.common.SimpleDefinitionRegistry;
+import org.powernukkitx.camera.CustomCameraDefinition;
+import org.powernukkitx.camera.CustomCameraRegistry;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
+ * Contains the built-in camera presets and the global camera preset registry.
+ *
  * @author Kaooot
  */
-public class DefaultCameraPresets {
+public final class DefaultCameraPresets {
 
     public static final CameraPreset FIRST_PERSON = CameraPreset.builder()
             .name("minecraft:first_person")
             .build();
+
     public static final CameraPreset FIXED_BOOM = CameraPreset.builder()
             .name("minecraft:fixed_boom")
             .viewOffset(Vector2f.ZERO)
             .entityOffset(Vector3f.ZERO)
             .build();
+
     public static final CameraPreset FOLLOW_ORBIT = CameraPreset.builder()
             .name("minecraft:follow_orbit")
             .viewOffset(Vector2f.ZERO)
             .entityOffset(Vector3f.ZERO)
             .radius(10.0f)
             .build();
+
     public static final CameraPreset FREE = CameraPreset.builder()
             .name("minecraft:free")
             .pos(Vector3f.ZERO)
             .pitch(0f)
             .yaw(0f)
             .build();
+
     public static final CameraPreset THIRD_PERSON = CameraPreset.builder()
             .name("minecraft:third_person")
             .build();
+
     public static final CameraPreset THIRD_PERSON_FRONT = CameraPreset.builder()
             .name("minecraft:third_person_front")
             .build();
 
-    /**
-     * The presets in the order they are sent to the client - a preset's runtime id is its index
-     * in this list, so the order has to stay in sync with the definitions below.
-     */
-    private static final List<CameraPreset> CAMERA_PRESETS = List.of(
-            FIRST_PERSON, FIXED_BOOM, FOLLOW_ORBIT, FREE, THIRD_PERSON, THIRD_PERSON_FRONT
-    );
-
-    private static final Map<String, NamedDefinition> DEFINITIONS_BY_NAME = new HashMap<>();
-
-    private static final DefinitionRegistry<NamedDefinition> DEFINITIONS;
+    private static final CustomCameraRegistry REGISTRY = new CustomCameraRegistry();
 
     static {
-        final SimpleDefinitionRegistry.Builder<NamedDefinition> builder = SimpleDefinitionRegistry.builder();
-        for (int runtimeId = 0; runtimeId < CAMERA_PRESETS.size(); runtimeId++) {
-            final NamedDefinition definition = new CameraPresetDefinition(CAMERA_PRESETS.get(runtimeId).getName(), runtimeId);
-            DEFINITIONS_BY_NAME.put(definition.getIdentifier(), definition);
-            builder.add(definition);
-        }
-        DEFINITIONS = builder.build();
+        REGISTRY.register(FIRST_PERSON);
+        REGISTRY.register(FIXED_BOOM);
+        REGISTRY.register(FOLLOW_ORBIT);
+        REGISTRY.register(FREE);
+        REGISTRY.register(THIRD_PERSON);
+        REGISTRY.register(THIRD_PERSON_FRONT);
     }
 
-    public static List<CameraPreset> getAll() {
-        return CAMERA_PRESETS;
+    private DefaultCameraPresets() {
     }
 
     /**
-     * The registry the codec helper needs to serialize a {@code CameraInstructionPacket}.
+     * Registers a custom camera preset.
+     *
+     * @param definition custom camera definition
+     * @return shared registered definition
+     */
+    public static NamedDefinition register(CustomCameraDefinition definition) {
+        return REGISTRY.register(definition);
+    }
+
+    /**
+     * Registers a camera preset directly.
+     *
+     * <p>Prefer {@link #register(CustomCameraDefinition)} for custom cameras.</p>
+     *
+     * @param preset camera preset
+     * @return shared registered definition
+     */
+    public static NamedDefinition register(CameraPreset preset) {
+        return REGISTRY.register(preset);
+    }
+
+    /**
+     * Returns all registered camera presets in runtime-ID order.
+     *
+     * @return immutable camera preset list
+     */
+    public static List<CameraPreset> getAll() {
+        return REGISTRY.getAll();
+    }
+
+    /**
+     * Returns the registry the codec helper uses to serialize camera instructions.
+     *
+     * @return camera definition registry
      */
     public static DefinitionRegistry<NamedDefinition> getDefinitions() {
-        return DEFINITIONS;
+        return REGISTRY.getDefinitions();
     }
 
     /**
-     * Looks up the definition of a preset by name. The instance is shared, which
-     * {@link SimpleDefinitionRegistry#isRegistered} relies on - it compares by reference.
+     * Looks up the shared definition of a camera preset by name.
      *
-     * @return the definition, or {@code null} when no preset carries that name
+     * <p>The returned instance must be reused in camera instructions because
+     * {@link SimpleDefinitionRegistry#isRegistered} compares definitions by reference.</p>
+     *
+     * @param name camera preset identifier
+     * @return shared definition, or {@code null} when not registered
      */
     public static NamedDefinition getDefinition(String name) {
-        return DEFINITIONS_BY_NAME.get(name);
+        return REGISTRY.getDefinition(name);
     }
 
-    private record CameraPresetDefinition(String identifier, int runtimeId) implements NamedDefinition {
-        @Override
-        public String getIdentifier() {
-            return this.identifier;
-        }
+    /**
+     * Looks up a shared camera definition by runtime ID.
+     *
+     * @param runtimeId camera runtime ID
+     * @return shared definition, or {@code null} when not registered
+     */
+    public static NamedDefinition getDefinition(int runtimeId) {
+        return REGISTRY.getDefinition(runtimeId);
+    }
 
-        @Override
-        public int getRuntimeId() {
-            return this.runtimeId;
-        }
+    /**
+     * Returns whether the camera preset is registered.
+     *
+     * @param identifier camera preset identifier
+     * @return {@code true} when registered
+     */
+    public static boolean contains(String identifier) {
+        return REGISTRY.contains(identifier);
+    }
+
+    /**
+     * Returns the number of registered camera presets.
+     *
+     * @return camera preset count
+     */
+    public static int size() {
+        return REGISTRY.size();
     }
 }

--- a/src/main/java/org/powernukkitx/utils/DefaultCameraPresets.java
+++ b/src/main/java/org/powernukkitx/utils/DefaultCameraPresets.java
@@ -7,7 +7,7 @@ import org.cloudburstmc.protocol.common.DefinitionRegistry;
 import org.cloudburstmc.protocol.common.NamedDefinition;
 import org.cloudburstmc.protocol.common.SimpleDefinitionRegistry;
 import org.powernukkitx.camera.CustomCameraDefinition;
-import org.powernukkitx.camera.CustomCameraRegistry;
+import org.powernukkitx.registry.Registries;
 
 import java.util.List;
 
@@ -50,15 +50,13 @@ public final class DefaultCameraPresets {
             .name("minecraft:third_person_front")
             .build();
 
-    private static final CustomCameraRegistry REGISTRY = new CustomCameraRegistry();
-
     static {
-        REGISTRY.register(FIRST_PERSON);
-        REGISTRY.register(FIXED_BOOM);
-        REGISTRY.register(FOLLOW_ORBIT);
-        REGISTRY.register(FREE);
-        REGISTRY.register(THIRD_PERSON);
-        REGISTRY.register(THIRD_PERSON_FRONT);
+        Registries.CAMERA.register(FIRST_PERSON);
+        Registries.CAMERA.register(FIXED_BOOM);
+        Registries.CAMERA.register(FOLLOW_ORBIT);
+        Registries.CAMERA.register(FREE);
+        Registries.CAMERA.register(THIRD_PERSON);
+        Registries.CAMERA.register(THIRD_PERSON_FRONT);
     }
 
     private DefaultCameraPresets() {
@@ -71,7 +69,7 @@ public final class DefaultCameraPresets {
      * @return shared registered definition
      */
     public static NamedDefinition register(CustomCameraDefinition definition) {
-        return REGISTRY.register(definition);
+        return Registries.CAMERA.register(definition);
     }
 
     /**
@@ -83,7 +81,7 @@ public final class DefaultCameraPresets {
      * @return shared registered definition
      */
     public static NamedDefinition register(CameraPreset preset) {
-        return REGISTRY.register(preset);
+        return Registries.CAMERA.register(preset);
     }
 
     /**
@@ -92,7 +90,7 @@ public final class DefaultCameraPresets {
      * @return immutable camera preset list
      */
     public static List<CameraPreset> getAll() {
-        return REGISTRY.getAll();
+        return Registries.CAMERA.getAll();
     }
 
     /**
@@ -101,7 +99,7 @@ public final class DefaultCameraPresets {
      * @return camera definition registry
      */
     public static DefinitionRegistry<NamedDefinition> getDefinitions() {
-        return REGISTRY.getDefinitions();
+        return Registries.CAMERA.getDefinitions();
     }
 
     /**
@@ -114,7 +112,7 @@ public final class DefaultCameraPresets {
      * @return shared definition, or {@code null} when not registered
      */
     public static NamedDefinition getDefinition(String name) {
-        return REGISTRY.getDefinition(name);
+        return Registries.CAMERA.getDefinition(name);
     }
 
     /**
@@ -124,7 +122,7 @@ public final class DefaultCameraPresets {
      * @return shared definition, or {@code null} when not registered
      */
     public static NamedDefinition getDefinition(int runtimeId) {
-        return REGISTRY.getDefinition(runtimeId);
+        return Registries.CAMERA.getDefinition(runtimeId);
     }
 
     /**
@@ -134,7 +132,7 @@ public final class DefaultCameraPresets {
      * @return {@code true} when registered
      */
     public static boolean contains(String identifier) {
-        return REGISTRY.contains(identifier);
+        return Registries.CAMERA.contains(identifier);
     }
 
     /**
@@ -143,6 +141,6 @@ public final class DefaultCameraPresets {
      * @return camera preset count
      */
     public static int size() {
-        return REGISTRY.size();
+        return Registries.CAMERA.size();
     }
 }


### PR DESCRIPTION
## What does this PR do?

Add CustomCameraDefinition and builder to allow developers easily create and register custom cameras presets.
This adds parity with BDS.

## Why?

No related problem.

Closes #

## Type of change

<!-- Tick what applies. -->

- [ ] Bug Fix
- [X] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** bc3f83bb1f530ed2ad9fab23a351f0c5efd6ebf0
- **Bedrock client version:** 26.33
- **Plugins loaded:** None

**Steps performed and results:**

```
DefaultCameraPresets.register(
                    CustomCameraDefinition.builder(SECURITY_CAMERA_ID)
                            .inheritFromFree()
                            .rotationSpeed(0.0f)
                            .snapToTarget(false)
                            .horizontalRotationLimit(0.0f, 360.0f)
                            .verticalRotationLimit(0.0f, 180.0f)
                            .continueTargeting(true)
                            .blockListeningRadius(50.0f)
                            .build()
            );
```

- [X] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
|   codex    |    javadocs          |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
