### PR TITLE
fix: the command parameters, if they are the same

### DIFF
--- a/src/main/java/org/powernukkitx/command/data/CommandParameter.java
+++ b/src/main/java/org/powernukkitx/command/data/CommandParameter.java
@@ -12,6 +12,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Represents a parameter definition for a command in PowerNukkitX.
@@ -50,6 +51,9 @@ import java.util.List;
  * @see IParamNode
  */
 public class CommandParameter {
+
+    private static final AtomicLong ENUM_COUNTER = new AtomicLong();
+
     /**
      * An empty array of CommandParameter, used for commands with no arguments.
      */
@@ -210,7 +214,7 @@ public class CommandParameter {
      * @see #newEnum(String, boolean, CommandEnum)
      */
     public static CommandParameter newEnum(String name, boolean optional, String[] values) {
-        return newEnum(name, optional, new CommandEnum(name + "Enums", values));
+        return newEnum(name, optional, new CommandEnum(name + "Enums_" + ENUM_COUNTER.incrementAndGet(), values));
     }
 
     /**
@@ -224,7 +228,7 @@ public class CommandParameter {
      * @see #newEnum(String, boolean, CommandEnum)
      */
     public static CommandParameter newEnum(String name, boolean optional, String[] values, boolean soft) {
-        return newEnum(name, optional, new CommandEnum(name + "Enums", Arrays.asList(values), soft));
+        return newEnum(name, optional, new CommandEnum(name + "Enums_" + ENUM_COUNTER.incrementAndGet(), Arrays.asList(values), soft));
     }
 
     /**

--- a/src/test/java/org/powernukkitx/command/data/CommandParameterTest.java
+++ b/src/test/java/org/powernukkitx/command/data/CommandParameterTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -47,9 +48,23 @@ class CommandParameterTest {
         assertFalse(p.optional);
         assertNull(p.type);
         assertNotNull(p.enumData);
-        assertEquals("modeEnums", p.enumData.getName());
+        assertTrue(p.enumData.getName().matches("modeEnums_\\d+"), p.enumData.getName());
         assertEquals(java.util.List.of("easy", "hard"), p.enumData.getValues());
         assertFalse(p.enumData.isSoft());
+    }
+
+    @Test
+    void newEnumFromValuesGeneratesUniqueEnumNames() {
+        CommandParameter first = CommandParameter.newEnum("mode", new String[]{"easy"});
+        CommandParameter second = CommandParameter.newEnum("mode", new String[]{"hard"});
+        assertNotEquals(first.enumData.getName(), second.enumData.getName());
+    }
+
+    @Test
+    void newEnumWithSoftFlagGeneratesUniqueEnumNames() {
+        CommandParameter first = CommandParameter.newEnum("mode", false, new String[]{"easy"}, true);
+        CommandParameter second = CommandParameter.newEnum("mode", false, new String[]{"hard"}, true);
+        assertNotEquals(first.enumData.getName(), second.enumData.getName());
     }
 
     @Test


### PR DESCRIPTION
## What does this PR do?

makes the generated CommandEnum names unique by appending an incrementing counter instead of always using the same <name>Enums suffix

## Why?

creating multiple command parameters with the same enum name can lead to name collisions

## Type of change

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 5d1b6d05a
- **Bedrock client version:** 26.30
- **Plugins loaded:** Private Plugin

**Steps performed and results:**

1. built the server with the change
2. registered commands creating multiple enums with the same parameter name and verified that each generated CommandEnum had a unique name

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

none

None

## Performance notes

N/A

## AI usage disclosure

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
