### PR TITLE
fix: prevent NPE crash in InternalPackManager on null resource pack chunk

### DIFF
--- a/src/main/java/org/powernukkitx/network/process/pack/InternalPackManager.java
+++ b/src/main/java/org/powernukkitx/network/process/pack/InternalPackManager.java
@@ -104,12 +104,13 @@ public class InternalPackManager {
                     dataPacket.setPackVersion(m.pack.getPackVersion());
                     dataPacket.setChunkID(m.nextToSend);
                     dataPacket.setByteOffset((long) m.maxChunkSize * m.nextToSend);
-                    dataPacket.setChunkData(Unpooled.wrappedBuffer(m.pack.getPackChunk(m.maxChunkSize * m.nextToSend, m.maxChunkSize)));
-                    if (dataPacket.getChunkData() == null) {
+                    byte[] chunkBytes = m.pack.getPackChunk(m.maxChunkSize * m.nextToSend, m.maxChunkSize);
+                    if (chunkBytes == null) {
                         log.warn("RP chunk out of range or null data: pack={} chunk={}", m.packId, m.nextToSend);
                         this.session.close("disconnectionScreen.resourcePack");
                         return;
                     }
+                    dataPacket.setChunkData(Unpooled.wrappedBuffer(chunkBytes));
 
                     // Enqueue to the baseline paced RP FIFO; pacer handles rate limiting
                     session.sendPacketImmediately(dataPacket);


### PR DESCRIPTION
## What does this PR do?

prevent NPE crash

## Why?

to security

## Type of change

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 9052ab4
- **Bedrock client version:** 26.40
- **Plugins loaded:** none

**Steps performed and results:**

1. with test

- [ ] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [X] Existing unit tests pass (`gradlew test`) - **I don't want to add another test, knowing that there are already so many.**
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|       |             |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
