### PR TITLE
fix: spawn egg spawns on top of clicked block instead of clicked face

### DIFF
--- a/src/main/java/org/powernukkitx/item/ItemCustomEntitySpawnEgg.java
+++ b/src/main/java/org/powernukkitx/item/ItemCustomEntitySpawnEgg.java
@@ -11,6 +11,7 @@ import org.powernukkitx.level.Location;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.level.vibration.VibrationEvent;
 import org.powernukkitx.level.vibration.VibrationType;
+import org.powernukkitx.math.AxisAlignedBB;
 import org.powernukkitx.math.BlockFace;
 import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.nbt.tag.DoubleTag;
@@ -89,9 +90,12 @@ public class ItemCustomEntitySpawnEgg extends Item implements SpawnEggPickable {
             return false;
         }
 
-        double spawnY = (target.getBoundingBox() == null) ? block.getY() : target.getBoundingBox().getMaxY() + 0.0001d;
-        double spawnX = target.getX() + fx;
-        double spawnZ = target.getZ() + fz;
+        AxisAlignedBB boundingBox = target.getBoundingBox();
+        double spawnY = (face == BlockFace.UP && boundingBox != null)
+            ? boundingBox.getMaxY() + 0.0001d
+            : block.getY() + 0.0001d;
+        double spawnX = block.getX() + 0.5d;
+        double spawnZ = block.getZ() + 0.5d;
         Location loc = new Location(spawnX, spawnY, spawnZ, 0f, 0f, level);
 
         if (player != null) {

--- a/src/main/java/org/powernukkitx/item/ItemSpawnEgg.java
+++ b/src/main/java/org/powernukkitx/item/ItemSpawnEgg.java
@@ -67,7 +67,9 @@ public class ItemSpawnEgg extends Item implements SpawnEggPickable {
     public boolean onActivate(Level level, Player player, Block block, Block target, BlockFace face, double fx, double fy, double fz) {
         if (player.isAdventure()) return false;
 
-        double spawnY = block.getY() + 0.0001d;
+        double spawnY = (face == BlockFace.UP && target.getBoundingBox() != null)
+            ? target.getBoundingBox().getMaxY() + 0.0001d
+            : block.getY() + 0.0001d;
         double spawnX = block.getX() + 0.5d;
         double spawnZ = block.getZ() + 0.5d;
         Location loc = new Location(spawnX, spawnY, spawnZ, 0f, 0f, level).setYawFacing(player);

--- a/src/main/java/org/powernukkitx/item/ItemSpawnEgg.java
+++ b/src/main/java/org/powernukkitx/item/ItemSpawnEgg.java
@@ -67,9 +67,11 @@ public class ItemSpawnEgg extends Item implements SpawnEggPickable {
     public boolean onActivate(Level level, Player player, Block block, Block target, BlockFace face, double fx, double fy, double fz) {
         if (player.isAdventure()) return false;
 
-        double spawnY = (target.getBoundingBox() == null) ? block.getY() : target.getBoundingBox().getMaxY() + 0.0001d;
-        double spawnX = target.getX() + fx;
-        double spawnZ = target.getZ() + fz;
+        double spawnY = (face == BlockFace.UP && target.getBoundingBox() != null)
+            ? target.getBoundingBox().getMaxY() + 0.0001d
+            : block.getY();
+        double spawnX = block.getX() + 0.5;
+        double spawnZ = block.getZ() + 0.5;
         Location loc = new Location(spawnX, spawnY, spawnZ, 0f, 0f, level).setYawFacing(player);
 
         IChunk chunk = level.getChunk((int) Math.floor(loc.getX()) >> 4, (int) Math.floor(loc.getZ()) >> 4);

--- a/src/main/java/org/powernukkitx/item/ItemSpawnEgg.java
+++ b/src/main/java/org/powernukkitx/item/ItemSpawnEgg.java
@@ -10,6 +10,7 @@ import org.powernukkitx.level.Location;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.level.vibration.VibrationEvent;
 import org.powernukkitx.level.vibration.VibrationType;
+import org.powernukkitx.math.AxisAlignedBB;
 import org.powernukkitx.math.BlockFace;
 import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.nbt.tag.DoubleTag;
@@ -67,8 +68,9 @@ public class ItemSpawnEgg extends Item implements SpawnEggPickable {
     public boolean onActivate(Level level, Player player, Block block, Block target, BlockFace face, double fx, double fy, double fz) {
         if (player.isAdventure()) return false;
 
-        double spawnY = (face == BlockFace.UP && target.getBoundingBox() != null)
-            ? target.getBoundingBox().getMaxY() + 0.0001d
+        AxisAlignedBB boundingBox = target.getBoundingBox();
+        double spawnY = (face == BlockFace.UP && boundingBox != null)
+            ? boundingBox.getMaxY() + 0.0001d
             : block.getY() + 0.0001d;
         double spawnX = block.getX() + 0.5d;
         double spawnZ = block.getZ() + 0.5d;


### PR DESCRIPTION
<!--
  Read CONTRIBUTING.md before submitting:
  https://github.com/PowerNukkitX/PowerNukkitX/blob/master/CONTRIBUTING.md

  PRs that leave this template unfilled, or fill it with generated filler,
  are closed without review. Delete the HTML comments as you go.

  SECURITY: never report a vulnerability in a public PR. See SECURITY.md.
-->

## What does this PR do?

Fixes the spawn position of entities spawned via spawn egg.

## Why?

<!-- What problem does this solve? Link the issue: Closes #123 -->

## Type of change

<!-- Tick what applies. -->

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** <!-- commit hash -->
- **Bedrock client version:** <!-- e.g. 1.21.x -->
- **Plugins loaded:** <!-- none / list them -->

**Steps performed and results:**

1.
2.

- [x] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
|       |             |

- [ ] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [ ] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [ ] My change follows the existing code style
- [ ] The PR is one logical change, with no unrelated reformatting or refactors
- [ ] Public API additions/changes have Javadoc
- [ ] No dead code, commented-out blocks, or debug logging left behind
- [ ] Commit messages follow Conventional Commits
- [ ] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [ ] "Allow maintainer edits" is enabled