### PR TITLE
fix: use info instead of debug

### DIFF
--- a/src/main/java/org/powernukkitx/network/process/PlayerSessionHolder.java
+++ b/src/main/java/org/powernukkitx/network/process/PlayerSessionHolder.java
@@ -166,13 +166,13 @@ public class PlayerSessionHolder {
         if (socketAddress instanceof InetSocketAddress address) {
             InetAddress inetAddress = address.getAddress();
 
-            log.debug("[Network session disconnected: {}:{}] - {}",
+            log.info("[Network session disconnected: {}:{}] - {}",
                 inetAddress != null ? inetAddress.getHostAddress() : address.getHostString(),
                 address.getPort(),
                 message
             );
         } else {
-            log.debug("[Network session disconnected] - {}", message);
+            log.info("[Network session disconnected] - {}", message);
         }
     }
 


### PR DESCRIPTION
Use info instead of debug because it never logs when a player disconnects