### PR TITLE
fix: Items not breakable that could be enchanted with unbreakable

### DIFF
--- a/src/main/java/org/powernukkitx/item/customitem/CustomItemDefinition.java
+++ b/src/main/java/org/powernukkitx/item/customitem/CustomItemDefinition.java
@@ -1829,7 +1829,7 @@ public record CustomItemDefinition(String identifier, CompoundTag nbt) implement
     public int maxDurability() {
         return hasComponent("minecraft:durability") ?
                 getComponent("minecraft:durability").getInt("max_durability")
-                : 0;
+                : -1;
     }
 
     public int damageChanceMin() {


### PR DESCRIPTION
## What does this PR do?

Fix items not breakable that could be enchanted with unbreakable

## Why?

The custom item definition was returning 0 when no component was defined, allowing the canAddEnchantment() to pass true allowing the item to be enchanted with some enchantments types such as:

- Unbreaking
- Mending
- Curse of Vanishing

Closes #

## Type of change

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** a7c50e9ba8beb3bba84f4e3d4fab53cdbe956bf2
- **Bedrock client version:** 26.33
- **Plugins loaded:** none

**Steps performed and results:**

1. Using APIs try to enchant a custom item without durability defined.

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
|       |             |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [ ] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
