### PR TITLE
feat: add crash reporting and fix auto craft handling

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -174,15 +174,7 @@ import org.powernukkitx.scoreboard.IScoreboardLine;
 import org.powernukkitx.scoreboard.data.DisplaySlot;
 import org.powernukkitx.scoreboard.displayer.IScoreboardViewer;
 import org.powernukkitx.scoreboard.scorer.PlayerScorer;
-import org.powernukkitx.utils.BlockIterator;
-import org.powernukkitx.utils.BossBarColor;
-import org.powernukkitx.utils.DummyBossBar;
-import org.powernukkitx.utils.Identifier;
-import org.powernukkitx.utils.ItemHelper;
-import org.powernukkitx.utils.PortalHelper;
-import org.powernukkitx.utils.SkinConverter;
-import org.powernukkitx.utils.TextFormat;
-import org.powernukkitx.utils.Utils;
+import org.powernukkitx.utils.*;
 
 import java.awt.*;
 import java.net.InetSocketAddress;
@@ -2495,7 +2487,11 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         if (this.spawned && this.level.getProvider() != null) {
             for (Entity entity : this.level.getChunkEntities(x, z).values()) {
                 if (this != entity && !entity.closed && entity.isAlive()) {
-                    entity.spawnTo(this);
+                    try {
+                        entity.spawnTo(this);
+                    } catch (Throwable e){
+                        CrashReporter.log("Spawning an entity to " + this.getName(), entity, e);
+                    }
                 }
             }
         }
@@ -2503,7 +2499,11 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         if (this.level.getProvider() != null) {
             for (BlockEntity entity : this.level.getChunkBlockEntities(x, z).values()) {
                 if (entity instanceof BlockEntitySpawnable spawnable) {
-                    spawnable.spawnTo(this);
+                    try {
+                        spawnable.spawnTo(this);
+                    } catch (Throwable e) {
+                        CrashReporter.log("Spawning a block entity to " + this.getName(), entity, e);
+                    }
                 }
             }
         }
@@ -2512,7 +2512,11 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
             if (!this.isConnected() || this.level == null) return;
             for (BlockEntity entity : this.level.getChunkBlockEntities(x, z).values()) {
                 if ((entity instanceof BlockEntityItemFrame || entity instanceof BlockEntitySign) && !entity.closed) {
-                    ((BlockEntitySpawnable) entity).spawnTo(this);
+                    try {
+                        ((BlockEntitySpawnable) entity).spawnTo(this);
+                    } catch (Throwable e) {
+                        CrashReporter.log("Spawning a block entity spawnable to " + this.getName(), entity, e);
+                    }
                 }
             }
         }, 2);
