### PR TITLE
fix: prevent campfire slots from copying slot 1's KeepItem state on chunk load

### DIFF
--- a/src/main/java/org/powernukkitx/blockentity/BlockEntityCampfire.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntityCampfire.java
@@ -126,7 +126,7 @@ public class BlockEntityCampfire extends BlockEntitySpawnable implements BlockEn
         super.saveNBT();
         for (int i = 1; i <= burnTime.length; i++) {
             Item item = inventory.getItem(i - 1);
-            if (item == null || item.getId() == BlockID.AIR || item.getCount() <= 0) {
+            if (item.isNull()) {
                 this.nbt.remove("Item" + i);
                 this.nbt.remove("KeepItem" + i);
                 this.nbt.putInt("ItemTime" + i, 0);
@@ -196,7 +196,7 @@ public class BlockEntityCampfire extends BlockEntitySpawnable implements BlockEn
 
     @Override
     public boolean isBlockEntityValid() {
-        return getBlock().getId() == BlockID.CAMPFIRE;
+        return getBlock().getId().equals(BlockID.CAMPFIRE);
     }
 
     public int getSize() {

--- a/src/main/java/org/powernukkitx/blockentity/BlockEntityCampfire.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntityCampfire.java
@@ -45,7 +45,7 @@ public class BlockEntityCampfire extends BlockEntitySpawnable implements BlockEn
         final CompoundTag nbtMap = getNbt();
         for (int i = 1; i <= burnTime.length; i++) {
             burnTime[i - 1] = nbtMap.getInt("ItemTime" + i);
-            keepItem[i - 1] = nbtMap.getBoolean("KeepItem" + 1);
+            keepItem[i - 1] = nbtMap.getBoolean("KeepItem" + i);
 
             if (this.nbt.contains("Item" + i) && this.nbt.get("Item" + i) instanceof CompoundTag itemNBT) {
                 inventory.setItem(i - 1, ItemHelper.read(itemNBT));


### PR DESCRIPTION
<!--
  Read CONTRIBUTING.md before submitting:
  https://github.com/PowerNukkitX/PowerNukkitX/blob/master/CONTRIBUTING.md

  PRs that leave this template unfilled, or fill it with generated filler,
  are closed without review. Delete the HTML comments as you go.

  SECURITY: never report a vulnerability in a public PR. See SECURITY.md.
-->

## What does this PR do and why?

Fixes a bug where `KeepItem` state was not preserved on chunk reload. Additionally, simplified if-statement in `saveNBT()` and matched style of `isBlockEntityValid()` with similar implementations.

## Type of change

<!-- Tick what applies. -->

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** 170a050cdd93b28ef44cd29dac8b87a03a229ca5
- **Bedrock client version:** 26.33
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
| Claude Opus 5 | Flagged this bug |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [ ] The PR is one logical change, with no unrelated reformatting or refactors - no, but that was intentional
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
