### PR TITLE
fix: NPE in player inventory

### DIFF
--- a/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
@@ -43,7 +43,7 @@ public class PlayerAuthInputHandler implements PacketHandler<PlayerAuthInputPack
     @Override
     public void handle(PlayerAuthInputPacket packet, PlayerSessionHolder holder, Server server) {
         final Player player = holder.getPlayer();
-        if (player == null || !player.spawned) {
+        if (player == null) {
             return;
         }
 

--- a/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
@@ -43,6 +43,10 @@ public class PlayerAuthInputHandler implements PacketHandler<PlayerAuthInputPack
     @Override
     public void handle(PlayerAuthInputPacket packet, PlayerSessionHolder holder, Server server) {
         final Player player = holder.getPlayer();
+        if (player == null || !player.spawned) {
+            return;
+        }
+
         Vector3f pos = Vector3f.fromNetwork(packet.getPosition());
         Vector3f rot = Vector3f.fromNetwork(packet.getPosition());
         if (!Float.isFinite(pos.getX()) || !Float.isFinite(pos.getY()) || !Float.isFinite(pos.getZ()) || !Float.isFinite(rot.getX()) || !Float.isFinite(rot.getY()) || !Float.isFinite(rot.getZ())) {


### PR DESCRIPTION
## What does this PR do?

fix a npe inventory

## Why?

prevents a npe when the player inventory is null

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** e3babffa2
- **Bedrock client version:** 26.30
- **Plugins loaded:** NONE

**Steps performed and results:**

1. join server
2. triggered the inventory code path that previously caused the npe
3. confirmed that the server no longer throws an exception and continues to operate normally

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

- [X]  The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X]  Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
