### PR TITLE
fix: derive auto craft output count when timesCrafted is unavailable

### DIFF
--- a/src/main/java/org/powernukkitx/inventory/request/CraftRecipeAutoProcessor.java
+++ b/src/main/java/org/powernukkitx/inventory/request/CraftRecipeAutoProcessor.java
@@ -97,12 +97,26 @@ public class CraftRecipeAutoProcessor implements ItemStackRequestActionProcessor
                         }
                     }
                 }
-                output.setCount(output.getCount() * action.getTimesCrafted());
+                output.setCount(output.getCount() * resolveTimesCrafted(action));
                 CreativeOutputInventory createdOutput = player.getCreativeOutputInventory();
                 createdOutput.setItem(0, output.clone().autoAssignStackNetworkId(), false);
             }
         }
         return null;
+    }
+
+    private static int resolveTimesCrafted(AutoCraftRecipeAction action) {
+        int timesCrafted = action.getTimesCrafted();
+        if (timesCrafted > 0) {
+            return timesCrafted;
+        }
+        int numberOfRequestedCrafts = action.getNumberOfRequestedCrafts();
+        if (numberOfRequestedCrafts > 0) {
+            return numberOfRequestedCrafts;
+        }
+        log.debug("Auto craft request carries no usable craft count (timesCrafted {}, numberOfRequestedCrafts {}), falling back to 1",
+                timesCrafted, numberOfRequestedCrafts);
+        return 1;
     }
 
     private boolean match(RecipeIngredient descriptorWithCount, ItemDescriptor descriptor, Item item) {


### PR DESCRIPTION
## What does this PR do?

Auto-crafting multiplied the recipe output by `timesCrafted`, a field the 1.26.40
codec no longer sends. The decoder substitutes `-1`, so the output count went
negative and PNX discarded it as air. This derives the craft count from
`numberOfRequestedCrafts` instead when `timesCrafted` is unusable.

## Why?

Shift-left-clicking a recipe in the recipe book ate the ingredients and gave
nothing back on 1.26.40. The consume actions run after the craft action and are
not rolled back, so the player just lost the items.

Closes #2965

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 2a0e7c37c
- **Bedrock client version:** 1.26.40 (protocol 2168)
- **Plugins loaded:** none

**Steps performed and results:**

1. Opened a crafting table and shift-left-clicked the stick recipe in the recipe
   book, requesting a full stack in one action.
2. Before the fix: the planks were consumed and no sticks were received.
3. After the fix: received all 64 sticks.

64 is the useful number here. The stick recipe yields 4 per craft, so this was 16
crafts and the output count tracked `numberOfRequestedCrafts` correctly. Had the
fallback collapsed to a single craft, the result would have been 4 sticks, not 64.

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`) — 982 tests, 0 failures, 0 errors, 0 skipped
- [ ] I added tests for the new logic, or explained below why that isn't practical

`resolveTimesCrafted` is a private static helper on a processor whose `handle`
needs a live `Player`, an inventory and a decoded `ItemStackRequest`, so there is
no existing harness to unit-test it through. The fix is a bounds guard on a
protocol field; it is exercised by the manual craft test above.

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| claude-opus-5 | Confirmed the root cause by disassembling `BedrockCodecHelper_v2168` to verify the hardcoded `-1`; wrote the `resolveTimesCrafted` helper and the call-site change; wrote the commit message; ran the existing unit suite; drafted this PR description. In-game testing was done by me. |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled