### PR TITLE
Fix: catch LevelException in block entity update queue [need test]

### DIFF
--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -1500,7 +1500,13 @@ public class Level implements Metadatable {
                 this.hasAsyncPrepareEntities = seenAsyncPrepare;
             }
             if (prof) phase[5] = -phaseStart + (phaseStart = System.nanoTime());
-            this.updateBlockEntities.removeIf(blockEntity -> !(!blockEntity.closed && blockEntity.isValid() && blockEntity.onUpdate()));
+            this.updateBlockEntities.removeIf(blockEntity -> {
+                try {
+                    return !(!blockEntity.closed && blockEntity.isValid() && blockEntity.onUpdate());
+                } catch (LevelException e) {
+                    return true;
+                }
+            });
             if (prof) phase[6] = -phaseStart + (phaseStart = System.nanoTime());
 
             this.tickChunks();


### PR DESCRIPTION
## What does this PR do?

Wraps the block entity update loop in Level.doTick() in a try/catch so a LevelException from one detached block entity no longer crashes the whole tick.

## Why?

Closes #3015

## Type of change

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** cdf419a81
- **Bedrock client version:** 26.42
- **Plugins loaded:** NONE

**Steps performed and results:**

1. need to test

- [ ] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|       |             |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
