### PR TITLE
fix: command parser and teleport command by matching BDS behavior

### DIFF
--- a/src/main/java/org/powernukkitx/command/SimpleCommandMap.java
+++ b/src/main/java/org/powernukkitx/command/SimpleCommandMap.java
@@ -354,6 +354,11 @@ public class SimpleCommandMap implements CommandMap {
      * @return the array of arguments
      */
     public static ArrayList<String> parseArguments(String cmdLine) {
+        ArrayList<String> args = parseArguments(cmdLine, true);
+        return args != null ? args : parseArguments(cmdLine, false);
+    }
+
+    private static ArrayList<String> parseArguments(String cmdLine, boolean groupSquareBrackets) {
         StringBuilder sb = new StringBuilder(cmdLine);
         ArrayList<String> args = new ArrayList<>();
         boolean notQuoted = true;
@@ -372,10 +377,12 @@ public class SimpleCommandMap implements CommandMap {
                 }
             }
             if (curlyBraceCount == 0) {
-                if (sb.charAt(i) == '[' && notQuoted) {
-                    squareBracketCount++;
-                } else if (sb.charAt(i) == ']' && notQuoted && squareBracketCount > 0) {
-                    squareBracketCount--;
+                if (groupSquareBrackets && notQuoted) {
+                    if (sb.charAt(i) == '[') {
+                        squareBracketCount++;
+                    } else if (sb.charAt(i) == ']' && squareBracketCount > 0) {
+                        squareBracketCount--;
+                    }
                 }
 
                 if (sb.charAt(i) == ' ' && notQuoted && squareBracketCount == 0) {
@@ -390,6 +397,10 @@ public class SimpleCommandMap implements CommandMap {
                     notQuoted = !notQuoted;
                 }
             }
+        }
+
+        if (squareBracketCount != 0) {
+            return null;
         }
 
         String arg = sb.substring(start);

--- a/src/main/java/org/powernukkitx/command/SimpleCommandMap.java
+++ b/src/main/java/org/powernukkitx/command/SimpleCommandMap.java
@@ -358,6 +358,7 @@ public class SimpleCommandMap implements CommandMap {
         ArrayList<String> args = new ArrayList<>();
         boolean notQuoted = true;
         int curlyBraceCount = 0;
+        int squareBracketCount = 0;
         int start = 0;
 
         for (int i = 0; i < sb.length(); i++) {
@@ -371,7 +372,13 @@ public class SimpleCommandMap implements CommandMap {
                 }
             }
             if (curlyBraceCount == 0) {
-                if (sb.charAt(i) == ' ' && notQuoted) {
+                if (sb.charAt(i) == '[' && notQuoted) {
+                    squareBracketCount++;
+                } else if (sb.charAt(i) == ']' && notQuoted && squareBracketCount > 0) {
+                    squareBracketCount--;
+                }
+
+                if (sb.charAt(i) == ' ' && notQuoted && squareBracketCount == 0) {
                     String arg = sb.substring(start, i);
                     if (!arg.isEmpty()) {
                         args.add(arg);

--- a/src/main/java/org/powernukkitx/command/defaults/LocateCommand.java
+++ b/src/main/java/org/powernukkitx/command/defaults/LocateCommand.java
@@ -7,7 +7,6 @@ import org.powernukkitx.command.tree.ParamList;
 import org.powernukkitx.command.utils.CommandLogger;
 import org.powernukkitx.level.Location;
 import org.powernukkitx.level.Position;
-import org.powernukkitx.level.biome.BiomeID;
 import org.powernukkitx.level.generator.biome.result.BiomeResult;
 import org.powernukkitx.level.generator.biome.result.OverworldBiomeResult;
 import org.powernukkitx.level.generator.populator.generic.PopulatorRuinedPortal;
@@ -129,17 +128,15 @@ public class LocateCommand extends VanillaCommand {
                     found = findBiomePosition(pos, maxRadius, biomeId);
                 }
 
-                if(found != null) {
+                if (found != null) {
                     found.setY(pos.getLevel().getHeightMap(pos.getFloorX(), pos.getFloorZ()) + 16);
                     String _x = String.valueOf(found.getFloorX());
                     String _y = String.valueOf(found.getFloorY());
                     String _z = String.valueOf(found.getFloorZ());
                     String _d = String.valueOf((int) (found.distance(pos)));
                     log.addSuccess("commands.locate.biome.success", name, _x, _y, _z, _d);
-                    if(list.hasResult(2)) {
-                        if(list.getResult(2)) {
-                            sender.asPlayer().teleport(found);
-                        }
+                    if (list.hasResult(2) && (boolean) list.getResult(2) && sender.isPlayer()) {
+                        sender.asPlayer().teleport(found);
                     }
                 } else log.addError("commands.locate.biome.fail", name);
             }

--- a/src/main/java/org/powernukkitx/command/defaults/TeleportCommand.java
+++ b/src/main/java/org/powernukkitx/command/defaults/TeleportCommand.java
@@ -23,6 +23,8 @@ import java.util.stream.Collectors;
  * @since 2015/11/12
  */
 public class TeleportCommand extends VanillaCommand {
+    private static final double HORIZONTAL_FACING_EPSILON = 1.0E-8;
+
     public TeleportCommand(String name) {
         super(name, "commands.tp.description", "commands.tp.usage", new String[]{"teleport"});
         this.setPermission("nukkit.command.teleport");
@@ -153,13 +155,14 @@ public class TeleportCommand extends VanillaCommand {
                     return 0;
                 }
                 Position pos = list.getResult(1);
-                boolean hasExplicitRotation = list.hasResult(2) || list.hasResult(3);
-                double yRot = list.hasResult(2) ? list.getResult(2) : 0;
-                double xRot = list.hasResult(3) ? list.getResult(3) : 0;
+                boolean hasYRot = list.hasResult(2);
+                boolean hasXRot = list.hasResult(3);
+                double yRot = hasYRot ? list.getResult(2) : 0;
+                double xRot = hasXRot ? list.getResult(3) : 0;
                 boolean checkForBlocks = list.hasResult(4) ? list.getResult(4) : false;
 
                 String message = victims.stream().map(v -> v.getViewableName(sender)).collect(Collectors.joining(", "));
-                Location target = Location.fromObject(pos, pos.level, xRot, yRot);
+                Location target = Location.fromObject(pos, pos.level);
 
                 if (isUnsafe(target, checkForBlocks)) {
                     log.addError("commands.tp.safeTeleportFail", message, NukkitMath.round(target.getX(), 2) + ", " + NukkitMath.round(target.getY(), 2) + ", " + NukkitMath.round(target.getZ(), 2)).output();
@@ -167,11 +170,10 @@ public class TeleportCommand extends VanillaCommand {
                 }
 
                 for (Entity victim : victims) {
-                    if (hasExplicitRotation) {
-                        victim.teleport(target);
-                    } else {
-                        victim.teleport(getTeleportLocation(victim, pos));
-                    }
+                    Location destination = getTeleportLocation(victim, pos);
+                    if (hasYRot) destination.setYaw(yRot).setHeadYaw(yRot);
+                    if (hasXRot) destination.setPitch(xRot);
+                    victim.teleport(destination);
                 }
                 log.addSuccess("commands.tp.success.coordinates", message, String.valueOf(NukkitMath.round(target.getX(), 2)), String.valueOf(NukkitMath.round(target.getY(), 2)), String.valueOf(NukkitMath.round(target.getZ(), 2))).output(true);
                 return 1;
@@ -239,14 +241,15 @@ public class TeleportCommand extends VanillaCommand {
                     return 0;
                 }
                 Position pos = list.getResult(0);
-                boolean hasExplicitRotation = list.hasResult(1) || list.hasResult(2);
-                double yRot = list.hasResult(1) ? list.getResult(1) : 0;
-                double xRot = list.hasResult(2) ? list.getResult(2) : 0;
+                boolean hasYRot = list.hasResult(1);
+                boolean hasXRot = list.hasResult(2);
+                double yRot = hasYRot ? list.getResult(1) : 0;
+                double xRot = hasXRot ? list.getResult(2) : 0;
                 boolean checkForBlocks = list.hasResult(3) ? list.getResult(3) : false;
 
-                Location target = hasExplicitRotation
-                        ? Location.fromObject(pos, pos.level, xRot, yRot)
-                        : getTeleportLocation(sender.asEntity(), pos);
+                Location target = getTeleportLocation(sender.asEntity(), pos);
+                if (hasYRot) target.setYaw(yRot).setHeadYaw(yRot);
+                if (hasXRot) target.setPitch(xRot);
                 if (isUnsafe(target, checkForBlocks)) {
                     log.addError("commands.tp.safeTeleportFail", sender.getViewableName(sender), NukkitMath.round(target.getX(), 2) + ", " + NukkitMath.round(target.getY(), 2) + ", " + NukkitMath.round(target.getZ(), 2)).output();
                     return 0;
@@ -320,27 +323,13 @@ public class TeleportCommand extends VanillaCommand {
 
     private Location getTeleportLocation(Entity entity, Position destination) {
         double dx = destination.getX() - entity.getX();
-        double dy = destination.getY() - entity.getY();
         double dz = destination.getZ() - entity.getZ();
 
-        if (dx == 0 && dy == 0 && dz == 0) {
-            return Location.fromObject(
-                    destination,
-                    destination.level,
-                    entity.getYaw(),
-                    entity.getPitch(),
-                    entity.getHeadYaw()
-            );
+        double yaw = entity.getYaw();
+        if (dx * dx + dz * dz > HORIZONTAL_FACING_EPSILON) {
+            yaw = Location.calculateYawFacing(entity.getX(), entity.getZ(), destination.getX(), destination.getZ());
         }
 
-        BVector3 direction = BVector3.fromPos(new Vector3(dx, dy, dz));
-
-        return Location.fromObject(
-                destination,
-                destination.level,
-                direction.getYaw(),
-                direction.getPitch(),
-                direction.getYaw()
-        );
+        return Location.fromObject(destination, destination.level, yaw, entity.getPitch(), yaw);
     }
 }

--- a/src/main/java/org/powernukkitx/command/defaults/TeleportCommand.java
+++ b/src/main/java/org/powernukkitx/command/defaults/TeleportCommand.java
@@ -1,6 +1,5 @@
 package org.powernukkitx.command.defaults;
 
-import org.powernukkitx.Player;
 import org.powernukkitx.command.CommandSender;
 import org.powernukkitx.command.data.CommandEnum;
 import org.powernukkitx.command.data.CommandParameter;
@@ -104,9 +103,8 @@ public class TeleportCommand extends VanillaCommand {
                     log.addError("commands.generic.tooManyTargets").output();
                     return 0;
                 }
-                Location victim = sender.getLocation();
                 Entity first = destination.getFirst();
-                Location target = first.setYaw(victim.getYaw()).setPitch(victim.getPitch());
+                Location target = getTeleportLocation(sender.asEntity(), first);
                 boolean checkForBlocks = list.hasResult(1) ? list.getResult(1) : false;
 
                 if (isUnsafe(target, checkForBlocks)) {
@@ -143,7 +141,7 @@ public class TeleportCommand extends VanillaCommand {
                 }
 
                 for (Entity victim : victims) {
-                    victim.teleport(target.getLocation().setYaw(victim.getYaw()).setPitch(victim.getPitch()));
+                    victim.teleport(getTeleportLocation(victim, target));
                 }
                 log.addSuccess("commands.tp.success", message, target.getViewableName(sender)).output(true);
                 return victims.size();
@@ -155,8 +153,9 @@ public class TeleportCommand extends VanillaCommand {
                     return 0;
                 }
                 Position pos = list.getResult(1);
-                double yRot = list.hasResult(2) ? list.getResult(2) : sender.getLocation().pitch;
-                double xRot = list.hasResult(3) ? list.getResult(3) : sender.getLocation().yaw;
+                boolean hasExplicitRotation = list.hasResult(2) || list.hasResult(3);
+                double yRot = list.hasResult(2) ? list.getResult(2) : 0;
+                double xRot = list.hasResult(3) ? list.getResult(3) : 0;
                 boolean checkForBlocks = list.hasResult(4) ? list.getResult(4) : false;
 
                 String message = victims.stream().map(v -> v.getViewableName(sender)).collect(Collectors.joining(", "));
@@ -168,7 +167,11 @@ public class TeleportCommand extends VanillaCommand {
                 }
 
                 for (Entity victim : victims) {
-                    victim.teleport(target);
+                    if (hasExplicitRotation) {
+                        victim.teleport(target);
+                    } else {
+                        victim.teleport(getTeleportLocation(victim, pos));
+                    }
                 }
                 log.addSuccess("commands.tp.success.coordinates", message, String.valueOf(NukkitMath.round(target.getX(), 2)), String.valueOf(NukkitMath.round(target.getY(), 2)), String.valueOf(NukkitMath.round(target.getZ(), 2))).output(true);
                 return 1;
@@ -236,11 +239,14 @@ public class TeleportCommand extends VanillaCommand {
                     return 0;
                 }
                 Position pos = list.getResult(0);
-                double yRot = list.hasResult(1) ? list.getResult(1) : sender.getLocation().pitch;
-                double xRot = list.hasResult(2) ? list.getResult(2) : sender.getLocation().yaw;
+                boolean hasExplicitRotation = list.hasResult(1) || list.hasResult(2);
+                double yRot = list.hasResult(1) ? list.getResult(1) : 0;
+                double xRot = list.hasResult(2) ? list.getResult(2) : 0;
                 boolean checkForBlocks = list.hasResult(3) ? list.getResult(3) : false;
 
-                Location target = Location.fromObject(pos, pos.level, xRot, yRot);
+                Location target = hasExplicitRotation
+                        ? Location.fromObject(pos, pos.level, xRot, yRot)
+                        : getTeleportLocation(sender.asEntity(), pos);
                 if (isUnsafe(target, checkForBlocks)) {
                     log.addError("commands.tp.safeTeleportFail", sender.getViewableName(sender), NukkitMath.round(target.getX(), 2) + ", " + NukkitMath.round(target.getY(), 2) + ", " + NukkitMath.round(target.getZ(), 2)).output();
                     return 0;
@@ -310,5 +316,31 @@ public class TeleportCommand extends VanillaCommand {
     private Location getFacingLocation(Position pos, Position lookAtPosition) {
         BVector3 bv = BVector3.fromPos(new Vector3(lookAtPosition.x - pos.x, lookAtPosition.y - pos.y, lookAtPosition.z - pos.z));
         return Location.fromObject(pos, pos.level, bv.getYaw(), bv.getPitch());
+    }
+
+    private Location getTeleportLocation(Entity entity, Position destination) {
+        double dx = destination.getX() - entity.getX();
+        double dy = destination.getY() - entity.getY();
+        double dz = destination.getZ() - entity.getZ();
+
+        if (dx == 0 && dy == 0 && dz == 0) {
+            return Location.fromObject(
+                    destination,
+                    destination.level,
+                    entity.getYaw(),
+                    entity.getPitch(),
+                    entity.getHeadYaw()
+            );
+        }
+
+        BVector3 direction = BVector3.fromPos(new Vector3(dx, dy, dz));
+
+        return Location.fromObject(
+                destination,
+                destination.level,
+                direction.getYaw(),
+                direction.getPitch(),
+                direction.getYaw()
+        );
     }
 }

--- a/src/main/java/org/powernukkitx/command/selector/EntitySelectorAPI.java
+++ b/src/main/java/org/powernukkitx/command/selector/EntitySelectorAPI.java
@@ -220,8 +220,9 @@ public class EntitySelectorAPI {
             // There are no entities that meet the conditions, return
             if (entities.isEmpty()) return entities;
         }
+        boolean hasCountArg = arguments.containsKey("c");
         // Randomly select one
-        if (selectorType == RANDOM_PLAYER && !entities.isEmpty()) {
+        if (selectorType == RANDOM_PLAYER && !entities.isEmpty() && !hasCountArg) {
             var index = ThreadLocalRandom.current().nextInt(entities.size()) + 1;
             Entity currentEntity = null;
             int i = 1;
@@ -235,7 +236,7 @@ public class EntitySelectorAPI {
             return Lists.newArrayList(currentEntity);
         }
         // Select Recent Player
-        if (selectorType == NEAREST_PLAYER && entities.size() != 1) {
+        if (selectorType == NEAREST_PLAYER && entities.size() != 1 && !hasCountArg) {
             Entity nearest = null;
             double min = Double.MAX_VALUE;
             for (var entity : entities) {

--- a/src/main/java/org/powernukkitx/command/selector/EntitySelectorAPI.java
+++ b/src/main/java/org/powernukkitx/command/selector/EntitySelectorAPI.java
@@ -279,17 +279,18 @@ public class EntitySelectorAPI {
 
         if (inputArguments != null) {
             for (String arg : separateArguments(inputArguments)) {
-                var split = StringUtils.fastSplit(ARGUMENT_JOINER, arg, 2);
-                String argName = split.get(0);
+                var split = StringUtils.fastSplit(ARGUMENT_JOINER, arg.trim(), 2);
+                String argName = split.get(0).trim();
+                String argValue = split.size() > 1 ? split.get(1).trim() : "";
 
                 if (!registry.containsKey(argName)) {
                     throw new SelectorSyntaxException("Unknown selector argument: " + argName);
                 }
 
                 if (!args.containsKey(argName)) {
-                    args.put(argName, Lists.newArrayList(split.size() > 1 ? split.get(1) : ""));
+                    args.put(argName, Lists.newArrayList(argValue));
                 } else {
-                    args.get(argName).add(split.size() > 1 ? split.get(1) : "");
+                    args.get(argName).add(argValue);
                 }
             }
         }

--- a/src/main/java/org/powernukkitx/command/selector/args/impl/C.java
+++ b/src/main/java/org/powernukkitx/command/selector/args/impl/C.java
@@ -18,7 +18,7 @@ import java.util.function.Function;
  * <p>
  * The 'c' argument is used to limit the number of entities returned by a selector, optionally reversing the order
  * to select the farthest entities instead of the nearest. This class sorts the entity list by distance to the
- * reference location and returns a sublist of the specified size. Negative values reverse the order.
+ * reference location and returns up to the specified number of entities. Negative values reverse the order.
  * <p>
  * <b>Features:</b>
  * <ul>
@@ -80,7 +80,9 @@ public class C extends CachedFilterSelectorArgument {
             entities.sort(Comparator.comparingDouble(e -> e.distanceSquared(basePos)));
             if (c < 0)
                 Collections.reverse(entities);
-            return entities.subList(0, Math.abs(c));
+
+            int limit = (int) Math.min(Math.abs((long) c), entities.size());
+            return entities.subList(0, limit);
         };
     }
 
@@ -95,9 +97,10 @@ public class C extends CachedFilterSelectorArgument {
     }
 
     /**
-     * Returns the priority for this argument (3).
+     * Returns the priority for this argument.
+     * The count limit is applied after all other selector filters.
      *
-     * @return the integer 3
+     * @return the maximum integer priority
      */
     @Override
     public int getPriority() {

--- a/src/main/java/org/powernukkitx/command/selector/args/impl/C.java
+++ b/src/main/java/org/powernukkitx/command/selector/args/impl/C.java
@@ -101,6 +101,6 @@ public class C extends CachedFilterSelectorArgument {
      */
     @Override
     public int getPriority() {
-        return 3;
+        return Integer.MAX_VALUE;
     }
 }

--- a/src/main/java/org/powernukkitx/command/selector/args/impl/C.java
+++ b/src/main/java/org/powernukkitx/command/selector/args/impl/C.java
@@ -8,9 +8,11 @@ import org.powernukkitx.command.selector.args.CachedFilterSelectorArgument;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.level.Location;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 
 /**
@@ -76,14 +78,37 @@ public class C extends CachedFilterSelectorArgument {
         ParseUtils.cannotReversed(arguments[0]);
         final var c = Integer.parseInt(arguments[0]);
         if (c == 0) throw new SelectorSyntaxException("C cannot be zero!");
+        final Location referencePos = basePos.clone();
         return entities -> {
-            entities.sort(Comparator.comparingDouble(e -> e.distanceSquared(basePos)));
-            if (c < 0)
-                Collections.reverse(entities);
+            if (selectorType == SelectorType.RANDOM_PLAYER) {
+                Collections.shuffle(entities, ThreadLocalRandom.current());
+            } else {
+                entities.sort(Comparator.comparingDouble(e -> e.distanceSquared(referencePos)));
+                if (c < 0)
+                    Collections.reverse(entities);
+            }
 
             int limit = (int) Math.min(Math.abs((long) c), entities.size());
-            return entities.subList(0, limit);
+            return new ArrayList<>(entities.subList(0, limit));
         };
+    }
+
+    /**
+     * Returns the filter function for the given arguments.
+     * <p>
+     * The filter is position dependent, so it is rebuilt for every sender instead of being served from the
+     * shared argument cache.
+     *
+     * @param selectorType the selector type
+     * @param sender the command sender
+     * @param basePos the reference location
+     * @param arguments the argument values
+     * @return the computed filter function
+     * @throws SelectorSyntaxException if the argument is invalid
+     */
+    @Override
+    public Function<List<Entity>, List<Entity>> getFilter(SelectorType selectorType, CommandSender sender, Location basePos, String... arguments) throws SelectorSyntaxException {
+        return cache(selectorType, sender, basePos, arguments);
     }
 
     /**
@@ -100,10 +125,10 @@ public class C extends CachedFilterSelectorArgument {
      * Returns the priority for this argument.
      * The count limit is applied after all other selector filters.
      *
-     * @return the maximum integer priority
+     * @return the integer 1000
      */
     @Override
     public int getPriority() {
-        return Integer.MAX_VALUE;
+        return 1000;
     }
 }

--- a/src/main/java/org/powernukkitx/entity/Entity.java
+++ b/src/main/java/org/powernukkitx/entity/Entity.java
@@ -5704,10 +5704,6 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
      * @return the boolean
      */
     public boolean teleport(Location location, PlayerTeleportEvent.TeleportCause cause) {
-        double yaw = location.yaw;
-        double pitch = location.pitch;
-        double headYaw = location.headYaw;
-
         Location from = this.getLocation();
         Location to = location;
         if (cause != null) {
@@ -5718,6 +5714,10 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
             }
             to = ev.getTo();
         }
+
+        double yaw = to.yaw;
+        double pitch = to.pitch;
+        double headYaw = to.headYaw;
 
         final Entity currentRide = getRiding();
         if (currentRide != null && !currentRide.dismountEntity(this, true, false)) {
@@ -5732,8 +5732,21 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         if (this.setPositionAndRotation(to, yaw, pitch, headYaw)) {
             this.resetFallDistance();
             this.onGround = !this.noClip;
-            this.updateMovement();
+
+            if (!enableHeadYaw()) {
+                this.headYaw = this.yaw;
+            }
             this.broadcastMovement(true);
+
+            this.lastX = this.x;
+            this.lastY = this.y;
+            this.lastZ = this.z;
+            this.lastYaw = this.yaw;
+            this.lastPitch = this.pitch;
+            this.lastHeadYaw = this.headYaw;
+
+            this.updateMovement();
+            this.positionChanged = true;
             return true;
         }
 

--- a/src/main/java/org/powernukkitx/entity/Entity.java
+++ b/src/main/java/org/powernukkitx/entity/Entity.java
@@ -1950,7 +1950,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         moveData.setOnGround(this.onGround);
         moveData.setTeleported(tp);
         moveData.setPos(this.getPosition().toNetwork().add(0f, this.getBaseOffset(), 0f));
-        moveData.setRotation(org.cloudburstmc.math.vector.Vector3f.from(this.pitch, this.yaw, this.yaw));
+        moveData.setRotation(org.cloudburstmc.math.vector.Vector3f.from(this.pitch, this.yaw, this.headYaw));
 
         final MoveActorAbsolutePacket packet = new MoveActorAbsolutePacket();
         packet.setMoveData(moveData);
@@ -5706,6 +5706,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
     public boolean teleport(Location location, PlayerTeleportEvent.TeleportCause cause) {
         double yaw = location.yaw;
         double pitch = location.pitch;
+        double headYaw = location.headYaw;
 
         Location from = this.getLocation();
         Location to = location;
@@ -5728,10 +5729,11 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
 
         this.setMotion(this.temporalVector.setComponents(0, 0, 0));
 
-        if (this.setPositionAndRotation(to, yaw, pitch)) {
+        if (this.setPositionAndRotation(to, yaw, pitch, headYaw)) {
             this.resetFallDistance();
             this.onGround = !this.noClip;
             this.updateMovement();
+            this.broadcastMovement(true);
             return true;
         }
 

--- a/src/main/java/org/powernukkitx/level/Location.java
+++ b/src/main/java/org/powernukkitx/level/Location.java
@@ -41,7 +41,7 @@ public class Location extends Position {
     }
 
     public Location(double x, double y, double z, double yaw, double pitch, Level level) {
-        this(x, y, z, yaw, pitch, 0, level);
+        this(x, y, z, yaw, pitch, yaw, level);
     }
 
     public Location(double x, double y, double z, double yaw, double pitch, double headYaw) {

--- a/src/test/java/org/powernukkitx/command/ParseArgumentsTest.java
+++ b/src/test/java/org/powernukkitx/command/ParseArgumentsTest.java
@@ -1,0 +1,56 @@
+package org.powernukkitx.command;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ParseArgumentsTest {
+
+    @Test
+    void splitsOnSpaces() {
+        assertEquals(List.of("@a", "stone", "1"), SimpleCommandMap.parseArguments("@a stone 1"));
+    }
+
+    @Test
+    void keepsSelectorBracketsTogether() {
+        assertEquals(List.of("@e[family=npc, c=1]", "~", "~", "~"),
+                SimpleCommandMap.parseArguments("@e[family=npc, c=1] ~ ~ ~"));
+    }
+
+    @Test
+    void keepsNestedSelectorBracketsTogether() {
+        assertEquals(List.of("@e[scores={a=1}, c=2]", "0", "64", "0"),
+                SimpleCommandMap.parseArguments("@e[scores={a=1}, c=2] 0 64 0"));
+    }
+
+    @Test
+    void unbalancedOpeningBracketStillSplits() {
+        assertEquals(List.of("hello", "[world", "again"),
+                SimpleCommandMap.parseArguments("hello [world again"));
+    }
+
+    @Test
+    void unbalancedClosingBracketStillSplits() {
+        assertEquals(List.of("hello", "world]", "again"),
+                SimpleCommandMap.parseArguments("hello world] again"));
+    }
+
+    @Test
+    void quotedBracketIsNotGrouping() {
+        assertEquals(List.of("say", "[oops", "next"),
+                SimpleCommandMap.parseArguments("say \"[oops\" next"));
+    }
+
+    @Test
+    void quotedSpacesAreNotSplit() {
+        assertEquals(List.of("give", "@s", "a b"), SimpleCommandMap.parseArguments("give @s \"a b\""));
+    }
+
+    @Test
+    void curlyBracesStayOneArgument() {
+        assertEquals(List.of("@s", "stick", "1", "0", "{\"a\":[\"b c\"]}"),
+                SimpleCommandMap.parseArguments("@s stick 1 0 {\"a\":[\"b c\"]}"));
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fix selector processing so c is applied after filters and allow spaces inside selector brackets without splitting command arguments.
Update teleport handling to preserve/sync the calculated destination-facing rotation correctly for teleported entities.

## Why?

The C selector was not working if in the command had any other filter, for instance @e[family=npc, c=1]
Fix the C selector when adding a value higher than the available entities generate IndexOutOfBoundsException
Adding spaces between the filter makes the command not work.
And teleport behavior on BDS, when there is no facing neither rotation set, the target entity is rotated to the the direction the teleport is taking the entity to.

Closes #

## Type of change

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** b8682b0dbde9bdd0a63a99a357c186214051597d
- **Bedrock client version:** 26.33
- **Plugins loaded:** none

**Steps performed and results:**

1. Execute a command with two filters like @e[family=npc, c=1] using C selector and also add space
2. The teleported entity updates the final rotation matching the direction it is being teleported

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
|       |             |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [ ] The PR is one logical change, with no unrelated reformatting or refactors
- [ ] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
