### PR TITLE
fix: Boss bar removal when a boss is /kill

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityBoss.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityBoss.java
@@ -46,6 +46,7 @@ public abstract class EntityBoss extends EntityMob {
 
     @Override
     public void despawnFrom(Player player) {
+        super.despawnFrom(player);
         if (getViewers().containsKey(player.getLoaderId())) {
             final BossEventPacket bossEventPacket = new BossEventPacket();
             bossEventPacket.setTargetActorID(this.getId());
@@ -53,7 +54,6 @@ public abstract class EntityBoss extends EntityMob {
             bossEventPacket.setEventType(BossEventUpdateType.REMOVE);
             player.sendPacket(bossEventPacket);
         }
-        super.despawnFrom(player);
     }
 
     protected boolean canBreakBlock(Block block) {

--- a/src/main/java/org/powernukkitx/entity/mob/EntityBoss.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityBoss.java
@@ -44,6 +44,18 @@ public abstract class EntityBoss extends EntityMob {
         }
     }
 
+    @Override
+    public void despawnFrom(Player player) {
+        if (getViewers().containsKey(player.getLoaderId())) {
+            final BossEventPacket bossEventPacket = new BossEventPacket();
+            bossEventPacket.setTargetActorID(this.getId());
+            bossEventPacket.setPlayerID(player.getId());
+            bossEventPacket.setEventType(BossEventUpdateType.REMOVE);
+            player.sendPacket(bossEventPacket);
+        }
+        super.despawnFrom(player);
+    }
+
     protected boolean canBreakBlock(Block block) {
         return switch (block.getId()) {
             case Block.BARRIER,


### PR DESCRIPTION
## What does this PR do?

Remove the boss-bar attached to the boss when /kill

## Why?

Boss-bat still here when /kill

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies