### PR TITLE
feat: Custom fallback in commandtree in case of error

### DIFF
--- a/src/main/java/org/powernukkitx/command/route/RouteTree.java
+++ b/src/main/java/org/powernukkitx/command/route/RouteTree.java
@@ -50,6 +50,9 @@ public class RouteTree {
             Map.entry(BlockNode.class, CommandEnum.ENUM_BLOCK)
     );
 
+    private static final int EXECUTOR = 0;
+    private static final int FALLBACK = 1;
+
     private final RouteNode root;
 
     private Command command;
@@ -63,7 +66,10 @@ public class RouteTree {
     }
 
     /**
-     * Dispatches the command by walking the tree to find the matching route, then executing it.
+     * Dispatches the command by walking the tree to find the matching route, then executing it.<br>
+     * Else, the deepest fallback node is executed if available.<br>
+     * If not available, the usage is showed if present.<br>
+     * If not present, the syntax error is showed.
      *
      * @param sender the command sender
      * @param args   the raw command arguments
@@ -72,13 +78,15 @@ public class RouteTree {
     public CommandResult dispatch(CommandSender sender, String[] args) {
         CommandContext context = new CommandContext(sender);
 
-        RouteNode current = match(root, args, 0, context);
-        if (current == null) {
-            String usage = command.getUsage();
-            if (usage.equals("/" + command.getLabel())) {
-                sender.sendMessage(new TranslationContainer("commands.generic.syntax", "", "", ""));
+        RouteNode[] matchResult = {null, null};
+        match(root, args, 0, context, matchResult);
+        if (matchResult[EXECUTOR] == null) {
+            if (matchResult[FALLBACK] != null) {
+                matchResult[FALLBACK].executeFallback(context);
+            } else if (!command.getUsage().equals("/" + command.getLabel())) {
+                sender.sendMessage(new TranslationContainer("commands.generic.usage", command.getUsage()));
             } else {
-                sender.sendMessage(new TranslationContainer("commands.generic.usage", usage));
+                sender.sendMessage(new TranslationContainer("commands.generic.syntax", "", "", ""));
             }
             return CommandResult.fail();
         }
@@ -87,7 +95,7 @@ public class RouteTree {
             return CommandResult.fail();
         }
 
-        CommandResult check = current.check(sender);
+        CommandResult check = matchResult[EXECUTOR].check(sender);
         if (!check.isSuccess()) {
             if (check.getMessage() != null) {
                 sender.sendMessage(check.getMessage());
@@ -95,7 +103,7 @@ public class RouteTree {
             return check;
         }
 
-        CommandResult result = current.execute(context);
+        CommandResult result = matchResult[EXECUTOR].execute(context);
 
         if (!result.isSuccess() && result.getMessage() != null) {
             sender.sendMessage(result.getMessage());
@@ -107,20 +115,32 @@ public class RouteTree {
     /**
      * Recursively matches {@code args} against the tree starting at {@code node}, with
      * backtracking: if a child route fails to consume the remaining args, sibling routes
-     * are tried. Literals are preferred over arguments at each level.
-     *
-     * @return the executable terminal node that consumes all args, or {@code null} if none
+     * are tried. Literals are preferred over arguments at each level. The fallback of the 
+     * most deeply nested node with fallback available is preferred.<br>
+     * The results are saved in the array of pointers {@code result} passed by the caller.
      */
