### PR TITLE
fix: portal frame rotation in stronghold generation

### DIFF
--- a/src/main/java/org/powernukkitx/block/BlockEndPortalFrame.java
+++ b/src/main/java/org/powernukkitx/block/BlockEndPortalFrame.java
@@ -39,7 +39,7 @@ public class BlockEndPortalFrame extends BlockTransparent implements Faceable {
     public BlockEndPortalFrame(BlockState blockstate) {
         super(blockstate);
     }
-    
+
     @Override
     public double getResistance() {
         return 3600000;
@@ -138,6 +138,23 @@ public class BlockEndPortalFrame extends BlockTransparent implements Faceable {
                 }
             }
         }
+    }
+
+    @Override
+    public boolean onBreak(Item item) {
+        Vector3 centerSpot = this.searchCenter();
+        boolean broken = super.onBreak(item);
+        if (broken && centerSpot != null) {
+            for (int x = -1; x <= 1; x++) {
+                for (int z = -1; z <= 1; z++) {
+                    Vector3 position = centerSpot.add(x, 0, z);
+                    if (this.getLevel().getBlockIdAt(position.getFloorX(), position.getFloorY(), position.getFloorZ()).equals(Block.END_PORTAL)) {
+                        this.getLevel().setBlock(position, Block.get(Block.AIR), true, true);
+                    }
+                }
+            }
+        }
+        return broken;
     }
 
     private Vector3 searchCenter() {

--- a/src/main/java/org/powernukkitx/level/generator/object/structures/StrongholdPieces.java
+++ b/src/main/java/org/powernukkitx/level/generator/object/structures/StrongholdPieces.java
@@ -61,14 +61,6 @@ public class StrongholdPieces {
     private static final BlockState LADDER_W = BlockLadder.PROPERTIES.getBlockState(CommonBlockProperties.FACING_DIRECTION.createValue(4));
     private static final BlockState LADDER_S = BlockLadder.PROPERTIES.getBlockState(CommonBlockProperties.FACING_DIRECTION.createValue(3));
     private static final BlockState STONE_BRICK_STAIRS_N = BlockStoneBrickStairs.PROPERTIES.getBlockState(CommonBlockProperties.WEIRDO_DIRECTION.createValue(3));
-    private static final BlockState END_PORTAL_FRAME_N = BlockEndPortalFrame.PROPERTIES.getBlockState(CommonBlockProperties.MINECRAFT_CARDINAL_DIRECTION.createValue(MinecraftCardinalDirection.NORTH));
-    private static final BlockState END_PORTAL_FRAME_E = BlockEndPortalFrame.PROPERTIES.getBlockState(CommonBlockProperties.MINECRAFT_CARDINAL_DIRECTION.createValue(MinecraftCardinalDirection.EAST));
-    private static final BlockState END_PORTAL_FRAME_S = BlockEndPortalFrame.PROPERTIES.getBlockState(CommonBlockProperties.MINECRAFT_CARDINAL_DIRECTION.createValue(MinecraftCardinalDirection.SOUTH));
-    private static final BlockState END_PORTAL_FRAME_W = BlockEndPortalFrame.PROPERTIES.getBlockState(CommonBlockProperties.MINECRAFT_CARDINAL_DIRECTION.createValue(MinecraftCardinalDirection.WEST));
-    private static final BlockState END_PORTAL_FRAME_N_E = BlockEndPortalFrame.PROPERTIES.getBlockState(CommonBlockProperties.MINECRAFT_CARDINAL_DIRECTION.createValue(MinecraftCardinalDirection.NORTH), CommonBlockProperties.END_PORTAL_EYE_BIT.createValue(true));
-    private static final BlockState END_PORTAL_FRAME_E_E = BlockEndPortalFrame.PROPERTIES.getBlockState(CommonBlockProperties.MINECRAFT_CARDINAL_DIRECTION.createValue(MinecraftCardinalDirection.EAST), CommonBlockProperties.END_PORTAL_EYE_BIT.createValue(true));
-    private static final BlockState END_PORTAL_FRAME_S_E = BlockEndPortalFrame.PROPERTIES.getBlockState(CommonBlockProperties.MINECRAFT_CARDINAL_DIRECTION.createValue(MinecraftCardinalDirection.SOUTH), CommonBlockProperties.END_PORTAL_EYE_BIT.createValue(true));
-    private static final BlockState END_PORTAL_FRAME_W_E = BlockEndPortalFrame.PROPERTIES.getBlockState(CommonBlockProperties.MINECRAFT_CARDINAL_DIRECTION.createValue(MinecraftCardinalDirection.WEST), CommonBlockProperties.END_PORTAL_EYE_BIT.createValue(true));
     private static final BlockState IRON_DOOR_W_L = BlockIronDoor.PROPERTIES.getBlockState(CommonBlockProperties.MINECRAFT_CARDINAL_DIRECTION.createValue(MinecraftCardinalDirection.WEST));
     private static final BlockState IRON_DOOR_W_U = BlockIronDoor.PROPERTIES.getBlockState(CommonBlockProperties.MINECRAFT_CARDINAL_DIRECTION.createValue(MinecraftCardinalDirection.WEST), CommonBlockProperties.UPPER_BLOCK_BIT.createValue(true));
 
@@ -1448,18 +1440,18 @@ public class StrongholdPieces {
                 actived &= hasEye[i];
             }
 
-            this.placeBlock(level, hasEye[0] ? END_PORTAL_FRAME_N_E : END_PORTAL_FRAME_N, 4, 3, 8, boundingBox);
-            this.placeBlock(level, hasEye[1] ? END_PORTAL_FRAME_N_E : END_PORTAL_FRAME_N, 5, 3, 8, boundingBox);
-            this.placeBlock(level, hasEye[2] ? END_PORTAL_FRAME_N_E : END_PORTAL_FRAME_N, 6, 3, 8, boundingBox);
-            this.placeBlock(level, hasEye[3] ? END_PORTAL_FRAME_S_E : END_PORTAL_FRAME_S, 4, 3, 12, boundingBox);
-            this.placeBlock(level, hasEye[4] ? END_PORTAL_FRAME_S_E : END_PORTAL_FRAME_S, 5, 3, 12, boundingBox);
-            this.placeBlock(level, hasEye[5] ? END_PORTAL_FRAME_S_E : END_PORTAL_FRAME_S, 6, 3, 12, boundingBox);
-            this.placeBlock(level, hasEye[6] ? END_PORTAL_FRAME_E_E : END_PORTAL_FRAME_E, 3, 3, 9, boundingBox);
-            this.placeBlock(level, hasEye[7] ? END_PORTAL_FRAME_E_E : END_PORTAL_FRAME_E, 3, 3, 10, boundingBox);
-            this.placeBlock(level, hasEye[8] ? END_PORTAL_FRAME_E_E : END_PORTAL_FRAME_E, 3, 3, 11, boundingBox);
-            this.placeBlock(level, hasEye[9] ? END_PORTAL_FRAME_W_E : END_PORTAL_FRAME_W, 7, 3, 9, boundingBox);
-            this.placeBlock(level, hasEye[10] ? END_PORTAL_FRAME_W_E : END_PORTAL_FRAME_W, 7, 3, 10, boundingBox);
-            this.placeBlock(level, hasEye[11] ? END_PORTAL_FRAME_W_E : END_PORTAL_FRAME_W, 7, 3, 11, boundingBox);
+            this.placePortalFrame(level, hasEye[0], 4, 3, 8, boundingBox);
+            this.placePortalFrame(level, hasEye[1], 5, 3, 8, boundingBox);
+            this.placePortalFrame(level, hasEye[2], 6, 3, 8, boundingBox);
+            this.placePortalFrame(level, hasEye[3], 4, 3, 12, boundingBox);
+            this.placePortalFrame(level, hasEye[4], 5, 3, 12, boundingBox);
+            this.placePortalFrame(level, hasEye[5], 6, 3, 12, boundingBox);
+            this.placePortalFrame(level, hasEye[6], 3, 3, 9, boundingBox);
+            this.placePortalFrame(level, hasEye[7], 3, 3, 10, boundingBox);
+            this.placePortalFrame(level, hasEye[8], 3, 3, 11, boundingBox);
+            this.placePortalFrame(level, hasEye[9], 7, 3, 9, boundingBox);
+            this.placePortalFrame(level, hasEye[10], 7, 3, 10, boundingBox);
+            this.placePortalFrame(level, hasEye[11], 7, 3, 11, boundingBox);
 
             if (actived) {
                 this.placeBlock(level, END_PORTAL, 4, 3, 9, boundingBox);
@@ -1487,6 +1479,28 @@ public class StrongholdPieces {
             }
 
             return true;
+        }
+
+        private void placePortalFrame(BlockManager level, boolean hasEye, int x, int y, int z, BoundingBox boundingBox) {
+            BlockVector3 position = new BlockVector3(this.getWorldX(x, z), this.getWorldY(y), this.getWorldZ(x, z));
+            if (!boundingBox.isInside(position)) {
+                return;
+            }
+
+            int centerX = this.getWorldX(5, 10);
+            int centerZ = this.getWorldZ(5, 10);
+            BlockFace face;
+            int distanceX = centerX - position.x;
+            int distanceZ = centerZ - position.z;
+            if (Math.abs(distanceX) > Math.abs(distanceZ)) {
+                face = distanceX > 0 ? BlockFace.EAST : BlockFace.WEST;
+            } else {
+                face = distanceZ > 0 ? BlockFace.SOUTH : BlockFace.NORTH;
+            }
+            BlockState state = BlockEndPortalFrame.PROPERTIES.getBlockState(
+                    CommonBlockProperties.MINECRAFT_CARDINAL_DIRECTION.createValue(MinecraftCardinalDirection.fromBlockFace(face)),
+                    CommonBlockProperties.END_PORTAL_EYE_BIT.createValue(hasEye));
+            level.setBlockStateAt(position.x, position.y, position.z, state);
         }
     }
 

--- a/src/test/java/org/powernukkitx/level/generator/object/structures/StrongholdPortalTest.java
+++ b/src/test/java/org/powernukkitx/level/generator/object/structures/StrongholdPortalTest.java
@@ -1,0 +1,93 @@
+package org.powernukkitx.level.generator.object.structures;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.powernukkitx.ServerMockFixture;
+import org.powernukkitx.block.Block;
+import org.powernukkitx.block.BlockEndPortalFrame;
+import org.powernukkitx.level.Level;
+import org.powernukkitx.level.generator.object.BlockManager;
+import org.powernukkitx.level.generator.object.structures.utils.BoundingBox;
+import org.powernukkitx.math.BlockFace;
+import org.powernukkitx.utils.random.Xoroshiro128;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class StrongholdPortalTest {
+
+    private static Level level;
+
+    @BeforeAll
+    static void boot() {
+        ServerMockFixture.boot();
+        level = ServerMockFixture.level;
+    }
+
+    @Test
+    void generatedPortalRoomsCanBeActivated() {
+        int offset = 0;
+        for (BlockFace orientation : BlockFace.Plane.HORIZONTAL) {
+            StrongholdPieces.PortalRoom room = StrongholdPieces.PortalRoom.createPiece(
+                    new ArrayList<>(), offset, 64, offset, orientation, 0);
+            assertNotNull(room);
+
+            BoundingBox box = room.getBoundingBox();
+            BlockManager manager = new BlockManager(level);
+            room.postProcess(manager, new Xoroshiro128(1), box, box.x0 >> 4, box.z0 >> 4);
+            manager.applyWithoutUpdate();
+
+            List<BlockEndPortalFrame> frames = findPortalFrames(box);
+            assertEquals(12, frames.size());
+            for (BlockEndPortalFrame frame : frames) {
+                assertEquals(expectedFace(frame, frames), frame.getBlockFace(),
+                        () -> "Unexpected frame direction at " + frame.getLocation());
+                frame.setEndPortalEye(true);
+                level.setBlock(frame, frame, true, true);
+            }
+
+            frames.getFirst().createPortal();
+            assertEquals(9, countPortalBlocks(box));
+            offset += 64;
+        }
+    }
+
+    private List<BlockEndPortalFrame> findPortalFrames(BoundingBox box) {
+        List<BlockEndPortalFrame> frames = new ArrayList<>();
+        for (int x = box.x0; x <= box.x1; x++) {
+            for (int z = box.z0; z <= box.z1; z++) {
+                Block block = level.getBlock(x, box.y0 + 3, z);
+                if (block instanceof BlockEndPortalFrame frame) {
+                    frames.add(frame);
+                }
+            }
+        }
+        return frames;
+    }
+
+    private BlockFace expectedFace(BlockEndPortalFrame frame, List<BlockEndPortalFrame> frames) {
+        int minX = frames.stream().mapToInt(Block::getFloorX).min().orElseThrow();
+        int minZ = frames.stream().mapToInt(Block::getFloorZ).min().orElseThrow();
+        int maxX = frames.stream().mapToInt(Block::getFloorX).max().orElseThrow();
+        int centerZ = minZ + 2;
+        if (frame.getFloorX() == minX) return BlockFace.EAST;
+        if (frame.getFloorX() == maxX) return BlockFace.WEST;
+        if (frame.getFloorZ() < centerZ) return BlockFace.SOUTH;
+        return BlockFace.NORTH;
+    }
+
+    private int countPortalBlocks(BoundingBox box) {
+        int count = 0;
+        for (int x = box.x0; x <= box.x1; x++) {
+            for (int z = box.z0; z <= box.z1; z++) {
+                if (level.getBlockIdAt(x, box.y0 + 3, z).equals(Block.END_PORTAL)) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
## What does this PR do?

This PR fixes the rotations of portal frames when the portal room is rotated

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- New test verifies fix, and fails without the fix.
- Tested ingame without and with fix

**Steps performed and results:**

1. /locate structure stronghold true
2. Fill the portal with eyes of ender
3. Portal opened

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [x] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| Codex 5.6      |     Everything xd (except debugging ingame ofc.)        |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [ ] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [?] "Allow maintainer edits" is enabled