@@ -2553,12 +2557,16 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
      * @param packet packet to send
      */
     public void sendPacket(BedrockPacket packet) {
-        final PacketSendEvent event = new PacketSendEvent(this, packet);
-        this.server.getPluginManager().callEvent(event);
-        if (event.isCancelled()) {
-            return;
+        try {
+            final PacketSendEvent event = new PacketSendEvent(this, packet);
+            this.server.getPluginManager().callEvent(event);
+            if (event.isCancelled()) {
+                return;
+            }
+            this.getSession().sendPacket(packet);
+        } catch (Throwable e) {
+            CrashReporter.log("Sending " + packet.getClass().getSimpleName() + " to " + this.getName(), packet, e);
         }
-        this.getSession().sendPacket(packet);
     }
 
     /**
@@ -5827,13 +5835,18 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         if (!this.isConnected()) {
             return false;
         }
-        final PacketSendEvent event = new PacketSendEvent(this, packet);
-        this.server.getPluginManager().callEvent(event);
-        if (event.isCancelled()) {
+        try {
+            final PacketSendEvent event = new PacketSendEvent(this, packet);
+            this.server.getPluginManager().callEvent(event);
+            if (event.isCancelled()) {
+                return false;
+            }
+            this.getSession().sendPacketImmediately(packet);
+            return true;
+        } catch (Throwable e) {
+            CrashReporter.log("Sending " + packet.getClass().getSimpleName() + " to " + this.getName(), packet, e);
             return false;
         }
-        this.getSession().sendPacketImmediately(packet);
-        return true;
     }
 
     /**

--- a/src/main/java/org/powernukkitx/PowerNukkitX.java
+++ b/src/main/java/org/powernukkitx/PowerNukkitX.java
@@ -117,6 +117,13 @@ public class PowerNukkitX {
         // Netty logger for debug info
         InternalLoggerFactory.setDefaultFactory(Log4J2LoggerFactory.INSTANCE);
 
+        // A thread that dies on an uncaught throwable writes to stderr by default, which the
+        // TerminalConsole appender does not capture: the thread simply stops and the server
+        // silently loses whatever it was responsible for, with no trace in the logs. Route it
+        // through the logger instead so nothing gets lost silently.
+        Thread.setDefaultUncaughtExceptionHandler((thread, thrown) ->
+            log.error("Thread {} died from an uncaught throwable", thread.getName(), thrown));
+
         // Define args
         OptionParser parser = new OptionParser();
         parser.allowsUnrecognizedOptions();

--- a/src/main/java/org/powernukkitx/Server.java
+++ b/src/main/java/org/powernukkitx/Server.java
@@ -1067,8 +1067,12 @@ public class Server {
     private void checkTickUpdates(int currentTick) {
         boolean tickPlayers = getSettings().levelSettings().alwaysTickPlayers();
         for (Player player : new ArrayList<>(this.players.values())) {
-            if (tickPlayers) player.onUpdate(currentTick);
-            if (!player.spawned) player.checkNetwork();
+            try {
+                if (tickPlayers) player.onUpdate(currentTick);
+                if (!player.spawned) player.checkNetwork();
+            } catch (Throwable e) {
+                CrashReporter.logAndDisconnect(player, "Ticking a player", e);
+            }
         }
 
         int baseTickRate = getSettings().levelSettings().baseTickRate();
@@ -1200,14 +1204,22 @@ public class Server {
             for (Level level : this.levelArray) {
                 for (BlockEntity be : level.getBlockEntities().values()) {
                     if (!be.closed) {
-                        be.saveNBT();
-                        be.serializationSnapshot = be.getNbt().copy();
+                        try {
+                            be.saveNBT();
+                            be.serializationSnapshot = be.getNbt().copy();
+                        } catch (Throwable e) {
+                            CrashReporter.log("Snapshotting a block entity for autosave", be, e);
+                        }
                     }
                 }
                 for (Entity entity : level.getEntities()) {
                     if (!(entity instanceof Player) && !entity.closed) {
-                        entity.saveNBT();
-                        entity.serializationSnapshot = entity.getNbt().copy();
+                        try {
+                            entity.saveNBT();
+                            entity.serializationSnapshot = entity.getNbt().copy();
+                        } catch (Throwable e) {
+                            CrashReporter.log("Snapshotting an entity for autosave", entity, e);
+                        }
                     }
                 }
             }

--- a/src/main/java/org/powernukkitx/camera/CustomCameraDefinition.java
+++ b/src/main/java/org/powernukkitx/camera/CustomCameraDefinition.java
@@ -9,7 +9,6 @@ import org.powernukkitx.registry.CameraRegistry;
 
 import java.util.Objects;
 
-
 /**
  * Defines a custom camera preset.
  *

--- a/src/main/java/org/powernukkitx/camera/CustomCameraDefinition.java
+++ b/src/main/java/org/powernukkitx/camera/CustomCameraDefinition.java
@@ -9,6 +9,15 @@ import org.powernukkitx.registry.CameraRegistry;
 
 import java.util.Objects;
 
+
+/**
+ * Defines a custom camera preset.
+ *
+ * <p>The runtime ID and protocol definition are assigned when the camera is
+ * registered in {@link CameraRegistry}.</p>
+ *
+ * @author Curse
+ */
 public record CustomCameraDefinition(String identifier, CameraPreset preset) {
     public CustomCameraDefinition {
         Objects.requireNonNull(identifier, "identifier");

--- a/src/main/java/org/powernukkitx/camera/CustomCameraDefinition.java
+++ b/src/main/java/org/powernukkitx/camera/CustomCameraDefinition.java
@@ -9,14 +9,6 @@ import org.powernukkitx.registry.CameraRegistry;
 
 import java.util.Objects;
 
-/**
- * Defines a custom camera preset.
- *
- * <p>The runtime ID and protocol definition are assigned when the camera is
- * registered in {@link CameraRegistry}.</p>
- *
- * @author Curse
- */
 public record CustomCameraDefinition(String identifier, CameraPreset preset) {
     public CustomCameraDefinition {
         Objects.requireNonNull(identifier, "identifier");

--- a/src/main/java/org/powernukkitx/entity/Entity.java
+++ b/src/main/java/org/powernukkitx/entity/Entity.java
@@ -79,6 +79,7 @@ import org.powernukkitx.scheduler.Task;
 import org.powernukkitx.tags.ItemTags;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import org.powernukkitx.utils.ChunkException;
+import org.powernukkitx.utils.CrashReporter;
 import org.powernukkitx.utils.Hash;
 import org.powernukkitx.utils.Identifier;
 import org.powernukkitx.utils.PortalHelper;
@@ -5773,7 +5774,11 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         this.hasSpawned.clear();
 
         for (Player player : players) {
-            this.spawnTo(player);
+            try {
+                this.spawnTo(player);
+            } catch (Throwable e) {
+                CrashReporter.log("Respawning an entity to a player", this, e);
+            }
         }
     }
 
@@ -5784,14 +5789,22 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
 
         for (Player player : this.level.getChunkPlayers(this.chunk.getX(), this.chunk.getZ()).values()) {
             if (player.isOnline()) {
-                this.spawnTo(player);
+                try {
+                    this.spawnTo(player);
+                } catch (Throwable e) {
+                    CrashReporter.log("Spawning an entity to a player", this, e);
+                }
             }
         }
     }
 
     public void despawnFromAll() {
         for (Player player : this.hasSpawned.values()) {
-            this.despawnFrom(player);
+            try {
+                this.despawnFrom(player);
+            } catch (Throwable e) {
+                CrashReporter.log("Despawning an entity from a player", this, e);
+            }
         }
     }
 

--- a/src/main/java/org/powernukkitx/entity/EntityHuman.java
+++ b/src/main/java/org/powernukkitx/entity/EntityHuman.java
@@ -168,7 +168,7 @@ public class EntityHuman extends EntityHumanType {
             }
 
             if(skin.getGeometryData() == null || skin.getGeometryData().isEmpty()) {
-                builder.skinResourcePatch(GEOMETRY_HUMANOID);
+                builder.geometryData(GEOMETRY_HUMANOID);
                 changed = true;
             }
 
@@ -232,8 +232,12 @@ public class EntityHuman extends EntityHumanType {
     @Override
     public void spawnTo(Player player) {
         if (this != player && !this.hasSpawned.containsKey(player.getLoaderId())) {
-            this.hasSpawned.put(player.getLoaderId(), player);
+            if (this.skin == null || !SkinUtils.isValid(this.skin.getSkin())) {
+                throw new IllegalStateException(this.getClass().getSimpleName() + " (id " + this.getId()
+                    + ", name '" + this.getNameTag() + "') has no valid skin assigned");
+            }
 
+            this.hasSpawned.put(player.getLoaderId(), player);
 
             if (!SkinUtils.isValid(this.skin.getSkin())) {
                 throw new IllegalStateException(this.getClass().getSimpleName() + " must have a valid skin set");

--- a/src/main/java/org/powernukkitx/inventory/request/CraftRecipeAutoProcessor.java
+++ b/src/main/java/org/powernukkitx/inventory/request/CraftRecipeAutoProcessor.java
@@ -97,7 +97,7 @@ public class CraftRecipeAutoProcessor implements ItemStackRequestActionProcessor
                         }
                     }
                 }
-                output.setCount(output.getCount() * action.getTimesCrafted());
+                output.setCount(output.getCount() * resolveTimesCrafted(action));
                 CreativeOutputInventory createdOutput = player.getCreativeOutputInventory();
                 createdOutput.setItem(0, output.clone().autoAssignStackNetworkId(), false);
             }
@@ -128,4 +128,19 @@ public class CraftRecipeAutoProcessor implements ItemStackRequestActionProcessor
         }
         return found;
     }
+
+    private static int resolveTimesCrafted(AutoCraftRecipeAction action) {
+        int timesCrafted = action.getTimesCrafted();
+        if (timesCrafted > 0) {
+            return timesCrafted;
+        }
+        int numberOfRequestedCrafts = action.getNumberOfRequestedCrafts();
+        if (numberOfRequestedCrafts > 0) {
+            return numberOfRequestedCrafts;
+        }
+        log.debug("Could not determine a usable craft count for this auto-craft request (timesCrafted={}, numberOfRequestedCrafts={}) - defaulting to 1",
+            timesCrafted, numberOfRequestedCrafts);
+        return 1;
+    }
+
 }