-    private RouteNode match(RouteNode node, String[] args, int index, CommandContext context) {
+    private void match(RouteNode node, String[] args, int index, CommandContext context, RouteNode[] result) {
+        match(node, args, index, context, result, new int[] {-1});
+    }
+
+    private void match(RouteNode node, String[] args, int index, CommandContext context, RouteNode[] result, int[] fallbackDepth) {
+        if (node.isFallbackAvailable() && index >= fallbackDepth[0]) {
+            result[FALLBACK] = node;
+            fallbackDepth[0] = index;
+        }
+
         if (index == args.length) {
-            return node.isExecutable() ? node : null;
+            if (node.isExecutable()) {
+                result[EXECUTOR] = node;
+            }
+            return;
         }
 
         for (RouteNode child : node.getChildren()) {
             if (child.getType() == NodeType.LITERAL && child.getName().equalsIgnoreCase(args[index])) {
-                RouteNode result = match(child, args, index + 1, context);
-                if (result != null) {
-                    return result;
+                match(child, args, index + 1, context, result, fallbackDepth);
+                if (result[EXECUTOR] != null) {
+                    return;
                 }
             }
         }
@@ -137,16 +157,21 @@ public class RouteTree {
             context.putArg(child.getName(), parsed);
 
             if (child.getParamNode().getUsedArgs() == -1) {        // If the node consumes all the tokens, then...
-                return child.isExecutable() ? child : null;
+                if (child.isExecutable()) {
+                    result[EXECUTOR] = child;
+                }
+                if (child.isFallbackAvailable() && args.length >= fallbackDepth[0]) {
+                    result[FALLBACK] = child;
+                    fallbackDepth[0] = args.length;
+                }
+                return;
             }
 
-            RouteNode result = match(child, args, index + child.getParamNode().getUsedArgs(), context);
-            if (result != null) {
-                return result;
+            match(child, args, index + child.getParamNode().getUsedArgs(), context, result, fallbackDepth);
+            if (result[EXECUTOR] != null) {
+                return;
             }
         }
-
-        return null;
     }
 
     /**

--- a/src/main/java/org/powernukkitx/command/route/node/RouteNode.java
+++ b/src/main/java/org/powernukkitx/command/route/node/RouteNode.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
@@ -36,6 +37,7 @@ public class RouteNode {
     private IParamNode<?> paramNode;
 
     private Function<CommandContext, CommandResult> executor;
+    private Consumer<CommandContext> fallback;
 
     private SenderType senderType = SenderType.ANY;
     private String permission;
@@ -98,6 +100,16 @@ public class RouteNode {
     }
 
     /**
+     * Sets the fallback for this node. If not present, anyway the fallback of 
+     * the most deeply nested node found in the route gets executed, in case 
+     * of command syntax error.
+     */
+    public RouteNode orElse(Consumer<CommandContext> fallback) {
+        this.fallback = fallback;
+        return this;
+    }
+
+    /**
      * Restricts who can use this node. Defaults to {@link SenderType#ANY}.
      */
     public RouteNode senderType(SenderType senderType) {
@@ -154,6 +166,13 @@ public class RouteNode {
     }
 
     /**
+     * Returns true if this node has a fallback.
+     */
+    public boolean isFallbackAvailable() {
+        return fallback != null;
+    }
+
+    /**
      * Returns true if this node should be hidden from tab-complete.
      */
     public boolean isSuggestHidden() {
@@ -179,6 +198,13 @@ public class RouteNode {
             return CommandResult.fail();
         }
         return executor.apply(context);
+    }
+
+    public void executeFallback(CommandContext context) {
+        if (fallback == null) {
+            return;
+        }
+        fallback.accept(context);
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?

Adds a .orElse(...) method to RouteNode that assigns a Consumer\<CommandContext\> to a new fallback var (null by default, similar to executor), which acts as a fallback such that the match method in RouteTree checks the most nested fallback available,  and in case of syntax error it gets executed if not null.

## Why?

To customize the fallback in CommandTree in case of syntax error.

Closes #2999

## Type of change

- [ ] Bug Fix
- [x] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- Server build tested: ed42571
- Bedrock client version: 26.44
- Plugins loaded: own

1) Created a command with many literal and argument nodes, and less/more nested nodes were equipped with a fallback (a few not, to test lower level fallback + a separate command with no fallback to test no fallback).
2) Tested the command with fallbacks (and the other command without fallbacks) by going through the command literals and arguments ingame.

- [x] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (gradlew test)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

New orElse(Consumer\<CommandContext\>) method added to RouteNode

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|   Claude Sonnet 5 (web)    |       Checking for possible bugs in the new code      |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
