### PR TITLE
fix: prevent deadlock during async chunk loading of brewing stands and container block entities

### DIFF
--- a/src/main/java/org/powernukkitx/blockentity/BlockEntityBeehive.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntityBeehive.java
@@ -71,7 +71,11 @@ public class BlockEntityBeehive extends BlockEntity {
                 int honeyLevel = this.nbt.getByte("HoneyLevel");
                 beehive.setBlockFace(beehive.getBlockFace());
                 beehive.setHoneyLevel(honeyLevel);
-                beehive.getLevel().setBlock(beehive, beehive, true, true);
+                if (this.chunk != null) {
+                    this.chunk.setBlockState(this.getFloorX() & 0x0f, this.getFloorY(), this.getFloorZ() & 0x0f, beehive.getBlockState());
+                } else if (this.isValid()) {
+                    this.level.setBlockStateAt(this.getFloorX(), this.getFloorY(), this.getFloorZ(), beehive.getBlockState());
+                }
             }
             this.nbt.remove("HoneyLevel");
         }

--- a/src/main/java/org/powernukkitx/blockentity/BlockEntityBeehive.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntityBeehive.java
@@ -73,8 +73,6 @@ public class BlockEntityBeehive extends BlockEntity {
                 beehive.setHoneyLevel(honeyLevel);
                 if (this.chunk != null) {
                     this.chunk.setBlockState(this.getFloorX() & 0x0f, this.getFloorY(), this.getFloorZ() & 0x0f, beehive.getBlockState());
-                } else if (this.isValid()) {
-                    this.level.setBlockStateAt(this.getFloorX(), this.getFloorY(), this.getFloorZ(), beehive.getBlockState());
                 }
             }
             this.nbt.remove("HoneyLevel");
@@ -89,18 +87,6 @@ public class BlockEntityBeehive extends BlockEntity {
             occupantsTag.add(occupant.saveNBT());
         }
         this.nbt.putList("Occupants", occupantsTag);
-
-        // Backward compatibility
-        if (this.nbt.contains("HoneyLevel")) {
-            Block block = getBlock();
-            if (block instanceof BlockBeehive beehive) {
-                int honeyLevel = this.nbt.getByte("HoneyLevel");
-                beehive.setBlockFace(beehive.getBlockFace());
-                beehive.setHoneyLevel(honeyLevel);
-                beehive.getLevel().setBlock(beehive, beehive, true, true);
-            }
-            this.nbt.remove("HoneyLevel");
-        }
     }
 
     public int getHoneyLevel() {

--- a/src/main/java/org/powernukkitx/blockentity/BlockEntityBrewingStand.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntityBrewingStand.java
@@ -57,7 +57,7 @@ public class BlockEntityBrewingStand extends BlockEntitySpawnable implements Rec
         }
 
         for (int i = 0; i < getSize(); i++) {
-            inventory.setItem(i, this.getItem(i));
+            inventory.setItemInternal(i, this.getItem(i));
         }
 
         final CompoundTag nbtMap = this.getNbt();

--- a/src/main/java/org/powernukkitx/blockentity/BlockEntityCampfire.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntityCampfire.java
@@ -48,7 +48,7 @@ public class BlockEntityCampfire extends BlockEntitySpawnable implements BlockEn
             keepItem[i - 1] = nbtMap.getBoolean("KeepItem" + 1);
 
             if (this.nbt.contains("Item" + i) && this.nbt.get("Item" + i) instanceof CompoundTag itemNBT) {
-                inventory.setItem(i - 1, ItemHelper.read(itemNBT));
+                inventory.setItemInternal(i - 1, ItemHelper.read(itemNBT));
             }
         }
     }

--- a/src/main/java/org/powernukkitx/blockentity/BlockEntityEjectable.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntityEjectable.java
@@ -33,7 +33,7 @@ public abstract class BlockEntityEjectable extends BlockEntitySpawnable implemen
         }
 
         for (int i = 0; i < this.getSize(); i++) {
-            this.inventory.setItem(i, this.getItem(i));
+            this.inventory.setItemInternal(i, this.getItem(i));
         }
     }
 

