### PR TITLE
feat: add void world generator

### DIFF
--- a/src/main/java/org/powernukkitx/level/generator/VoidGenerator.java
+++ b/src/main/java/org/powernukkitx/level/generator/VoidGenerator.java
@@ -1,0 +1,30 @@
+package org.powernukkitx.level.generator;
+
+import org.powernukkitx.Server;
+import org.powernukkitx.level.DimensionData;
+import org.powernukkitx.level.generator.stages.FinishedStage;
+import org.powernukkitx.level.generator.stages.LightPopulationStage;
+import org.powernukkitx.level.generator.stages.VoidGenerateStage;
+import org.powernukkitx.registry.Registries;
+
+import java.util.Map;
+
+public class VoidGenerator extends Generator {
+    public VoidGenerator(DimensionData dimensionData, Map<String, Object> options) {
+        super(dimensionData, options);
+    }
+
+    @Override
+    public void stages(GenerateStage.Builder builder) {
+        builder.start(Registries.GENERATE_STAGE.get(VoidGenerateStage.NAME));
+        if (Server.getInstance().getSettings().chunkSettings().lightUpdates()) {
+            builder.next(Registries.GENERATE_STAGE.get(LightPopulationStage.NAME));
+        }
+        builder.next(Registries.GENERATE_STAGE.get(FinishedStage.NAME));
+    }
+
+    @Override
+    public String getName() {
+        return "void";
+    }
+}

--- a/src/main/java/org/powernukkitx/level/generator/stages/VoidGenerateStage.java
+++ b/src/main/java/org/powernukkitx/level/generator/stages/VoidGenerateStage.java
@@ -16,9 +16,10 @@ public class VoidGenerateStage extends GenerateStage {
     @Override
     public void apply(ChunkGenerateContext context) {
         IChunk chunk = context.getChunk();
+        int minHeight = context.getGenerator().getDimensionData().getMinHeight();
         for (int x = 0; x < 16; x++) {
             for (int z = 0; z < 16; z++) {
-                chunk.setHeightMap(x, z, 0);
+                chunk.setHeightMap(x, z, minHeight);
             }
         }
         chunk.setChunkState(ChunkState.POPULATED);

--- a/src/main/java/org/powernukkitx/level/generator/stages/VoidGenerateStage.java
+++ b/src/main/java/org/powernukkitx/level/generator/stages/VoidGenerateStage.java
@@ -1,0 +1,26 @@
+package org.powernukkitx.level.generator.stages;
+
+import org.powernukkitx.level.format.ChunkState;
+import org.powernukkitx.level.format.IChunk;
+import org.powernukkitx.level.generator.ChunkGenerateContext;
+import org.powernukkitx.level.generator.GenerateStage;
+
+public class VoidGenerateStage extends GenerateStage {
+    public static final String NAME = "void_generate";
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public void apply(ChunkGenerateContext context) {
+        IChunk chunk = context.getChunk();
+        for (int x = 0; x < 16; x++) {
+            for (int z = 0; z < 16; z++) {
+                chunk.setHeightMap(x, z, 0);
+            }
+        }
+        chunk.setChunkState(ChunkState.POPULATED);
+    }
+}

--- a/src/main/java/org/powernukkitx/registry/GenerateStageRegistry.java
+++ b/src/main/java/org/powernukkitx/registry/GenerateStageRegistry.java
@@ -6,6 +6,7 @@ import org.powernukkitx.level.generator.stages.NormalChunkFeatureStage;
 import org.powernukkitx.level.generator.stages.end.TheEndPopulatorStage;
 import org.powernukkitx.level.generator.stages.end.TheEndTerrainStage;
 import org.powernukkitx.level.generator.stages.FinishedStage;
+import org.powernukkitx.level.generator.stages.VoidGenerateStage;
 import org.powernukkitx.level.generator.stages.flat.FlatGenerateStage;
 import org.powernukkitx.level.generator.stages.LightPopulationStage;
 import org.powernukkitx.level.generator.stages.BiomeMapStage;
@@ -32,6 +33,7 @@ public class GenerateStageRegistry implements IRegistry<String, GenerateStage, C
             this.register(FinishedStage.NAME, FinishedStage.class);
             this.register(GeneratedStage.NAME, GeneratedStage.class);
             this.register(FlatGenerateStage.NAME, FlatGenerateStage.class);
+            this.register(VoidGenerateStage.NAME, VoidGenerateStage.class);
             this.register(LightPopulationStage.NAME, LightPopulationStage.class);
             this.register(BiomeMapStage.NAME, BiomeMapStage.class);
             this.register(NormalTerrainStage.NAME, NormalTerrainStage.class);

--- a/src/main/java/org/powernukkitx/registry/GeneratorRegistry.java
+++ b/src/main/java/org/powernukkitx/registry/GeneratorRegistry.java
@@ -5,6 +5,7 @@ import org.powernukkitx.level.generator.Generator;
 import org.powernukkitx.level.generator.Nether;
 import org.powernukkitx.level.generator.Normal;
 import org.powernukkitx.level.generator.TheEnd;
+import org.powernukkitx.level.generator.VoidGenerator;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 
 import java.util.Locale;
@@ -23,6 +24,7 @@ public class GeneratorRegistry implements IRegistry<String, Class<? extends Gene
             register("normal", Normal.class);
             register("nether", Nether.class);
             register("the_end", TheEnd.class);
+            register("void", VoidGenerator.class);
         } catch (RegisterException e) {
             throw new IllegalStateException(e);
         }


### PR DESCRIPTION
## What does this PR do?

Adds a `void` world generator that produces empty chunks, alongside the existing
`flat`, `normal`, `nether` and `the_end` generators.

## Why?

Worlds whose content comes entirely from saved chunks or pasted structures (lobbies,
minigame arenas, schematic-driven builds) currently have to generate terrain and
then delete it. There was no built-in way to ask for nothing.
Furthermore, adding a standalone plugin for an empty world generator adds complexity to the server creator.

## Type of change

- [ ] Bug Fix
- [x] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** fb3492a18
- **Bedrock client version:** 1.26.40
- **Plugins loaded:** none

**Steps performed and results:**

1. Set a world's `config.json` generator to `void` and started the server on a
   build of this branch.
2. Joined the world: chunks generate empty, no terrain, no errors in console.

- [x] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes) — N/A, this is a feature
- [x] Existing unit tests pass (`gradlew test`) — 982 tests, 0 failures, 0 errors, 0 skipped
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

No existing API is changed or removed, but two new registry keys are now claimed
at startup:

- `GeneratorRegistry` registers `"void"`
- `GenerateStageRegistry` registers `"void_generate"`

`GeneratorRegistry.register` throws `RegisterException` when a key is already
present, and plugins register after the built-in registries are initialised.
A plugin that currently ships its own generator under the name `void` will
therefore start failing to register once this lands.

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| claude-opus-5 | Ran the existing unit suite on this branch; reviewed the diff and identified the registry-collision impact noted above; drafted this PR description. The generator itself was written by me. |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [ ] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [ ] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled