### PR TITLE
fix: NPE in BlockEntityHopper#onUpdate when level is null

### DIFF
--- a/src/main/java/org/powernukkitx/blockentity/BlockEntityHopper.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntityHopper.java
@@ -235,7 +235,7 @@ public class BlockEntityHopper extends BlockEntitySpawnable implements BlockEnti
             return false;
         }
 
-        if (this.getLocation().getLevel() == null) return true;
+        if (!this.isValid()) return true;
 
         Block blockSide = this.getSide(BlockFace.UP).getTickCachedLevelBlock();
         BlockEntity blockEntity = this.level.getBlockEntity(temporalVector.setComponentsAdding(this, BlockFace.UP));

--- a/src/main/java/org/powernukkitx/blockentity/BlockEntityHopper.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntityHopper.java
@@ -235,10 +235,10 @@ public class BlockEntityHopper extends BlockEntitySpawnable implements BlockEnti
             return false;
         }
 
+        if (this.getLocation().getLevel() == null) return true;
+
         Block blockSide = this.getSide(BlockFace.UP).getTickCachedLevelBlock();
         BlockEntity blockEntity = this.level.getBlockEntity(temporalVector.setComponentsAdding(this, BlockFace.UP));
-
-        if (this.getLocation().getLevel() == null) return true;
 
         boolean changed = pushItems() || pushItemsIntoMinecart();
 


### PR DESCRIPTION
## Summary
- `onUpdate()` dereferences `this.level` (via `this.level.getBlockEntity(...)`) one statement *before* the existing `if (this.getLocation().getLevel() == null) return true;` guard that was clearly meant to protect it, so the guard never runs in time and the tick throws a NullPointerException instead of returning early.
- Moves the null check above the `this.level` dereference so it actually guards it.

## Crash observed
```
java.lang.NullPointerException: Cannot invoke "org.powernukkitx.level.Level.getBlockEntity(org.powernukkitx.math.BlockVector3)" because "this.level" is null
    at org.powernukkitx.blockentity.BlockEntityHopper.onUpdate(BlockEntityHopper.java:239)
    at org.powernukkitx.level.Level.lambda$doTick$9(Level.java:1504)
    at java.base/java.util.concurrent.ConcurrentLinkedQueue.bulkRemove(ConcurrentLinkedQueue.java:1004)
    at java.base/java.util.concurrent.ConcurrentLinkedQueue.removeIf(ConcurrentLinkedQueue.java:964)
    at org.powernukkitx.level.Level.doTick(Level.java:1504)
    at org.powernukkitx.Server.checkTickUpdates(Server.java:1089)
    at org.powernukkitx.Server.tick(Server.java:1180)
```

This crashes the whole world tick loop (caught by the caller and logged as "ワールドをチェックすることができませんでした" / "couldn't check world", but it's a recurring failure on every subsequent tick until the hopper is otherwise removed from the queue).

## Test plan
- [ ] Existing hopper unit/behavior tests still pass
- [ ] Manually reproduce: get a hopper block entity into a state where its level becomes null mid-tick (e.g. concurrent chunk unload) and confirm `onUpdate()` now returns `true` early instead of throwing