--- a/src/main/java/org/powernukkitx/blockentity/BlockEntityFurnace.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntityFurnace.java
@@ -64,7 +64,7 @@ public class BlockEntityFurnace extends BlockEntitySpawnable implements RecipeIn
         }
 
         for (int i = 0; i < this.getSize(); i++) {
-            this.inventory.setItem(i, this.getItem(i));
+            this.inventory.setItemInternal(i, this.getItem(i));
         }
 
         final CompoundTag nbtMap = getNbt();

--- a/src/main/java/org/powernukkitx/blockentity/BlockEntityHopper.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntityHopper.java
@@ -85,7 +85,7 @@ public class BlockEntityHopper extends BlockEntitySpawnable implements BlockEnti
         }
 
         for (int i = 0; i < this.getSize(); i++) {
-            this.inventory.setItem(i, this.getItem(i));
+            this.inventory.setItemInternal(i, this.getItem(i));
         }
 
         this.pickupArea = generatePickupArea();

--- a/src/main/java/org/powernukkitx/blockentity/BlockEntityShelf.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntityShelf.java
@@ -31,6 +31,7 @@ public class BlockEntityShelf extends BlockEntitySpawnableContainer {
 
         ListTag<CompoundTag> itemsTag = this.getNbt().getList("Items", CompoundTag.class);
         for (int i = 0; i < itemsTag.size(); i++) {
+            if (i >= this.getSize()) break;
             this.inventory.setItemInternal(i, ItemHelper.read(itemsTag.get(i)));
         }
         this.scheduleComparatorOutputUpdate();

--- a/src/main/java/org/powernukkitx/blockentity/BlockEntityShelf.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntityShelf.java
@@ -31,7 +31,7 @@ public class BlockEntityShelf extends BlockEntitySpawnableContainer {
 
         ListTag<CompoundTag> itemsTag = this.getNbt().getList("Items", CompoundTag.class);
         for (int i = 0; i < itemsTag.size(); i++) {
-            this.inventory.setItem(i, ItemHelper.read(itemsTag.get(i)));
+            this.inventory.setItemInternal(i, ItemHelper.read(itemsTag.get(i)));
         }
         this.scheduleComparatorOutputUpdate();
     }

--- a/src/test/java/org/powernukkitx/ServerMockFixture.java
+++ b/src/test/java/org/powernukkitx/ServerMockFixture.java
@@ -191,12 +191,13 @@ public final class ServerMockFixture {
                 1, LevelDBProvider.class,
                 new LevelConfig.GeneratorConfig("flat", 114514L, false, LevelConfig.AntiXrayMode.LOW,
                         true, DimensionEnum.OVERWORLD.getDimensionData(), new HashMap<>()));
-        level.initLevel();
 
         HashMap<Integer, Level> levels = new HashMap<>();
         levels.put(1, level);
         doReturn(levels).when(server).getLevels();
         doReturn(level).when(server).getDefaultLevel();
+        
+        level.initLevel();
     }
 
     /** Force class-load / static-init. */

