### PR TITLE
fix: load smithing transform recipes

### DIFF
--- a/src/main/java/org/powernukkitx/registry/RecipeRegistry.java
+++ b/src/main/java/org/powernukkitx/registry/RecipeRegistry.java
@@ -638,9 +638,12 @@ public class RecipeRegistry implements IRegistry<String, Recipe, Recipe> {
                 String block = (String) recipe.get("block");
 
                 if (block == null) {
-                    Object typeObj = recipe.get("type");
-                    if (recipe.containsKey("base") && recipe.containsKey("addition") && recipe.containsKey("template") && recipe.containsKey("result")) {
-                        block = "smithing_table";
+                    if (recipe.containsKey("base") &&
+                        recipe.containsKey("addition") &&
+                        recipe.containsKey("template") &&
+                        recipe.containsKey("result") &&
+                        recipe.get("id").toString().startsWith("minecraft:smithing_")) {
+                            block = "smithing_table";
                     }
                 }
 

--- a/src/main/java/org/powernukkitx/registry/RecipeRegistry.java
+++ b/src/main/java/org/powernukkitx/registry/RecipeRegistry.java
@@ -638,6 +638,13 @@ public class RecipeRegistry implements IRegistry<String, Recipe, Recipe> {
                 String block = (String) recipe.get("block");
 
                 if (block == null) {
+                    Object typeObj = recipe.get("type");
+                    if (recipe.containsKey("base") && recipe.containsKey("addition") && recipe.containsKey("template") && recipe.containsKey("result")) {
+                        block = "smithing_table";
+                    }
+                }
+
+                if (block == null) {
                     // Multi recipes (type 4) have no crafting block. They are client-side
                     // special recipes such as applying a banner pattern to a shield, cloning
                     // maps, crafting fireworks, etc. They must still be registered so the client


### PR DESCRIPTION
## What does this PR do?

Fixes Netherite upgrade recipes being skipped because they do not define a `block` field.

## Why?

Without this fix, Netherite upgrade recipes do not work in the smithing table.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** `76862faec`
- **Bedrock client version:** 26.40
- **Plugins loaded:** None

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| GPT-5.6-SOL | Inspected the recipe-data. |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [ ] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled