### PR TITLE
fix: Minimum limit to add item enchantment type in custom items

### DIFF
--- a/src/main/java/org/powernukkitx/item/customitem/CustomItemDefinition.java
+++ b/src/main/java/org/powernukkitx/item/customitem/CustomItemDefinition.java
@@ -498,7 +498,7 @@ public record CustomItemDefinition(String identifier, CompoundTag nbt) implement
          * builder.enchantable("pickaxe", 20);
          * </pre>
          * @param slot {@link ItemEnchantSlot} slot ID of the enchantable item
-         * @param value int value, can be 0 if you enchant over API, must be >= 1 if you use Anvil
+         * @param value int value, minimum of 0
          */
         public SimpleBuilder enchantable(ItemEnchantSlot slot, int value) {
             if (value < 0) value = 0;
@@ -515,11 +515,11 @@ public record CustomItemDefinition(String identifier, CompoundTag nbt) implement
          * builder.enchantable("pickaxe", 20);
          * </pre>
          * @param slot string slot ID of the enchantable item
-         * @param value int value, can be 0 if you enchant over API, must be >= 1 if you use Anvil
+         * @param value int value, minimum of 0
          */
         public SimpleBuilder enchantable(String slot, int value) {
             if (slot == null || slot.isBlank()) return this;
-            if (value <= 0) return this;
+            if (value < 0) return this;
             if (value > 255) value = 255;
 
             CompoundTag itemProps = ensureItemProperties();


### PR DESCRIPTION
## What does this PR do?

Fix the minimum limit to add item enchantment type, this would break items type methods for custom items (isSword, isAxe, isPickaxe, etc)

## Why?

Defining items with enchantment value of 0 is possible on BDS, on PNX was being returned earlier, items with value 0 get out of sync damage bar and also do not work with methods like isSword() where it test which type the item is.

Closes #

## Type of change

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 170a050cdd93b28ef44cd29dac8b87a03a229ca5
- **Bedrock client version:** 26.33
- **Plugins loaded:** none

**Steps performed and results:**

1. Define a item with enchanting type and set value to 0
2. Use the item until it get damaged, you will not see the damage bar, and while holding the item it will also disappear

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
|    none   |    none         |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