--- a/src/main/java/org/powernukkitx/inventory/request/CraftRecipeAutoProcessor.java
+++ b/src/main/java/org/powernukkitx/inventory/request/CraftRecipeAutoProcessor.java
@@ -118,6 +118,20 @@ public class CraftRecipeAutoProcessor implements ItemStackRequestActionProcessor
         return false;
     }
 
+    private static int resolveTimesCrafted(AutoCraftRecipeAction action) {
+        int timesCrafted = action.getTimesCrafted();
+        if (timesCrafted > 0) {
+            return timesCrafted;
+        }
+        int numberOfRequestedCrafts = action.getNumberOfRequestedCrafts();
+        if (numberOfRequestedCrafts > 0) {
+            return numberOfRequestedCrafts;
+        }
+        log.debug("Auto craft request carries no usable craft count (timesCrafted {}, numberOfRequestedCrafts {}), falling back to 1",
+            timesCrafted, numberOfRequestedCrafts);
+        return 1;
+    }
+
     private static List<ConsumeAction> findAllConsumeActions(ItemStackRequestAction[] actions, int startIndex) {
         var found = new ArrayList<ConsumeAction>();
         for (int i = startIndex; i < actions.length; i++) {

--- a/src/main/java/org/powernukkitx/inventory/request/CraftRecipeAutoProcessor.java
+++ b/src/main/java/org/powernukkitx/inventory/request/CraftRecipeAutoProcessor.java
@@ -118,20 +118,6 @@ public class CraftRecipeAutoProcessor implements ItemStackRequestActionProcessor
         return false;
     }
 
-    private static int resolveTimesCrafted(AutoCraftRecipeAction action) {
-        int timesCrafted = action.getTimesCrafted();
-        if (timesCrafted > 0) {
-            return timesCrafted;
-        }
-        int numberOfRequestedCrafts = action.getNumberOfRequestedCrafts();
-        if (numberOfRequestedCrafts > 0) {
-            return numberOfRequestedCrafts;
-        }
-        log.debug("Auto craft request carries no usable craft count (timesCrafted {}, numberOfRequestedCrafts {}), falling back to 1",
-            timesCrafted, numberOfRequestedCrafts);
-        return 1;
-    }
-
     private static List<ConsumeAction> findAllConsumeActions(ItemStackRequestAction[] actions, int startIndex) {
         var found = new ArrayList<ConsumeAction>();
         for (int i = startIndex; i < actions.length; i++) {

--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -1494,8 +1494,15 @@ public class Level implements Metadatable {
                     if (entity instanceof EntityAsyncPrepare) {
                         seenAsyncPrepare = true;
                     }
-                    if (entity.closed || !entity.onUpdate(currentTick)) {
+                    try {
+                        if (entity.closed || !entity.onUpdate(currentTick)) {
+                            this.updateEntities.remove(id);
+                        }
+                    } catch (Throwable e) {
+                        // If a single entity throws on every tick, it would otherwise stall the entire level
+                        // tick forever. Remove it from the tick loop and let the rest of the level keep running.
                         this.updateEntities.remove(id);
+                        CrashReporter.log("ticking an entity (it will no longer be ticked)", entity, e);
                     }
                 }
                 this.hasAsyncPrepareEntities = seenAsyncPrepare;
@@ -4723,20 +4730,25 @@ public class Level implements Metadatable {
                     try {
                         for (Player player : playersToSend.values()) {
                             if (player.isConnected()) {
-                                final NetworkChunkPublisherUpdatePacket networkChunkPublisherUpdatePacket = new NetworkChunkPublisherUpdatePacket();
-                                networkChunkPublisherUpdatePacket.setNewPositionForView(player.asBlockVector3().toNetwork());
-                                networkChunkPublisherUpdatePacket.setNewRadiusForView(player.getViewDistance() << 4);
-                                player.sendPacketImmediately(networkChunkPublisherUpdatePacket);
-
-                                final LevelChunkPacket levelChunkPacket;
-                                levelChunkPacket = new LevelChunkPacket();
-                                levelChunkPacket.setChunkX(x);
-                                levelChunkPacket.setChunkZ(z);
-                                levelChunkPacket.setDimension(DimensionType.from(this.getDimensionData().getDimensionId()));
-                                levelChunkPacket.setSubChunksCount(pair.second());
-                                levelChunkPacket.setSerializedChunkData(/*Unpooled.buffer()*/chunkData.retainedDuplicate());
-                                player.sendChunk(x, z, levelChunkPacket);
-                                //player.refreshBlockEntity(chunk);
+                                try {
+                                    final NetworkChunkPublisherUpdatePacket networkChunkPublisherUpdatePacket = new NetworkChunkPublisherUpdatePacket();
+                                    networkChunkPublisherUpdatePacket.setNewPositionForView(player.asBlockVector3().toNetwork());
+                                    networkChunkPublisherUpdatePacket.setNewRadiusForView(player.getViewDistance() << 4);
+                                    player.sendPacketImmediately(networkChunkPublisherUpdatePacket);
+                                    final LevelChunkPacket levelChunkPacket;
+                                    levelChunkPacket = new LevelChunkPacket();
+                                    levelChunkPacket.setChunkX(x);
+                                    levelChunkPacket.setChunkZ(z);
+                                    levelChunkPacket.setDimension(DimensionType.from(this.getDimensionData().getDimensionId()));
+                                    levelChunkPacket.setSubChunksCount(pair.second());
+                                    levelChunkPacket.setSerializedChunkData(/*Unpooled.buffer()*/chunkData.retainedDuplicate());
+                                    player.sendChunk(x, z, levelChunkPacket);
+                                    //player.refreshBlockEntity(chunk);
+                                } catch (Throwable e) {
+                                    // Chunk delivery is a shared loop: one player failing to receive this chunk must not
+                                    // block the players queued after them from getting it.
+                                    CrashReporter.log("Sending a chunk to a player", player, e);
+                                }
                             }
                         }
                     } finally {

--- a/src/main/java/org/powernukkitx/network/Network.java
+++ b/src/main/java/org/powernukkitx/network/Network.java
@@ -151,6 +151,7 @@ public class Network implements NetworkInterface {
                             channel.pipeline().addLast("queryPacketCodec", new QueryPacketCodec())
                                     .addLast("queryPacketHandler", new QueryPacketHandler(address -> Network.this.server.getQueryInformation()));
                         }
+                        channel.pipeline().addLast("outboundFailureNotifier", new OutboundFailureNotifier());
                     }
 
                     @Override

--- a/src/main/java/org/powernukkitx/network/OutboundFailureNotifier.java
+++ b/src/main/java/org/powernukkitx/network/OutboundFailureNotifier.java
@@ -1,0 +1,42 @@
+package org.powernukkitx.network;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import org.powernukkitx.utils.CrashReporter;
+
+/**
+ * Tail handler that surfaces outbound write failures instead of letting them vanish silently.
+ * <p>
+ * When an outbound write fails, Netty only fails the associated promise - and a promise nobody
+ * listens to just swallows its cause. Packet serialization happens as part of that write, on the
+ * Netty thread, far from the game code that originally queued the packet. As a result, a packet
+ * built with a field accidentally left null - the most common cause - used to silently drop an
+ * entire session's batch with nothing printed anywhere. The listener registered here isn't tied
+ * to any particular session, so whatever goes wrong stays attached to the channel it happened on.
+ */
+final class OutboundFailureNotifier extends ChannelDuplexHandler {
+
+    private static final ChannelFutureListener NOTIFY_ON_FAILURE = future -> {
+        final Throwable cause = future.cause();
+        if (cause != null) {
+            CrashReporter.log("Writing to a client session", future.channel().remoteAddress(), cause);
+        }
+    };
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
+        if (!promise.isVoid()) {
+            promise.addListener(NOTIFY_ON_FAILURE);
+        }
+        ctx.write(msg, promise);
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        // Deliberately not forwarded further down the pipeline: Netty's built-in tail handler would
+        // just log it again as "nobody handled this exception", which adds nothing useful here.
+        CrashReporter.log("Handling a channel event for a session", ctx.channel().remoteAddress(), cause);
+    }
+}

--- a/src/main/java/org/powernukkitx/plugin/PluginManager.java
+++ b/src/main/java/org/powernukkitx/plugin/PluginManager.java
@@ -603,7 +603,10 @@ public class PluginManager {
 
                 try {
                     registration.callEvent(event);
-                } catch (Exception e) {
+                } catch (Throwable e) {
+                    // Throwable on purpose, not Exception: a listener built against a mismatched API version
+                    // would throw a NoClassDefFoundError, which would otherwise propagate out of the tick loop
+                    // and stop every listener still waiting to run after it.
                     log.error(this.server.getLanguage().tr("nukkit.plugin.eventError", event.getEventName(), registration.getPlugin().getDescription().getFullName(), e.getMessage(), registration.getListener().getClass().getName()), e);
                 }
             }

--- a/src/main/java/org/powernukkitx/utils/CrashReporter.java
+++ b/src/main/java/org/powernukkitx/utils/CrashReporter.java
@@ -1,0 +1,137 @@
+package org.powernukkitx.utils;
+
+import org.powernukkitx.Player;
+import org.powernukkitx.event.player.PlayerKickEvent;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Centralizes the logging and rate-limiting of internal server errors.
+ *
+ * Each "distinct" error prints its full stack trace once, then further
+ * occurrences are counted and summarized periodically so logs don't get
+ * flooded.
+ *
+ * Thread-safe: can be called from any server thread.
+ */
+public final class CrashReporter {
+
+    /** Minimum delay between two summaries of the same recurring error. */
+    public static final long SUMMARY_DELAY_MS = 60_000L;
+
+    private static final Logger LOGGER = Logger.getLogger(CrashReporter.class.getName());
+
+    private static final ConcurrentMap<String, Occurrence> HISTORY = new ConcurrentHashMap<>();
+
+    private CrashReporter() {
+        throw new UnsupportedOperationException("utility class, cannot be instantiated");
+    }
+
+    /** State kept for a given error signature. */
+    private static final class Occurrence {
+        final AtomicLong countSinceReport = new AtomicLong();
+        volatile long lastReportedAt;
+        volatile boolean reportedOnce;
+    }
+
+    /**
+     * Logs a caught and isolated error.
+     *
+     * @param task    what the server was doing when the error occurred, phrased so
+     *                the log line is actionable on its own, e.g. "ticking a player",
+     *                "sending an entity to the player"
+     * @param culprit the object responsible for the error (player, entity, packet...).
+     *                Its toString() is only evaluated if the error is actually printed.
+     *                Can be null.
+     * @param error   the caught exception
+     */
+    public static void log(String task, Object culprit, Throwable error) {
+        if (task == null || error == null) {
+            throw new IllegalArgumentException("task and error cannot be null");
+        }
+
+        final String signature = buildSignature(task, error);
+        final Occurrence occurrence = HISTORY.computeIfAbsent(signature, unused -> new Occurrence());
+
+        final long timesSkipped = occurrence.countSinceReport.getAndIncrement();
+        final long now = System.currentTimeMillis();
+
+        final boolean withinCooldown = occurrence.reportedOnce
+            && (now - occurrence.lastReportedAt) < SUMMARY_DELAY_MS;
+        if (withinCooldown) {
+            return;
+        }
+
+        occurrence.reportedOnce = true;
+        occurrence.lastReportedAt = now;
+        occurrence.countSinceReport.set(0);
+
+        if (timesSkipped == 0) {
+            LOGGER.log(Level.SEVERE, formatHeader(task, culprit), error);
+        } else {
+            LOGGER.log(Level.SEVERE, formatHeader(task, culprit) + " - happened " + timesSkipped
+                + " more time(s) since the last report", error);
+        }
+    }
+
+    /**
+     * Logs an error then disconnects only the player it is attributed to,
+     * leaving everyone else connected. The disconnect screen shows the
+     * exception type and message.
+     *
+     * Only use this when the error came directly from that player's own tick
+     * or session handling. For an error tied to shared state (a broken entity
+     * or chunk), skip the offending object instead of disconnecting, otherwise
+     * every player who comes near it gets kicked in turn.
+     *
+     * @param player player to disconnect
+     * @param task   what the server was doing, see {@link #log(String, Object, Throwable)}
+     * @param error  the caught exception
+     */
+    public static void logAndDisconnect(Player player, String task, Throwable error) {
+        if (player == null) {
+            throw new IllegalArgumentException("player cannot be null");
+        }
+
+        log(task, player, error);
+
+        final String reason = "Internal error while " + task + " - " + summarize(error);
+        try {
+            player.kick(PlayerKickEvent.Reason.UNKNOWN, reason,
+                "Internal error while " + task + "\n" + summarize(error), false);
+        } catch (Throwable kickError) {
+            log("disconnecting a player after an internal error", player, kickError);
+        }
+    }
+
+    public static String summarize(Throwable error) {
+        final String message = error.getMessage();
+        final String type = error.getClass().getSimpleName();
+        return message == null ? type : type + ": " + message;
+    }
+
+    private static String buildSignature(String task, Throwable error) {
+        final StackTraceElement[] trace = error.getStackTrace();
+        final String origin = trace.length == 0 ? "unknown" : trace[0].toString();
+        return task + "::" + error.getClass().getName() + "::" + origin;
+    }
+
+    private static String formatHeader(String task, Object culprit) {
+        return "Isolated error while " + task + " [" + describe(culprit) + "]";
+    }
+
+    private static String describe(Object culprit) {
+        if (culprit == null) {
+            return "no subject";
+        }
+        try {
+            return culprit.getClass().getSimpleName() + ": " + culprit;
+        } catch (Throwable toStringFailed) {
+            return culprit.getClass().getSimpleName() + ": <toString failed>";
+        }
+    }
+}

--- a/src/test/java/org/powernukkitx/utils/CrashReporterTest.java
+++ b/src/test/java/org/powernukkitx/utils/CrashReporterTest.java
@@ -1,0 +1,109 @@
+package org.powernukkitx.utils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The rate-limiting logic is the part of {@link CrashReporter} that's easy to get backwards: an
+ * error repeating every tick must be printed once, not twenty times a second, and a distinct error
+ * must never get hidden behind an unrelated one that's already being throttled.
+ */
+class CrashReporterTest {
+
+    private CapturingHandler handler;
+    private Logger logger;
+
+    private static final class CapturingHandler extends Handler {
+        private final List<LogRecord> records = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void publish(LogRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    @BeforeEach
+    void attachHandler() {
+        handler = new CapturingHandler();
+        logger = Logger.getLogger(CrashReporter.class.getName());
+        logger.addHandler(handler);
+    }
+
+    @AfterEach
+    void detachHandler() {
+        logger.removeHandler(handler);
+    }
+
+    @Test
+    void printsTheFirstOccurrenceWithItsStackTrace() {
+        final IllegalStateException thrown = new IllegalStateException("boom");
+        CrashReporter.log(uniqueTask(), "subject", thrown);
+
+        assertEquals(1, handler.records.size());
+        final LogRecord record = handler.records.getFirst();
+        assertEquals(Level.SEVERE, record.getLevel());
+        assertNotNull(record.getThrown(), "The throwable must reach the log, not only its message");
+        assertTrue(record.getMessage().contains("subject"));
+    }
+
+    @Test
+    void throttlesTheSameErrorRepeatingEveryTick() {
+        final String task = uniqueTask();
+        for (int tick = 0; tick < 100; tick++) {
+            CrashReporter.log(task, "subject", new IllegalStateException("boom"));
+        }
+        assertEquals(1, handler.records.size(), "An error repeating every tick must be printed once");
+    }
+
+    @Test
+    void doesNotHideAnUnrelatedErrorBehindAThrottledOne() {
+        final String throttledTask = uniqueTask();
+        for (int tick = 0; tick < 10; tick++) {
+            CrashReporter.log(throttledTask, "subject", new IllegalStateException("boom"));
+        }
+        CrashReporter.log(uniqueTask(), "other subject", new IllegalStateException("boom"));
+
+        assertEquals(2, handler.records.size());
+    }
+
+    @Test
+    void survivesASubjectWhoseToStringThrows() {
+        final Object hostile = new Object() {
+            @Override
+            public String toString() {
+                throw new UnsupportedOperationException();
+            }
+        };
+        CrashReporter.log(uniqueTask(), hostile, new IllegalStateException("boom"));
+
+        assertEquals(1, handler.records.size());
+    }
+
+    /**
+     * Errors are throttled per task for the lifetime of the JVM, so every test needs its own
+     * unique task description.
+     */
+    private static String uniqueTask() {
+        return "a unit test " + System.nanoTime();
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Adds a crash reporting system and outbound network failure notifications.

This introduces:
- A CrashReporter utility to collect and report server crashes.
- An OutboundFailureNotifier to handle outbound network failure notifications.
- Integration with core server components to improve error visibility.
- Unit tests for the crash reporting logic.

The auto craft fix derives the craft count from:
1. timesCrafted when valid.
2. numberOfRequestedCrafts as fallback.
3. 1 as a final fallback.

## Why?

Improve server diagnostics and make unexpected failures easier to detect and investigate.
This should help maintainers and server owners understand when and where failures happen.

## Type of change

- [X] Bug Fix
- [x] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 05ade96dc
- **Bedrock client version:** 26.40
- **Plugins loaded:** none

**Steps performed and results:**

1. Built the server successfully with the changes
2. Ran the existing tests and verified the crash reporting tests pass

- [x] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [x] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None.

## AI usage disclosure

| Model | What it did |

| ChatGPT | Assisted with Git workflow, PR description, and development guidance |
| Claude Fable 5 / Claude Opus 5 | Assisted with implementing the patch, formulating Javadocs, and improving documentation |

- [x] The disclosure above covers **all AI use** in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled