### PR TITLE
fix: only attach teleport data to MovePlayerPacket on a teleport

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -4722,10 +4722,13 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
             pk.setPositionMode(PositionMode.ONLY_HEAD_ROT);
         }
 
-        final MovePlayerTeleportData teleportData = new MovePlayerTeleportData();
-        teleportData.setTeleportationCause(TeleportationCause.UNKNOWN);
-
-        pk.setTeleportData(teleportData);
+        if (pk.getPositionMode() == PositionMode.TELEPORT) {
+            // Only a teleport carries this block; the serializer writes it whenever it is set, so
+            // attaching it to an ordinary move hands the client a field it does not read there.
+            final MovePlayerTeleportData teleportData = new MovePlayerTeleportData();
+            teleportData.setTeleportationCause(TeleportationCause.UNKNOWN);
+            pk.setTeleportData(teleportData);
+        }
 
         if (targets != null) {
             Server.broadcastPacket(targets, pk);

--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -4723,8 +4723,6 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         }
 
         if (pk.getPositionMode() == PositionMode.TELEPORT) {
-            // Only a teleport carries this block; the serializer writes it whenever it is set, so
-            // attaching it to an ordinary move hands the client a field it does not read there.
             final MovePlayerTeleportData teleportData = new MovePlayerTeleportData();
             teleportData.setTeleportationCause(TeleportationCause.UNKNOWN);
             pk.setTeleportData(teleportData);

--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -5557,10 +5557,6 @@ public class Level implements Metadatable {
         } else {
             packet.setPositionMode(PositionMode.NORMAL);
         }
-        // No teleport data: the serializer writes the block whenever it is set, and the client only
-        // reads it back for PositionMode.TELEPORT. This packet carries ordinary movement to every
-        // viewer of the entity, so the surplus block lands on the bystanders rather than on the
-        // player who moved.
 
         Server.broadcastPacket(entity.getViewers().values(), packet);
     }

--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -1,9 +1,7 @@
 package org.powernukkitx.level;
 
 import org.cloudburstmc.protocol.bedrock.data.payload.move.MoveActorDeltaData;
-import org.cloudburstmc.protocol.bedrock.data.payload.move.MovePlayerTeleportData;
 import org.cloudburstmc.protocol.bedrock.data.payload.move.PositionMode;
-import org.cloudburstmc.protocol.bedrock.data.payload.move.TeleportationCause;
 import org.powernukkitx.Player;
 import org.powernukkitx.PlayerHandle;
 import org.powernukkitx.Server;
@@ -5559,10 +5557,10 @@ public class Level implements Metadatable {
         } else {
             packet.setPositionMode(PositionMode.NORMAL);
         }
-        final MovePlayerTeleportData teleportData = new MovePlayerTeleportData();
-        teleportData.setTeleportationCause(TeleportationCause.UNKNOWN);
-
-        packet.setTeleportData(teleportData);
+        // No teleport data: the serializer writes the block whenever it is set, and the client only
+        // reads it back for PositionMode.TELEPORT. This packet carries ordinary movement to every
+        // viewer of the entity, so the surplus block lands on the bystanders rather than on the
+        // player who moved.
 
         Server.broadcastPacket(entity.getViewers().values(), packet);
     }


### PR DESCRIPTION
## What does this PR do?

Fixed a client crash that occurred when dismounting from a ghast, and a crash affecting players near someone dismounting from a horse. There are likely other bugs related to this.

## Why?

Client crash.

`MovePlayerPacket` was given a `MovePlayerTeleportData` on every move. The serializer writes that block whenever it is set, but the client only reads it back for `PositionMode.TELEPORT`. Since `Level#addPlayerMovement` broadcasts to every viewer of the entity, the surplus block landed on the bystanders rather than on the player who moved — which is why dismounting a horse dropped everyone around the rider but not the rider himself, and why dismounting a ghast dropped everyone.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** `ed9d6323cbda5f8ae24568aecc833b1041406bb3` — I ran it from my own fork build, which contains this commit plus unrelated local changes.
- **Bedrock client version:** 1.26.40
- **Plugins loaded:** FastEdit and a personal plugin

**Steps performed and results:**

1. Mounted a happy ghast with several players nearby, then dismounted. Before this change: every player present was disconnected with "Session closed", and nothing was logged server-side.
2. Mounted a horse with players nearby, then dismounted. Before this change: the players around were disconnected, the rider stayed connected.
3. Repeated both with this change applied: no disconnection, neither for the rider nor for the players around.

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [x] I added tests for the new logic, or explained below why that isn't practical

Not practical: the change is about which optional block is written to the wire, and the failure only shows up in how a real Bedrock client parses it. The test harness (`GameMockExtension`, `TestPlayer`) has no client-side packet consumer, so a unit test could only assert that the field is null outside `PositionMode.TELEPORT` — restating the diff rather than testing the behaviour.

## Breaking changes / API impact

None. `Player#sendPosition` and `Level#addPlayerMovement` keep their signatures; only what they put on the wire changes.

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| Claude Opus 5 | Code change, commit message, and the investigation of the packet path that located it |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [ ] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled