### PR TITLE
fix: LevelException in BlockEntityLectern#onUpdate when level is invalid

### DIFF
--- a/src/main/java/org/powernukkitx/blockentity/BlockEntityLectern.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntityLectern.java
@@ -67,6 +67,7 @@ public class BlockEntityLectern extends BlockEntitySpawnable {
 
     @Override
     public boolean onUpdate() {
+        if (this.closed || !isValid()) return false;
         if(!this.chunk.isInitiated()) return true; //Update once chunk is initiated.
         updateTotalPages();
         return super.onUpdate();


### PR DESCRIPTION
## Summary
- `BlockEntityLectern#onUpdate()` calls `updateTotalPages()` (which reaches `RedstoneComponent.updateAroundRedstone()` -> `Position.getLevelBlock()` -> `getValidLevel()`) with no guard for a closed/detached lectern (`level == null`), unlike other block entities (e.g. `BlockEntityHopper`, see #2995) which check `this.closed` / validity before doing level-dependent work in `onUpdate()`.
- Adds the same `this.closed || !isValid()` guard used elsewhere in the codebase.

## Crash observed
```
org.powernukkitx.utils.LevelException: Undefined Level reference
    at org.powernukkitx.level.Position.getValidLevel(Position.java:185)
    at org.powernukkitx.level.Position.getLevelBlock(Position.java:143)
    at org.powernukkitx.level.Position.getLevelBlock(Position.java:139)
    at org.powernukkitx.utils.RedstoneComponent.updateAroundRedstone(RedstoneComponent.java:56)
    at org.powernukkitx.utils.RedstoneComponent.updateAroundRedstone(RedstoneComponent.java:44)
    at org.powernukkitx.blockentity.BlockEntityLectern.updateTotalPages(BlockEntityLectern.java:134)
    at org.powernukkitx.blockentity.BlockEntityLectern.onUpdate(BlockEntityLectern.java:71)
    at org.powernukkitx.level.Level.lambda$doTick$9(Level.java:1504)
    at org.powernukkitx.level.Level.doTick(Level.java:1504)
    at org.powernukkitx.Server.checkTickUpdates(Server.java:1089)
```

Same underlying pattern as #2995: a block entity still present in the level's tick queue whose `level` reference has already gone null/invalid crashes the whole world tick loop instead of being skipped.

## Test plan
- [ ] Existing lectern tests still pass
- [ ] Manually reproduce a lectern whose block entity becomes closed/detached mid-tick and confirm `onUpdate()` now returns `false` early instead of throwing