--- a/src/test/java/org/powernukkitx/blockentity/BlockEntityNbtLoadTest.java
+++ b/src/test/java/org/powernukkitx/blockentity/BlockEntityNbtLoadTest.java
@@ -4,17 +4,22 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.powernukkitx.ServerMockFixture;
+import org.powernukkitx.block.Block;
+import org.powernukkitx.block.BlockID;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.level.Position;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.nbt.tag.ListTag;
+import org.powernukkitx.utils.ItemHelper;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class BlockEntityNbtLoadTest {
 
     static Level level;
-    static int testX = 1000;
+    static AtomicInteger testX = new AtomicInteger(1000);
 
     @BeforeAll
     static void boot() {
@@ -31,7 +36,7 @@ public class BlockEntityNbtLoadTest {
 
     @Test
     void brewingStandNbtLoadDoesNotTriggerSetBlock() {
-        Position pos = new Position(testX++, 80, 100, level);
+        Position pos = new Position(testX.getAndIncrement(), 80, 100, level);
         CompoundTag nbt = BlockEntity.getDefaultCompound(pos, BlockEntityID.BREWING_STAND);
         ListTag<CompoundTag> items = new ListTag<>();
         CompoundTag potionItem = new CompoundTag()
@@ -52,7 +57,7 @@ public class BlockEntityNbtLoadTest {
 
     @Test
     void furnaceNbtLoadDoesNotTriggerSetBlock() {
-        Position pos = new Position(testX++, 80, 100, level);
+        Position pos = new Position(testX.getAndIncrement(), 80, 100, level);
         CompoundTag nbt = BlockEntity.getDefaultCompound(pos, BlockEntityID.FURNACE);
         ListTag<CompoundTag> items = new ListTag<>();
         CompoundTag coalItem = new CompoundTag()
@@ -66,37 +71,86 @@ public class BlockEntityNbtLoadTest {
         IChunk chunk = getLoadedChunk(pos);
         BlockEntityFurnace be = new BlockEntityFurnace(chunk, nbt);
         Assertions.assertNotNull(be.getInventory());
+        Assertions.assertFalse(be.getInventory().getItem(1).isNull());
         be.close();
     }
 
     @Test
     void hopperNbtLoadDoesNotTriggerSetBlock() {
-        Position pos = new Position(testX++, 80, 100, level);
+        Position pos = new Position(testX.getAndIncrement(), 80, 100, level);
         CompoundTag nbt = BlockEntity.getDefaultCompound(pos, BlockEntityID.HOPPER);
+        ListTag<CompoundTag> items = new ListTag<>();
+        items.add(ItemHelper.write(Item.get("minecraft:stone"), 0));
+        nbt.putList("Items", items);
         IChunk chunk = getLoadedChunk(pos);
         BlockEntityHopper be = new BlockEntityHopper(chunk, nbt);
         Assertions.assertNotNull(be.getInventory());
+        Assertions.assertFalse(be.getInventory().getItem(0).isNull());
         be.close();
     }
 
     @Test
     void campfireNbtLoadDoesNotTriggerSetBlock() {
-        Position pos = new Position(testX++, 80, 100, level);
+        Position pos = new Position(testX.getAndIncrement(), 80, 100, level);
         CompoundTag nbt = BlockEntity.getDefaultCompound(pos, BlockEntityID.CAMPFIRE);
+        Item stone = Item.get("minecraft:stone");
+        stone.setCount(1);
+        CompoundTag item1 = ItemHelper.write(stone);
+        nbt.putCompound("Item1", item1);
+        nbt.putInt("ItemTime1", 100);
         IChunk chunk = getLoadedChunk(pos);
-        BlockEntityCampfire be = new BlockEntityCampfire(chunk, nbt);
+        BlockEntity be = BlockEntity.createBlockEntity(BlockEntityID.CAMPFIRE, chunk, nbt);
+        if (be instanceof BlockEntityCampfire campfire) {
+            Assertions.assertNotNull(campfire.getInventory());
+            Assertions.assertFalse(campfire.getInventory().getItem(0).isNull());
+            campfire.close();
+        }
+    }
+
+    @Test
+    void shelfNbtLoadDoesNotTriggerSetBlock() {
+        Position pos = new Position(testX.getAndIncrement(), 80, 100, level);
+        CompoundTag nbt = BlockEntity.getDefaultCompound(pos, BlockEntityID.SHELF);
+        ListTag<CompoundTag> items = new ListTag<>();
+        Item book = Item.get("minecraft:book");
+        book.setCount(1);
+        items.add(ItemHelper.write(book));
+        nbt.putList("Items", items);
+        IChunk chunk = getLoadedChunk(pos);
+        BlockEntityShelf be = new BlockEntityShelf(chunk, nbt);
         Assertions.assertNotNull(be.getInventory());
+        Assertions.assertFalse(be.getInventory().getItem(0).isNull(), "Shelf slot 0 item should be loaded");
         be.close();
     }
 
     @Test
     void beehiveNbtLoadWithLegacyHoneyLevel() {
-        Position pos = new Position(testX++, 80, 100, level);
+        Position pos = new Position(testX.getAndIncrement(), 80, 100, level);
+        IChunk chunk = getLoadedChunk(pos);
+        chunk.setBlockState(pos.getFloorX() & 0x0f, pos.getFloorY(), pos.getFloorZ() & 0x0f, Block.get(BlockID.BEEHIVE).getBlockState());
+
         CompoundTag nbt = BlockEntity.getDefaultCompound(pos, BlockEntityID.BEEHIVE);
         nbt.putByte("HoneyLevel", (byte) 3);
-        IChunk chunk = getLoadedChunk(pos);
         BlockEntityBeehive be = new BlockEntityBeehive(chunk, nbt);
         Assertions.assertFalse(nbt.contains("HoneyLevel"), "Legacy HoneyLevel NBT tag should be removed after load");
         be.close();
+    }
+
+    @Test
+    void shelfNbtLoadIgnoresOutOfBoundsItems() {
+        Position pos = new Position(testX.getAndIncrement(), 80, 100, level);
+        CompoundTag nbt = BlockEntity.getDefaultCompound(pos, BlockEntityID.SHELF);
+        ListTag<CompoundTag> items = new ListTag<>();
+        Item book = Item.get("minecraft:book");
+        book.setCount(1);
+        for (int i = 0; i < 10; i++) {
+            items.add(ItemHelper.write(book));
+        }
+        nbt.putList("Items", items);
+        IChunk chunk = getLoadedChunk(pos);
+        BlockEntityShelf be = new BlockEntityShelf(chunk, nbt);
+        Assertions.assertNotNull(be.getInventory());
+        Assertions.assertFalse(be.getInventory().getItem(0).isNull());
+        be.close(); // Should not throw exception or pollute out of bounds
     }
 }

--- a/src/test/java/org/powernukkitx/blockentity/BlockEntityNbtLoadTest.java
+++ b/src/test/java/org/powernukkitx/blockentity/BlockEntityNbtLoadTest.java
@@ -1,0 +1,102 @@
+package org.powernukkitx.blockentity;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.powernukkitx.ServerMockFixture;
+import org.powernukkitx.item.Item;
+import org.powernukkitx.level.Level;
+import org.powernukkitx.level.Position;
+import org.powernukkitx.level.format.IChunk;
+import org.powernukkitx.nbt.tag.CompoundTag;
+import org.powernukkitx.nbt.tag.ListTag;
+
+public class BlockEntityNbtLoadTest {
+
+    static Level level;
+    static int testX = 1000;
+
+    @BeforeAll
+    static void boot() {
+        ServerMockFixture.boot();
+        level = ServerMockFixture.level;
+    }
+
+    private IChunk getLoadedChunk(Position pos) {
+        int chunkX = pos.getFloorX() >> 4;
+        int chunkZ = pos.getFloorZ() >> 4;
+        level.loadChunk(chunkX, chunkZ);
+        return level.getChunk(chunkX, chunkZ);
+    }
+
+    @Test
+    void brewingStandNbtLoadDoesNotTriggerSetBlock() {
+        Position pos = new Position(testX++, 80, 100, level);
+        CompoundTag nbt = BlockEntity.getDefaultCompound(pos, BlockEntityID.BREWING_STAND);
+        ListTag<CompoundTag> items = new ListTag<>();
+        CompoundTag potionItem = new CompoundTag()
+                .putByte("Slot", (byte) 1)
+                .putString("Name", "minecraft:potion")
+                .putShort("Damage", (short) 0)
+                .putByte("Count", (byte) 1);
+        items.add(potionItem);
+        nbt.putList("Items", items);
+
+        IChunk chunk = getLoadedChunk(pos);
+        BlockEntityBrewingStand be = new BlockEntityBrewingStand(chunk, nbt);
+        Assertions.assertNotNull(be.getInventory());
+        Item loadedSlot1 = be.getInventory().getItem(1);
+        Assertions.assertFalse(loadedSlot1.isNull(), "Slot 1 item should be loaded from NBT");
+        be.close();
+    }
+
+    @Test
+    void furnaceNbtLoadDoesNotTriggerSetBlock() {
+        Position pos = new Position(testX++, 80, 100, level);
+        CompoundTag nbt = BlockEntity.getDefaultCompound(pos, BlockEntityID.FURNACE);
+        ListTag<CompoundTag> items = new ListTag<>();
+        CompoundTag coalItem = new CompoundTag()
+                .putByte("Slot", (byte) 1)
+                .putString("Name", "minecraft:coal")
+                .putShort("Damage", (short) 0)
+                .putByte("Count", (byte) 1);
+        items.add(coalItem);
+        nbt.putList("Items", items);
+
+        IChunk chunk = getLoadedChunk(pos);
+        BlockEntityFurnace be = new BlockEntityFurnace(chunk, nbt);
+        Assertions.assertNotNull(be.getInventory());
+        be.close();
+    }
+
+    @Test
+    void hopperNbtLoadDoesNotTriggerSetBlock() {
+        Position pos = new Position(testX++, 80, 100, level);
+        CompoundTag nbt = BlockEntity.getDefaultCompound(pos, BlockEntityID.HOPPER);
+        IChunk chunk = getLoadedChunk(pos);
+        BlockEntityHopper be = new BlockEntityHopper(chunk, nbt);
+        Assertions.assertNotNull(be.getInventory());
+        be.close();
+    }
+
+    @Test
+    void campfireNbtLoadDoesNotTriggerSetBlock() {
+        Position pos = new Position(testX++, 80, 100, level);
+        CompoundTag nbt = BlockEntity.getDefaultCompound(pos, BlockEntityID.CAMPFIRE);
+        IChunk chunk = getLoadedChunk(pos);
+        BlockEntityCampfire be = new BlockEntityCampfire(chunk, nbt);
+        Assertions.assertNotNull(be.getInventory());
+        be.close();
+    }
+
+    @Test
+    void beehiveNbtLoadWithLegacyHoneyLevel() {
+        Position pos = new Position(testX++, 80, 100, level);
+        CompoundTag nbt = BlockEntity.getDefaultCompound(pos, BlockEntityID.BEEHIVE);
+        nbt.putByte("HoneyLevel", (byte) 3);
+        IChunk chunk = getLoadedChunk(pos);
+        BlockEntityBeehive be = new BlockEntityBeehive(chunk, nbt);
+        Assertions.assertFalse(nbt.contains("HoneyLevel"), "Legacy HoneyLevel NBT tag should be removed after load");
+        be.close();
+    }
+}


### PR DESCRIPTION
## What does this PR do?
Fixes a deadlock during async chunk loading by populating container block entities via `setItemInternal` rather than emitting synchronous world modifications. Also updated the legacy migration logic in `BlockEntityBeehive.loadNBT()` to update the block state directly.

## Why?
During `Level.getChunkAsync`, `Chunk.initChunk()` runs on an async worker thread while holding the `Chunk` monitor lock. Instantiating `BlockEntityBrewingStand` (and other block entites) previously called `inventory.setItem()` which triggered `onSlotChange` -> `updateBlock()` -> `Level.setBlock()`. This attempted to lock `Level.changedBlocks` which was held by the main thread in `Level.doTick()` causing a deadlock.

## Type of change

<!-- Tick what applies. -->

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** bc3f83bb1f530ed2ad9fab23a351f0c5efd6ebf0
- **Bedrock client version:** 26.33
- **Plugins loaded:** Multi-module closed-source Prison project

**Steps performed and results:**

Currently testing in production. Will report when any issues occur.

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem ~~and confirmed this fixes it (bug fixes)~~
- [x] Existing unit tests pass (`gradlew test`)
- [x] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
| Gemini 3.6 Flash (High) |  Root cause investigation, unit test creation (`BlockEntityNbtLoadTest.java`), implementation suggestion, commit message |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] ~~Public API additions/changes have Javadoc~~
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] ~~"Allow maintainer edits" is enabled~~
