### PR TITLE
feat: added persistent End dragon fight with portal and spike regeneration

### DIFF
--- a/src/main/java/org/powernukkitx/command/defaults/LocateCommand.java
+++ b/src/main/java/org/powernukkitx/command/defaults/LocateCommand.java
@@ -13,6 +13,7 @@ import org.powernukkitx.level.generator.populator.generic.PopulatorRuinedPortal;
 import org.powernukkitx.level.generator.populator.nether.BastionRemnantPopulator;
 import org.powernukkitx.level.generator.populator.nether.NetherFortressPopulator;
 import org.powernukkitx.level.generator.populator.nether.soulsand_valley.NetherFossilPopulator;
+import org.powernukkitx.level.generator.populator.the_end.EndCityPopulator;
 import org.powernukkitx.level.generator.populator.normal.*;
 import org.powernukkitx.level.generator.populator.placement.StructurePlacement;
 import org.powernukkitx.math.ChunkVector2;
@@ -36,7 +37,7 @@ public class LocateCommand extends VanillaCommand {
         this.commandParameters.clear();
         this.commandParameters.put("structure", new CommandParameter[]{
                 CommandParameter.newEnum("mode", new CommandEnum("LocateModeStructure", "structure")),
-                CommandParameter.newEnum("structures", new String[]{"woodland_mansion", "desert_pyramid", "igloo", "jungle_temple", "ocean_monument", "ocean_ruin", "pillager_outpost", "shipwreck", "stronghold", "swamp_hut", "trail_ruins", "trial_chambers", "village", "ruined_portal", "ancient_city", "bastion_remnant", "nether_fortress", "nether_fossil"}),
+                CommandParameter.newEnum("structures", new String[]{"woodland_mansion", "desert_pyramid", "igloo", "jungle_temple", "ocean_monument", "ocean_ruin", "pillager_outpost", "shipwreck", "stronghold", "swamp_hut", "trail_ruins", "trial_chambers", "village", "ruined_portal", "ancient_city", "end_city", "bastion_remnant", "nether_fortress", "nether_fossil"}),
                 CommandParameter.newEnum("teleport", true, CommandEnum.ENUM_BOOLEAN),
                 CommandParameter.newType("radius", true, CommandParamType.INT)
         });
@@ -85,6 +86,7 @@ public class LocateCommand extends VanillaCommand {
                     case "nether_fortress" -> NetherFortressPopulator.PLACEMENT;
                     case "nether_fossil" -> NetherFossilPopulator.PLACEMENT;
                     case "ancient_city" -> AncientCityPopulator.PLACEMENT;
+                    case "end_city" -> EndCityPopulator.PLACEMENT;
                     default -> null;
                 };
                 if (placement == null) {

--- a/src/main/java/org/powernukkitx/entity/item/EntityEnderCrystal.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityEnderCrystal.java
@@ -16,6 +16,8 @@ import org.powernukkitx.nbt.tag.CompoundTag;
 import org.cloudburstmc.protocol.bedrock.data.actor.ActorDataTypes;
 import org.cloudburstmc.protocol.bedrock.data.actor.ActorFlags;
 import org.jetbrains.annotations.NotNull;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * @author PetteriM1
@@ -33,6 +35,14 @@ public class EntityEnderCrystal extends Entity implements EntityExplosive {
      */
     protected boolean detonated = false;
 
+    /**
+     * Whether this crystal belongs to an active End dragon respawn sequence.
+     * While {@code true} the crystal is invulnerable.
+     */
+    @Getter
+    @Setter
+    private boolean respawning;
+
     public EntityEnderCrystal(IChunk chunk, CompoundTag nbt) {
         super(chunk, nbt);
     }
@@ -46,6 +56,7 @@ public class EntityEnderCrystal extends Entity implements EntityExplosive {
         if (nbtMap.contains("ShowBottom")) {
             this.setShowBase(nbtMap.getBoolean("ShowBottom"));
         }
+        respawning = nbtMap.getBoolean("Respawning");
     }
 
     @Override
@@ -53,6 +64,7 @@ public class EntityEnderCrystal extends Entity implements EntityExplosive {
         super.saveNBT();
 
         this.nbt.putBoolean("ShowBottom", this.showBase());
+        this.nbt.putBoolean("Respawning", respawning);
     }
 
     @Override
@@ -77,7 +89,7 @@ public class EntityEnderCrystal extends Entity implements EntityExplosive {
 
     @Override
     public boolean attack(EntityDamageEvent source) {
-        if (isClosed()) {
+        if (isClosed() || respawning) {
             return false;
         }
 
@@ -150,6 +162,13 @@ public class EntityEnderCrystal extends Entity implements EntityExplosive {
 
     public void setBeamTarget(BlockVector3 beamTarget) {
         this.setDataProperty(ActorDataTypes.BLOCK_TARGET, beamTarget.toNetwork());
+    }
+
+    /**
+     * Clears the crystal beam target.
+     */
+    public void clearBeamTarget() {
+        this.setDataProperty(ActorDataTypes.BLOCK_TARGET, null);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityEnderDragon.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityEnderDragon.java
@@ -3,10 +3,6 @@ package org.powernukkitx.entity.mob;
 import org.powernukkitx.Player;
 import org.powernukkitx.Server;
 import org.powernukkitx.block.Block;
-import org.powernukkitx.block.BlockBedrock;
-import org.powernukkitx.block.BlockEndGateway;
-import org.powernukkitx.block.BlockTorch;
-import org.powernukkitx.block.property.enums.TorchFacingDirection;
 import org.powernukkitx.entity.Attribute;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityFlyable;
@@ -64,7 +60,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 
-import static org.powernukkitx.block.property.CommonBlockProperties.TORCH_FACING_DIRECTION;
 
 public class EntityEnderDragon extends EntityBoss implements EntityFlyable {
 
@@ -181,42 +176,9 @@ public class EntityEnderDragon extends EntityBoss implements EntityFlyable {
             super.kill();
             close();
             if(this.getLevel().getDimension() == Level.DIMENSION_THE_END) {
-                if (!isRevived()) {
-                    int y = getLevel().getHighestBlockAt(Vector2.ZERO);
-                    getLevel().setBlock(new Vector3(0, y + 1, 0), Block.get(Block.DRAGON_EGG));
-                    for (BlockFace face : BlockFace.getHorizontals()) {
-                        Block torch = BlockTorch.PROPERTIES.getBlockState(TORCH_FACING_DIRECTION.createValue(TorchFacingDirection.getByTorchDirection(face))).toBlock();
-                        getLevel().setBlock(new Vector3(0, y - 1, 0).getSide(face), torch);
-                    }
-                }
-
-                for (int y = getLevel().getMinHeight(); y < getLevel().getHighestBlockAt(0, 0); y++) {
-                    if (getLevel().getBlock(0, y, 0) instanceof BlockBedrock) {
-                        for (int i = -2; i <= 2; i++) {
-                            for (int j = -1; j <= 1; j++) {
-                                if (!(i == 0 && j == 0)) {
-                                    getLevel().setBlock(new Vector3(i, y + 1, j), Block.get(Block.END_PORTAL));
-                                    getLevel().setBlock(new Vector3(j, y + 1, i), Block.get(Block.END_PORTAL));
-                                }
-                            }
-                        }
-                        break;
-                    }
-                }
-
-                for (int i = 0; i < 20; i++) {
-                    Vector3 origin = Vector3.ZERO;
-                    double angleIncrement = 360.0 / 20;
-                    double angle = Math.toRadians(i * angleIncrement);
-                    double particleX = origin.getX() + Math.cos(angle) * 96;
-                    double particleZ = origin.getZ() + Math.sin(angle) * 96;
-                    Block dest = getLevel().getBlock(new Vector3(particleX, 75, particleZ));
-                    if (!(dest instanceof BlockEndGateway)) {
-                        Arrays.stream(BlockFace.values()).forEach(face -> getLevel().setBlock(dest.up().getSide(face), Block.get(Block.BEDROCK)));
-                        Arrays.stream(BlockFace.values()).forEach(face -> getLevel().setBlock(dest.down().getSide(face), Block.get(Block.BEDROCK)));
-                        getLevel().setBlock(dest, Block.get(Block.END_GATEWAY));
-                        break;
-                    }
+                var fight = getLevel().getEnderDragonFight();
+                if (fight != null) {
+                    fight.setDragonKilled(this);
                 }
             }
         }
@@ -356,4 +318,3 @@ public class EntityEnderDragon extends EntityBoss implements EntityFlyable {
         }
     }
 }
-

--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -16,6 +16,7 @@ import org.powernukkitx.blockentity.BlockEntitySpawnable;
 import org.powernukkitx.config.category.GameplaySettings;
 import org.powernukkitx.level.tickingarea.TickingArea;
 import org.powernukkitx.level.tickingarea.manager.TickingAreaManager;
+import org.powernukkitx.level.enderdragon.EnderDragonFight;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityAsyncPrepare;
 import org.powernukkitx.entity.EntityID;
@@ -317,6 +318,7 @@ public class Level implements Metadatable {
      */
     public static final AtomicLong GENERATED_CHUNK_COUNT = new AtomicLong();
     private final Server server;
+    private EnderDragonFight enderDragonFight;
     private final int levelId;
     // Loaders still remain single-threaded
     private final Int2ObjectOpenHashMap<ChunkLoader> loaders = new Int2ObjectOpenHashMap<>();
@@ -480,6 +482,9 @@ public class Level implements Metadatable {
             throw new LevelException("Constructor of " + provider + " failed", e);
         }
         LevelProvider levelProvider = requireProvider();
+        if (levelProvider.isTheEnd()) {
+            this.enderDragonFight = new EnderDragonFight(this);
+        }
         //to be changed later as the Dim0 will be deleted to be put in a config.json file of the world
         log.info(this.server.getLanguage().tr("nukkit.level.preparing", TextFormat.GREEN + levelProvider.getName() + TextFormat.RESET));
         levelProvider.updateLevelName(name);
@@ -686,6 +691,16 @@ public class Level implements Metadatable {
 
     public Generator getGenerator() {
         return generator;
+    }
+
+    /**
+     * Returns the End dragon fight controller for this level.
+     *
+     * @return the controller, or {@code null} when this is not an End level
+     */
+    @Nullable
+    public EnderDragonFight getEnderDragonFight() {
+        return enderDragonFight;
     }
 
     public BlockMetadataStore getBlockMetadata() {
@@ -1428,6 +1443,9 @@ public class Level implements Metadatable {
             }
 
             this.levelCurrentTick++;
+            if (this.enderDragonFight != null) {
+                this.enderDragonFight.tick();
+            }
             if (prof) phase[2] = -phaseStart + (phaseStart = System.nanoTime());
 
             if (gameplaySettings.enableEntitySpawning() && getGameRules().getBoolean(GameRule.DO_MOB_SPAWNING)) {

--- a/src/main/java/org/powernukkitx/level/enderdragon/EnderDragonFight.java
+++ b/src/main/java/org/powernukkitx/level/enderdragon/EnderDragonFight.java
@@ -1,0 +1,369 @@
+package org.powernukkitx.level.enderdragon;
+
+import org.powernukkitx.entity.Entity;
+import org.powernukkitx.entity.item.EntityEnderCrystal;
+import org.powernukkitx.entity.mob.EntityEnderDragon;
+import org.powernukkitx.block.BlockBedrock;
+import org.powernukkitx.block.BlockEndPortal;
+import org.powernukkitx.level.Level;
+import org.powernukkitx.level.format.leveldb.LevelDBProvider;
+import org.powernukkitx.level.generator.object.BlockManager;
+import org.powernukkitx.level.generator.object.ObjectEndGateway;
+import org.powernukkitx.level.generator.object.ObjectExitPortal;
+import org.powernukkitx.level.generator.object.ObjectObsidianPillar;
+import org.powernukkitx.level.Position;
+import org.powernukkitx.math.SimpleAxisAlignedBB;
+import org.powernukkitx.math.BlockVector3;
+import org.powernukkitx.math.Vector3;
+import org.powernukkitx.nbt.tag.CompoundTag;
+import org.powernukkitx.nbt.tag.ListTag;
+import org.powernukkitx.nbt.tag.StringTag;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+public class EnderDragonFight {
+    private static final String TAG = "EnderDragonFight";
+    private static final int GATEWAY_COUNT = 20;
+    private static final int DRAGON_SPAWN_Y = 128;
+    private static final int PLAYER_SCAN_INTERVAL = 20;
+    private static final int CRYSTAL_SCAN_INTERVAL = 100;
+    private static final int DRAGON_SCAN_INTERVAL = 1200;
+    private static final int PREPARING_RESPAWN_TICKS = 100;
+    private static final int PILLAR_RESPAWN_TICKS = 40;
+    private static final int SUMMONING_DRAGON_TICKS = 100;
+    private static final int RESPAWN_DURATION = PREPARING_RESPAWN_TICKS + PILLAR_RESPAWN_TICKS * 10 + SUMMONING_DRAGON_TICKS;
+    private static final int[][] RESPAWN_CRYSTAL_OFFSETS = {{3, 0}, {-3, 0}, {0, 3}, {0, -3}};
+
+    private final Level level;
+    private final List<Integer> gateways = new ArrayList<>(GATEWAY_COUNT);
+    private boolean dragonKilled;
+    private boolean previouslyKilled;
+    private boolean needsStateScanning;
+    private String dragonUniqueId;
+    private boolean nearbyPlayer;
+    private int ticksSincePlayerScan = PLAYER_SCAN_INTERVAL + 1;
+    private int ticksSinceCrystalScan;
+    private int ticksSinceDragonSeen;
+    private int ticksSinceRespawnCrystalRestore = CRYSTAL_SCAN_INTERVAL;
+    private int respawnTicks = -1;
+    private final List<EntityEnderCrystal> respawnCrystals = new ArrayList<>(4);
+    private final List<String> respawnCrystalUniqueIds = new ArrayList<>(4);
+
+    /**
+     * Creates the End dragon fight controller for a level.
+     *
+     * @param level the End level that owns this controller
+     */
+    public EnderDragonFight(Level level) {
+        this.level = level;
+        load();
+        if (gateways.isEmpty()) {
+            for (int i = 0; i < GATEWAY_COUNT; i++) {
+                gateways.add(i);
+            }
+            Collections.shuffle(gateways, new Random(level.getSeed()));
+            save();
+        }
+    }
+
+    /**
+     * Updates the fight state from the owning level tick.
+     */
+    public void tick() {
+        if (++ticksSincePlayerScan >= PLAYER_SCAN_INTERVAL) {
+            nearbyPlayer = hasNearbyPlayer();
+            ticksSincePlayerScan = 0;
+        }
+        if (!nearbyPlayer) {
+            return;
+        }
+        if (needsStateScanning) {
+            scanState();
+            needsStateScanning = false;
+            save();
+        }
+        if (respawnTicks >= 0) {
+            if (respawnCrystals.isEmpty() && !restoreRespawnCrystals()) {
+                return;
+            }
+            tickRespawn();
+            return;
+        }
+        if (!dragonKilled) {
+            if (dragonUniqueId == null || ++ticksSinceDragonSeen >= DRAGON_SCAN_INTERVAL) {
+                if (findDragon() == null) {
+                    createDragon();
+                }
+                ticksSinceDragonSeen = 0;
+            }
+        } else if (++ticksSinceCrystalScan >= CRYSTAL_SCAN_INTERVAL) {
+            tryRespawn();
+            ticksSinceCrystalScan = 0;
+        }
+    }
+
+    /**
+     * Records the death of the dragon managed by this fight.
+     *
+     * @param dragon the dragon that completed its death animation
+     */
+    public void setDragonKilled(EntityEnderDragon dragon) {
+        if (dragonUniqueId != null && !dragonUniqueId.equals(dragon.getUniqueId().toString())) {
+            return;
+        }
+        dragonKilled = true;
+        dragonUniqueId = dragon.getUniqueId().toString();
+        respawnTicks = -1;
+        ticksSinceCrystalScan = 0;
+        spawnPodium(true);
+        if (!previouslyKilled) {
+            int y = level.getHighestBlockAt(0, 0);
+            level.setBlock(new Vector3(0, y + 1, 0), org.powernukkitx.block.Block.get(org.powernukkitx.block.Block.DRAGON_EGG));
+        }
+        spawnGateway();
+        previouslyKilled = true;
+        save();
+    }
+
+    private void tryRespawn() {
+        int podiumY = getPodiumY();
+        List<EntityEnderCrystal> crystals = new ArrayList<>(4);
+        for (int[] offset : RESPAWN_CRYSTAL_OFFSETS) {
+            EntityEnderCrystal crystal = null;
+            for (Entity entity : level.getNearbyEntities(new SimpleAxisAlignedBB(offset[0] - 1, podiumY, offset[1] - 1, offset[0] + 2, podiumY + 4, offset[1] + 2))) {
+                if (entity instanceof EntityEnderCrystal enderCrystal) {
+                    crystal = enderCrystal;
+                    break;
+                }
+            }
+            if (crystal == null) {
+                return;
+            }
+            crystals.add(crystal);
+        }
+        respawnCrystals.clear();
+        respawnCrystalUniqueIds.clear();
+        for (EntityEnderCrystal crystal : crystals) {
+            crystal.setRespawning(true);
+            crystal.setBeamTarget(new BlockVector3(0, podiumY + 1, 0));
+            respawnCrystals.add(crystal);
+            respawnCrystalUniqueIds.add(crystal.getUniqueId().toString());
+        }
+        respawnTicks = 0;
+        spawnPodium(false);
+        save();
+    }
+
+    private void tickRespawn() {
+        int tick = respawnTicks++;
+        if (respawnCrystals.stream().anyMatch(Entity::isClosed)) {
+            abortRespawn();
+            return;
+        }
+        if (tick >= PREPARING_RESPAWN_TICKS && tick < PREPARING_RESPAWN_TICKS + PILLAR_RESPAWN_TICKS * 10
+                && (tick - PREPARING_RESPAWN_TICKS) % PILLAR_RESPAWN_TICKS == 0) {
+            resetSpike((tick - PREPARING_RESPAWN_TICKS) / PILLAR_RESPAWN_TICKS);
+        }
+        if (tick < RESPAWN_DURATION) {
+            return;
+        }
+        for (EntityEnderCrystal crystal : respawnCrystals) {
+            crystal.setRespawning(false);
+            crystal.close();
+        }
+        respawnCrystals.clear();
+        respawnCrystalUniqueIds.clear();
+        dragonKilled = false;
+        respawnTicks = -1;
+        ticksSinceDragonSeen = 0;
+        createDragon();
+        save();
+    }
+
+    private void resetSpike(int index) {
+        Random random = new Random(level.getSeed());
+        random.setSeed(random.nextLong() & 65535L);
+        List<Integer> values = new ArrayList<>(10);
+        for (int i = 0; i < 10; i++) {
+            values.add(i);
+        }
+        Collections.shuffle(values, random);
+        int value = values.get(index);
+        int x = (int) Math.floor(42d * Math.cos(2d * (-Math.PI + Math.PI / 10d * index)));
+        int z = (int) Math.floor(42d * Math.sin(2d * (-Math.PI + Math.PI / 10d * index)));
+        int height = 76 + value * 3;
+        BlockVector3 beamTarget = new BlockVector3(x, height + 1, z);
+        for (EntityEnderCrystal crystal : respawnCrystals) {
+            crystal.setBeamTarget(beamTarget);
+        }
+        for (Entity entity : level.getNearbyEntities(new SimpleAxisAlignedBB(x - 5, height - 1, z - 5, x + 6, height + 5, z + 6))) {
+            if (entity instanceof EntityEnderCrystal) {
+                entity.close();
+            }
+        }
+        BlockManager manager = new BlockManager(level);
+        new ObjectObsidianPillar(2 + value / 3, height, value == 1 || value == 2)
+                .generate(manager, null, new Vector3(x, level.getHeightMap(x, z), z));
+        manager.applySubChunkUpdate();
+    }
+
+    private void abortRespawn() {
+        for (EntityEnderCrystal crystal : respawnCrystals) {
+            crystal.setRespawning(false);
+            crystal.clearBeamTarget();
+        }
+        respawnCrystals.clear();
+        respawnCrystalUniqueIds.clear();
+        respawnTicks = -1;
+        spawnPodium(true);
+        save();
+    }
+
+    private void spawnPodium(boolean active) {
+        BlockManager manager = new BlockManager(level);
+        new ObjectExitPortal(active).generate(manager, null, new Vector3(0, getPodiumY(), 0));
+        manager.applySubChunkUpdate();
+    }
+
+    private void spawnGateway() {
+        if (gateways.isEmpty()) {
+            return;
+        }
+        int gateway = gateways.removeLast();
+        int x = (int) Math.floor(96d * Math.cos(2d * (-Math.PI + Math.PI / 20d * gateway)));
+        int z = (int) Math.floor(96d * Math.sin(2d * (-Math.PI + Math.PI / 20d * gateway)));
+        BlockManager manager = new BlockManager(level);
+        new ObjectEndGateway().generate(manager, null, new Vector3(x, 75, z));
+        manager.applySubChunkUpdate();
+    }
+
+    private EntityEnderDragon findDragon() {
+        EntityEnderDragon firstDragon = null;
+        for (Entity entity : level.getEntities()) {
+            if (entity instanceof EntityEnderDragon dragon && dragon.isAlive()) {
+                if (dragonUniqueId == null || dragonUniqueId.equals(dragon.getUniqueId().toString())) {
+                    dragonUniqueId = dragon.getUniqueId().toString();
+                    return dragon;
+                }
+                firstDragon = dragon;
+            }
+        }
+        if (firstDragon != null) {
+            dragonUniqueId = firstDragon.getUniqueId().toString();
+        }
+        return firstDragon;
+    }
+
+    private void createDragon() {
+        Entity entity = Entity.createEntity(Entity.ENDER_DRAGON, new Position(0.5, DRAGON_SPAWN_Y, 0.5, level));
+        if (entity instanceof EntityEnderDragon dragon) {
+            level.addEntity(dragon);
+            dragon.spawnToAll();
+            dragonUniqueId = dragon.getUniqueId().toString();
+            save();
+        }
+    }
+
+    private int getPodiumY() {
+        int highest = level.getHighestBlockAt(0, 0);
+        for (int y = highest; y >= level.getMinHeight() + 4; y--) {
+            if (level.getBlock(0, y, 0) instanceof BlockBedrock
+                    && level.getBlock(0, y - 1, 0) instanceof BlockBedrock
+                    && level.getBlock(0, y - 2, 0) instanceof BlockBedrock
+                    && level.getBlock(0, y - 3, 0) instanceof BlockBedrock) {
+                return y - 3;
+            }
+        }
+        return Math.max(level.getMinHeight() + 1, highest - 3);
+    }
+
+    private boolean restoreRespawnCrystals() {
+        if (++ticksSinceRespawnCrystalRestore < CRYSTAL_SCAN_INTERVAL || respawnCrystalUniqueIds.isEmpty()) {
+            return false;
+        }
+        ticksSinceRespawnCrystalRestore = 0;
+        List<EntityEnderCrystal> crystals = new ArrayList<>(respawnCrystalUniqueIds.size());
+        for (String uniqueId : respawnCrystalUniqueIds) {
+            EntityEnderCrystal crystal = null;
+            for (Entity entity : level.getEntities()) {
+                if (entity instanceof EntityEnderCrystal enderCrystal && uniqueId.equals(enderCrystal.getUniqueId().toString())) {
+                    crystal = enderCrystal;
+                    break;
+                }
+            }
+            if (crystal == null) {
+                return false;
+            }
+            crystals.add(crystal);
+        }
+        respawnCrystals.addAll(crystals);
+        return true;
+    }
+
+    private void scanState() {
+        boolean activePortal = false;
+        int highest = level.getHighestBlockAt(0, 0);
+        for (int y = highest; y >= level.getMinHeight(); y--) {
+            if (level.getBlock(0, y, 0) instanceof BlockEndPortal) {
+                activePortal = true;
+                break;
+            }
+        }
+        EntityEnderDragon dragon = findDragon();
+        previouslyKilled = activePortal;
+        dragonKilled = dragon == null;
+        if (!previouslyKilled && dragonKilled) {
+            dragonKilled = false;
+        }
+        if (!activePortal && dragon == null) {
+            spawnPodium(false);
+        }
+    }
+
+    private boolean hasNearbyPlayer() {
+        for (var player : level.getPlayers().values()) {
+            if (player.distanceSquared(new Vector3(0, 128, 0)) <= 192 * 192) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void load() {
+        if (level.getProvider() instanceof LevelDBProvider provider) {
+            CompoundTag tag = provider.getWorldDynamicProperties().getCompound(TAG);
+            needsStateScanning = !provider.getWorldDynamicProperties().contains(TAG) || tag.getBoolean("NeedsStateScanning");
+            dragonKilled = tag.getBoolean("DragonKilled");
+            previouslyKilled = tag.getBoolean("PreviouslyKilled");
+            dragonUniqueId = tag.getString("DragonUniqueId");
+            if (dragonUniqueId.isEmpty()) {
+                dragonUniqueId = null;
+            }
+            respawnTicks = tag.getInt("RespawnTicks", -1);
+            for (StringTag crystalUniqueId : tag.getList("RespawnCrystals", StringTag.class).getAll()) {
+                respawnCrystalUniqueIds.add(crystalUniqueId.parseValue());
+            }
+            for (int gateway : tag.getIntArray("Gateways")) {
+                gateways.add(gateway);
+            }
+        }
+    }
+
+    private void save() {
+        if (level.getProvider() instanceof LevelDBProvider provider) {
+            CompoundTag properties = provider.getWorldDynamicProperties();
+            properties.putCompound(TAG, new CompoundTag()
+                    .putBoolean("DragonKilled", dragonKilled)
+                    .putBoolean("PreviouslyKilled", previouslyKilled)
+                    .putBoolean("NeedsStateScanning", needsStateScanning)
+                    .putString("DragonUniqueId", dragonUniqueId == null ? "" : dragonUniqueId)
+                    .putInt("RespawnTicks", respawnTicks)
+                    .putList("RespawnCrystals", new ListTag<StringTag>().addAll(respawnCrystalUniqueIds.stream().map(StringTag::new).toList()))
+                    .putIntArray("Gateways", gateways.stream().mapToInt(Integer::intValue).toArray()));
+            provider.setWorldDynamicPropertiesDirty(true);
+        }
+    }
+}

--- a/src/main/java/org/powernukkitx/level/generator/object/ObjectExitPortal.java
+++ b/src/main/java/org/powernukkitx/level/generator/object/ObjectExitPortal.java
@@ -2,32 +2,61 @@ package org.powernukkitx.level.generator.object;
 
 import org.powernukkitx.block.BlockAir;
 import org.powernukkitx.block.BlockBedrock;
+import org.powernukkitx.block.BlockEndPortal;
+import org.powernukkitx.block.BlockEndStone;
 import org.powernukkitx.block.BlockState;
+import org.powernukkitx.block.BlockTorch;
+import org.powernukkitx.block.property.enums.TorchFacingDirection;
+import org.powernukkitx.math.BlockFace;
 import org.powernukkitx.math.Vector3;
 import org.powernukkitx.utils.random.RandomSourceProvider;
+
+import static org.powernukkitx.block.property.CommonBlockProperties.TORCH_FACING_DIRECTION;
 
 public class ObjectExitPortal extends ObjectGenerator {
 
     protected static final BlockState BEDROCK = BlockBedrock.PROPERTIES.getDefaultState();
+    protected static final BlockState END_STONE = BlockEndStone.PROPERTIES.getDefaultState();
+    protected static final BlockState END_PORTAL = BlockEndPortal.PROPERTIES.getDefaultState();
+
+    private final boolean active;
+
+    public ObjectExitPortal(boolean active) {
+        this.active = active;
+    }
 
     @Override
     public boolean generate(BlockManager level, RandomSourceProvider rand, Vector3 pos) {
 
-        for(int x = -2; x <= 2; x++){
-            for(int z = -2; z <= 2; z++){
-                if(!(Math.abs(x) == 2 && Math.abs(z) == 2)) {
-                    level.setBlockStateAt(pos.getFloorX() + x, pos.getFloorY() - 1, pos.getFloorZ() + z, BEDROCK);
-                    level.setBlockStateAt(pos.getFloorX() + x, pos.getFloorY(), pos.getFloorZ() + z, BlockAir.STATE);
-                    if(x == -2) level.setBlockStateAt(pos.getFloorX() - 3, pos.getFloorY(), pos.getFloorZ() + z, BEDROCK);
-                    if(x == 2) level.setBlockStateAt(pos.getFloorX() + 3, pos.getFloorY(), pos.getFloorZ() + z, BEDROCK);
-                    if(z == -2) level.setBlockStateAt(pos.getFloorX() + x, pos.getFloorY(), pos.getFloorZ() - 3, BEDROCK);
-                    if(z == 2) level.setBlockStateAt(pos.getFloorX() + x, pos.getFloorY(), pos.getFloorZ() + 3, BEDROCK);
-                } else level.setBlockStateAt(pos.getFloorX() + x, pos.getFloorY(), pos.getFloorZ() + z, BEDROCK);
+        int originX = pos.getFloorX();
+        int originY = pos.getFloorY();
+        int originZ = pos.getFloorZ();
+        for (int x = -4; x <= 4; x++) {
+            for (int y = -1; y <= 32; y++) {
+                for (int z = -4; z <= 4; z++) {
+                    int distanceSquared = x * x + y * y + z * z;
+                    if (distanceSquared >= 13) {
+                        continue;
+                    }
+                    if (y < 0) {
+                        level.setBlockStateAt(originX + x, originY + y, originZ + z, distanceSquared < 7 ? BEDROCK : END_STONE);
+                    } else if (y > 0) {
+                        level.setBlockStateAt(originX + x, originY + y, originZ + z, BlockAir.STATE);
+                    } else if (distanceSquared >= 7) {
+                        level.setBlockStateAt(originX + x, originY, originZ + z, BEDROCK);
+                    } else {
+                        level.setBlockStateAt(originX + x, originY, originZ + z, active ? END_PORTAL : BlockAir.STATE);
+                    }
+                }
             }
         }
 
-        for(int i = 0; i < 4; i++) {
-            level.setBlockStateAt(pos.getFloorX(), pos.getFloorY() + i, pos.getFloorZ(), BEDROCK);
+        for (int y = 0; y < 4; y++) {
+            level.setBlockStateAt(originX, originY + y, originZ, BEDROCK);
+        }
+        for (BlockFace face : BlockFace.getHorizontals()) {
+            level.setBlockStateAt(originX + face.getXOffset(), originY + 2, originZ + face.getZOffset(),
+                    BlockTorch.PROPERTIES.getBlockState(TORCH_FACING_DIRECTION.createValue(TorchFacingDirection.getByTorchDirection(face))));
         }
 
         return true;

--- a/src/main/java/org/powernukkitx/level/generator/object/ObjectObsidianPillar.java
+++ b/src/main/java/org/powernukkitx/level/generator/object/ObjectObsidianPillar.java
@@ -1,6 +1,7 @@
 package org.powernukkitx.level.generator.object;
 
 import org.powernukkitx.block.BlockBedrock;
+import org.powernukkitx.block.BlockAir;
 import org.powernukkitx.block.BlockFire;
 import org.powernukkitx.block.BlockIronBars;
 import org.powernukkitx.block.BlockObsidian;
@@ -11,57 +12,39 @@ import org.powernukkitx.nbt.tag.DoubleTag;
 import org.powernukkitx.nbt.tag.FloatTag;
 import org.powernukkitx.nbt.tag.ListTag;
 import org.powernukkitx.utils.random.RandomSourceProvider;
-import lombok.Getter;
-import lombok.Setter;
-
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.powernukkitx.block.property.CommonBlockProperties.INFINIBURN_BIT;
 
-@Getter
-@Setter
 public class ObjectObsidianPillar extends ObjectGenerator {
+    private final int radius;
+    private final int height;
+    private final boolean guarded;
 
-    public int i = 0;
-    private int seed = 0;
-
-
-    public int getPillar() {
-        return Math.abs((i * 73 + seed) % 10);
-    }
-
-    public int getRadius() {
-        return 2 + getPillar() / 3;
-    }
-
-    public int getHeight() {
-        return 76 + getPillar() * 3;
-    }
-
-    public boolean isGuarded() {
-        int pillar = getPillar();
-        return pillar == 1 || pillar == 2;
+    public ObjectObsidianPillar(int radius, int height, boolean guarded) {
+        this.radius = radius;
+        this.height = height;
+        this.guarded = guarded;
     }
 
     @Override
     public boolean generate(BlockManager level, RandomSourceProvider rand, Vector3 position) {
-        this.seed = (int) level.getSeed();
         int x = position.getFloorX();
         int z = position.getFloorZ();
-        int height = getHeight();
-        int radius = getRadius();
 
-        for (int i = 0; i < height; i++) {
+        for (int i = level.getLevel().getMinHeight(); i <= height + 10; i++) {
             for (int j = -radius; j <= radius; j++) {
                 for (int k = -radius; k <= radius; k++) {
-                    if (j * j + k * k <= radius * radius + 1) {
+                    if (j * j + k * k <= radius * radius + 1 && i < height) {
                         level.setBlockStateAt(x + j, i, z + k, BlockObsidian.PROPERTIES.getDefaultState());
+                    } else if (i > 65) {
+                        level.setBlockStateAt(x + j, i, z + k, BlockAir.STATE);
                     }
                 }
             }
         }
 
-        if (this.isGuarded()) {
+        if (guarded) {
             for (int i = -2; i <= 2; ++i) {
                 for (int j = -2; j <= 2; ++j) {
                     if (Math.abs(i) == 2 || Math.abs(j) == 2) {
@@ -87,11 +70,14 @@ public class ObjectObsidianPillar extends ObjectGenerator {
                             .add(new DoubleTag(0))
                             .add(new DoubleTag(0)))
                     .putList("Rotation", new ListTag<FloatTag>()
-                            .add(new FloatTag(new Random().nextFloat() * 360))
+                            .add(new FloatTag(ThreadLocalRandom.current().nextFloat() * 360))
                             .add(new FloatTag(0)));
 
             Entity entity = Entity.createEntity(Entity.ENDER_CRYSTAL, level.getChunk(position.getChunkX(), position.getChunkZ()), nbt);
-            entity.spawnToAll();
+            if (entity != null) {
+                level.getLevel().addEntity(entity);
+                entity.spawnToAll();
+            }
         });
         return true;
     }

--- a/src/main/java/org/powernukkitx/level/generator/populator/the_end/EndCityPopulator.java
+++ b/src/main/java/org/powernukkitx/level/generator/populator/the_end/EndCityPopulator.java
@@ -8,7 +8,9 @@ import org.powernukkitx.level.generator.object.BlockManager;
 import org.powernukkitx.level.generator.object.structures.EndCityPieces;
 import org.powernukkitx.level.generator.populator.Populator;
 import org.powernukkitx.level.generator.populator.PopulatorStructure;
+import org.powernukkitx.level.generator.populator.placement.StructurePlacement;
 import org.powernukkitx.math.BlockVector3;
+import org.powernukkitx.utils.random.RandomSourceProvider;
 import org.powernukkitx.utils.random.Xoroshiro128;
 
 public class EndCityPopulator extends Populator implements PopulatorStructure {
@@ -16,6 +18,21 @@ public class EndCityPopulator extends Populator implements PopulatorStructure {
     public static final String NAME = "the_end_end_city";
     private static final int SPACING = 20;
     private static final int SEPARATION = 11;
+
+    /**
+     * End City placement shared by generation and {@code /locate structure end_city}.
+     */
+    public static final StructurePlacement PLACEMENT = new StructurePlacement(StructurePlacement.PlacementSettings.builder()
+            .salt(10387313L)
+            .minDistance(SEPARATION)
+            .maxDistance(SPACING)
+            .build()) {
+        @Override
+        public boolean canGenerate(long levelSeed, RandomSourceProvider random, int chunkX, int chunkZ, int biome) {
+            return (long) chunkX * chunkX + (long) chunkZ * chunkZ > 4096L
+                    && super.canGenerate(levelSeed, random, chunkX, chunkZ, biome);
+        }
+    };
 
     @Override
     public void apply(ChunkGenerateContext context) {
@@ -26,13 +43,7 @@ public class EndCityPopulator extends Populator implements PopulatorStructure {
         int chunkZ = chunk.getZ();
         Level level = chunk.getLevel();
 
-        if ((long) chunkX * (long) chunkX + (long) chunkZ * (long) chunkZ <= 4096L) {
-            return;
-        }
-
-        random.setSeed(level.getSeed() ^ Level.chunkHash(chunkX, chunkZ));
-        if (chunkX != (((chunkX < 0 ? chunkX - SPACING + 1 : chunkX) / SPACING) * SPACING) + random.nextBoundedInt(SPACING - SEPARATION)
-                || chunkZ != (((chunkZ < 0 ? chunkZ - SPACING + 1 : chunkZ) / SPACING) * SPACING) + random.nextBoundedInt(SPACING - SEPARATION)) {
+        if (!chunk.isTheEnd() || !PLACEMENT.canGenerate(level.getSeed(), random, chunkX, chunkZ, 0)) {
             return;
         }
 

--- a/src/main/java/org/powernukkitx/level/generator/populator/the_end/EnderDragonPopulator.java
+++ b/src/main/java/org/powernukkitx/level/generator/populator/the_end/EnderDragonPopulator.java
@@ -36,7 +36,10 @@ public class EnderDragonPopulator extends Populator {
                             .add(new FloatTag(new Random().nextFloat() * 360))
                             .add(new FloatTag(0)));
             Entity entity = Entity.createEntity(Entity.ENDER_DRAGON, chunk, nbt);
-            entity.spawnToAll();
+            if (entity != null) {
+                chunk.getLevel().addEntity(entity);
+                entity.spawnToAll();
+            }
         }
     }
 

--- a/src/main/java/org/powernukkitx/level/generator/populator/the_end/ExitPortalPopulator.java
+++ b/src/main/java/org/powernukkitx/level/generator/populator/the_end/ExitPortalPopulator.java
@@ -21,7 +21,7 @@ public class ExitPortalPopulator extends Populator {
 
         if(chunkX == 1 && chunkZ == 0) {
             BlockManager object = new BlockManager(level);
-            ObjectExitPortal exitPortal = new ObjectExitPortal();
+            ObjectExitPortal exitPortal = new ObjectExitPortal(false);
             exitPortal.generate(object, null, new Vector3(0, chunk.getHeightMap(0, 0), 0));
             object.applySubChunkUpdate();
         }

--- a/src/main/java/org/powernukkitx/level/generator/populator/the_end/ObsidianPillarPopulator.java
+++ b/src/main/java/org/powernukkitx/level/generator/populator/the_end/ObsidianPillarPopulator.java
@@ -9,11 +9,17 @@ import org.powernukkitx.level.generator.populator.Populator;
 import org.powernukkitx.math.Vector2;
 import org.powernukkitx.math.Vector3;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
 public class ObsidianPillarPopulator extends Populator {
 
     public static final String NAME = "the_end_obsidian_pillar";
 
-    private Vector2[] pillarPos;
+    private EndSpike[] spikes;
+    private long spikeSeed = Long.MIN_VALUE;
 
     @Override
     public void apply(ChunkGenerateContext context) {
@@ -21,24 +27,41 @@ public class ObsidianPillarPopulator extends Populator {
         int chunkX = chunk.getX();
         int chunkZ = chunk.getZ();
         Level level = chunk.getLevel();
-        if(pillarPos == null) {
-            pillarPos = new Vector2[10];
-            for(int i = 0; i < 10; i++) {
-                int x = (int) (42d * Math.cos(2d * (-Math.PI + (Math.PI / 10d) * i)));
-                int z = (int) (42d * Math.sin(2d * (-Math.PI + (Math.PI / 10d) * i)));
-                pillarPos[i] = new Vector2(x, z);
-            }
+        if (spikes == null || spikeSeed != level.getSeed()) {
+            spikeSeed = level.getSeed();
+            spikes = createSpikes(spikeSeed);
         }
-        for(int i = 0; i < pillarPos.length; i++) {
-            Vector2 p = pillarPos[i];
+        for (EndSpike spike : spikes) {
+            Vector2 p = spike.position();
             if(p.getFloorX() >> 4 == chunkX && p.getFloorY() >> 4 == chunkZ) {
                 BlockManager object = new BlockManager(level);
-                ObjectObsidianPillar pillar = new ObjectObsidianPillar();
-                pillar.i = i;
+                ObjectObsidianPillar pillar = new ObjectObsidianPillar(spike.radius(), spike.height(), spike.guarded());
                 pillar.generate(object, null, new Vector3(p.x, level.getHeightMap(p.getFloorX(), p.getFloorY()), p.y));
                 queueObject(chunk, object);
             }
         }
+    }
+
+    private EndSpike[] createSpikes(long seed) {
+        Random random = new Random(seed);
+        random.setSeed(random.nextLong() & 65535L);
+        List<Integer> values = new ArrayList<>(10);
+        for (int i = 0; i < 10; i++) {
+            values.add(i);
+        }
+        Collections.shuffle(values, random);
+
+        EndSpike[] spikes = new EndSpike[10];
+        for (int i = 0; i < spikes.length; i++) {
+            int value = values.get(i);
+            int x = (int) Math.floor(42d * Math.cos(2d * (-Math.PI + Math.PI / 10d * i)));
+            int z = (int) Math.floor(42d * Math.sin(2d * (-Math.PI + Math.PI / 10d * i)));
+            spikes[i] = new EndSpike(new Vector2(x, z), 2 + value / 3, 76 + value * 3, value == 1 || value == 2);
+        }
+        return spikes;
+    }
+
+    private record EndSpike(Vector2 position, int radius, int height, boolean guarded) {
     }
 
     @Override

--- a/src/test/java/org/powernukkitx/level/generator/object/ObjectAndFeatureSmokeTest.java
+++ b/src/test/java/org/powernukkitx/level/generator/object/ObjectAndFeatureSmokeTest.java
@@ -72,12 +72,12 @@ class ObjectAndFeatureSmokeTest {
         driveObject(new ObjectDarkOakTree(), nextCol(4), y, 0);
         driveObject(new ObjectEndGateway(), nextCol(4), y, 0);
         driveObject(new ObjectEndIsland(), nextCol(4), y, 0);
-        driveObject(new ObjectExitPortal(), nextCol(4), y, 0);
+        driveObject(new ObjectExitPortal(true), nextCol(4), y, 0);
         driveObject(new ObjectFallenTree(), nextCol(4), y, 0);
         driveObject(new ObjectFancyOakTree(), nextCol(4), y, 0);
         driveObject(new ObjectJungleBush(), nextCol(4), y, 0);
         driveObject(new ObjectMangroveTree(), nextCol(4), y, 0);
-        driveObject(new ObjectObsidianPillar(), nextCol(4), y, 0);
+        driveObject(new ObjectObsidianPillar(2, 8, false), nextCol(4), y, 0);
         driveObject(new ObjectPaleOakTree(), nextCol(4), y, 0);
         driveObject(new ObjectSavannaTree(), nextCol(4), y, 0);
         driveObject(new ObjectSmallSpruceTree(), nextCol(4), y, 0);


### PR DESCRIPTION
## What does this PR do?

This PR add the End dragon fight system.

## Why?

Before this, the main End island and the dragon fight was incomplete.

## Type of change

- [ ] Bug Fix
- [x] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?
Regenerated the end world, did a fight against the dragon, tested the crystal respawn system (placed 4 crystal in the edrock portal)

- **Server build tested:** 5605bc9a9
- **Bedrock client version:** 26.40
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

Added Level#getEnderDragonFight().

## Performance notes

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
|   GPT-5.6-SOL    |    did more similar to minecraft maths        |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
