### PR TITLE
FIX : Reject nameless voxel shapes that broke VoxelShapesPacket encoding

### DIFF
--- a/src/main/java/org/powernukkitx/registry/VoxelShapeRegistry.java
+++ b/src/main/java/org/powernukkitx/registry/VoxelShapeRegistry.java
@@ -69,16 +69,21 @@ public final class VoxelShapeRegistry implements IRegistry<String, VoxelShapes.S
             final List<VanillaShape> shapes = new Gson().fromJson(reader, new TypeToken<List<VanillaShape>>() {
             }.getType());
             for (VanillaShape shape : shapes) {
+                if (shape.identifier == null || shape.identifier.isBlank()) {
+                    continue;
+                }
                 final List<VoxelBox> boxes = new ArrayList<>();
                 for (int[][] box : shape.boxes) {
                     boxes.add(new VoxelBox(box[0], box[1]));
                 }
-                register(shape.identifier, boxes);
+                try {
+                    register(shape.identifier, boxes);
+                } catch (RegisterException e) {
+                    e.printStackTrace();
+                }
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
-        } catch (RegisterException e) {
-            e.printStackTrace();
         }
     }
 
@@ -196,6 +201,9 @@ public final class VoxelShapeRegistry implements IRegistry<String, VoxelShapes.S
 
     @Override
     public void register(String key, VoxelShapes.SerializableVoxelShape value) throws RegisterException {
+        if (key == null || key.isBlank()) {
+            throw new RegisterException("A VoxelShape cannot be registered without an identifier!");
+        }
         if (REGISTRY.putIfAbsent(key, value) != null) {
             throw new RegisterException("The VoxelShape " + key + " has already been registered!");
         }


### PR DESCRIPTION
<!--
  Read CONTRIBUTING.md before submitting:
  https://github.com/PowerNukkitX/PowerNukkitX/blob/master/CONTRIBUTING.md

  PRs that leave this template unfilled, or fill it with generated filler,
  are closed without review. Delete the HTML comments as you go.

  SECURITY: never report a vulnerability in a public PR. See SECURITY.md.
-->

## What does this PR do?

Fixes a crash that prevents VoxelShapesPacket from ever reaching the client.

## Why?

It affects every server on this gamedata version. No plugin is involved and no configuration triggers it — a stock server logs a full stack trace for every single player who joins, and the client silently never gets the shape table it was supposed to receive. Server and client can then disagree on collision and selection boxes for the blocks that table describes.

Bad data should not be able to break a packet. The registry is keyed by String and is handed identifiers straight from a JSON file, so a missing field is a case worth expecting. Object2ObjectOpenHashMap accepting a null key means the problem stays invisible until it surfaces far away, in the serializer, as an NPE with no indication of where the null came from. Validating at register puts the failure where the mistake is, and protects plugins registering their own shapes too.

A single malformed entry should not truncate the registry. The try around the whole loop meant one duplicate key cost 66 perfectly valid shapes, with nothing in the log tying the two together. That failure mode is worse than the crash it caused, because it is silent.

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** git-5756bf2
- **Bedrock client version:** 1.26.40
- **Plugins loaded:** none

**Steps performed and results:**

1.
2.

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [X] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
|       |             |

- [ ] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [ ] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [ ] Public API additions/changes have Javadoc
- [[X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
