### PR TITLE
fix: prevent DoS through text and settings packets

### DIFF
--- a/src/main/java/org/powernukkitx/network/process/handler/SettingsCommandHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/SettingsCommandHandler.java
@@ -4,6 +4,7 @@ import org.powernukkitx.Player;
 import org.powernukkitx.Server;
 import org.powernukkitx.network.process.PacketHandler;
 import org.powernukkitx.network.process.PlayerSessionHolder;
+import lombok.extern.slf4j.Slf4j;
 import org.cloudburstmc.protocol.bedrock.packet.SettingsCommandPacket;
 
 import java.util.Locale;
@@ -11,12 +12,46 @@ import java.util.Locale;
 /**
  * @author Kaooot
  */
+@Slf4j
 public class SettingsCommandHandler implements PacketHandler<SettingsCommandPacket> {
+    private static final int MAX_COMMAND_LENGTH = 512;
 
     @Override
     public void handle(SettingsCommandPacket packet, PlayerSessionHolder holder, Server server) {
         Player player = holder.getPlayer();
-        String command = packet.getCommand().toLowerCase(Locale.ENGLISH);
+
+        if (!player.spawned || !player.isAlive()) {
+            return;
+        }
+
+        if (!holder.getPlayerHandle().packetRateLimiter.tryChat()) {
+            return;
+        }
+
+        String rawCommand = packet.getCommand();
+
+        if (rawCommand == null || rawCommand.isEmpty()) {
+            return;
+        }
+
+        if (rawCommand.length() > MAX_COMMAND_LENGTH) {
+            log.warn("{} sent an oversized SettingsCommand ({} chars)", player.getName(), rawCommand.length());
+            player.close("§cPacket handling error");
+            return;
+        }
+
+        int breakLine = rawCommand.indexOf('\n');
+        if (breakLine != -1) {
+            rawCommand = rawCommand.substring(0, breakLine);
+        }
+
+        if (rawCommand.isEmpty()) {
+            return;
+        }
+
+        String[] parts = rawCommand.split(" ", 2);
+        String command = parts[0].toLowerCase(Locale.ENGLISH) + (parts.length > 1 ? " " + parts[1] : "");
+
         player.getServer().executeCommand(player, command);
     }
 }

--- a/src/main/java/org/powernukkitx/network/process/handler/TextHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/TextHandler.java
@@ -15,6 +15,7 @@ import org.cloudburstmc.protocol.bedrock.packet.TextPacket;
  */
 @Slf4j
 public class TextHandler implements PacketHandler<TextPacket> {
+    private static final int MAX_CHAT_LENGTH = 256;
 
     @Override
     public void handle(TextPacket packet, PlayerSessionHolder holder, Server server) {
@@ -39,14 +40,71 @@ public class TextHandler implements PacketHandler<TextPacket> {
             playerHandle.player.close("§cPacket handling error");
             return;
         }
+
         if (packet.getMessageType().equals(TextPacketType.CHAT)) {
             String chatMessage = authorAndMessage.getMessage();
+
+            if (chatMessage == null || chatMessage.isEmpty()) {
+                return;
+            }
+
+            if (chatMessage.length() > MAX_CHAT_LENGTH) {
+                log.warn("{} sent an oversized chat message ({} chars)", playerHandle.getUsername(), chatMessage.length());
+                playerHandle.player.close("§cPacket handling error");
+                return;
+            }
+
+            chatMessage = sanitizeChatMessage(chatMessage);
+
+            if (chatMessage.isEmpty()) {
+                return;
+            }
+
             int breakLine = chatMessage.indexOf('\n');
-            // Chat messages shouldn't contain break lines so ignore text afterwards
             if (breakLine != -1) {
                 chatMessage = chatMessage.substring(0, breakLine);
             }
+
             playerHandle.player.chat(chatMessage);
         }
+    }
+
+    private String sanitizeChatMessage(String input) {
+        StringBuilder sb = new StringBuilder(input.length());
+
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+
+            if (c < 0x20 && c != '\n' && c != '\t') {
+                continue;
+            }
+            if (c >= 0x7F && c <= 0x9F) {
+                continue;
+            }
+
+            if (Character.isHighSurrogate(c)) {
+                if (i + 1 < input.length() && Character.isLowSurrogate(input.charAt(i + 1))) {
+                    sb.append(c);
+                    sb.append(input.charAt(i + 1));
+                    i++;
+                }
+                continue;
+            }
+            if (Character.isLowSurrogate(c)) {
+                continue;
+            }
+
+            if ((c >= 0x202A && c <= 0x202E) || (c >= 0x2066 && c <= 0x2069)) {
+                continue;
+            }
+
+            if (Character.getType(c) == Character.FORMAT) {
+                continue;
+            }
+
+            sb.append(c);
+        }
+
+        return sb.toString();
     }
 }


### PR DESCRIPTION
## What does this PR do?

To prevent DoS with specials chars and so that the player doesn't freeze when receiving a barrage of characters

## Why?

security
## Type of change

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** d16947437
- **Bedrock client version:** 26.40
- **Plugins loaded:** none

**Steps performed and results:**

1. join a server
2. connect a bot with gophertunnel with script

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|   Claude Fable 5    |     for the sanitizeChatMessage function        |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
