### PR TITLE
fix: harden packet handlers against malformed/malicious input

### DIFF
--- a/src/main/java/org/powernukkitx/network/process/NetworkPacketHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/NetworkPacketHandler.java
@@ -42,7 +42,7 @@ public class NetworkPacketHandler implements BedrockPacketHandler {
             if (player != null && firePacketHandle(player, packet)) {
                 return PacketSignal.UNHANDLED;
             }
-            packetHandler.handle(packet, this.session, this.server);
+            dispatch(packetHandler, packet);
             return PacketSignal.HANDLED;
         }
         return BedrockPacketHandler.super.handlePacket(packet);
@@ -61,7 +61,23 @@ public class NetworkPacketHandler implements BedrockPacketHandler {
         if (packetHandler == null || firePacketHandle(player, packet)) {
             return;
         }
-        packetHandler.handle(packet, this.session, this.server);
+        dispatch(packetHandler, packet);
+    }
+
+    /**
+     * Runs a packet handler, containing any exception it throws so a single malformed or malicious
+     * packet cannot tear down the session. Logged at debug: this path is client-controlled, so a
+     * client able to trigger a failure reliably must not be able to flood the logs (or fill the disk)
+     * with per-packet stack traces.
+     */
+    private void dispatch(PacketHandler packetHandler, BedrockPacket packet) {
+        try {
+            packetHandler.handle(packet, this.session, this.server);
+        } catch (Exception e) {
+            final Player player = this.session.getPlayer();
+            log.debug("Failed to handle {} for {}", packet.getClass().getSimpleName(),
+                    player == null ? "unknown" : player.getName(), e);
+        }
     }
 
     private boolean firePacketReceive(@Nullable Player player, BedrockPacket packet) {

--- a/src/main/java/org/powernukkitx/network/process/handler/StructureBlockUpdateHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/StructureBlockUpdateHandler.java
@@ -9,33 +9,51 @@ import org.powernukkitx.blockentity.BlockEntityStructBlock;
 import org.powernukkitx.math.Vector3;
 import org.powernukkitx.network.process.PacketHandler;
 import org.powernukkitx.network.process.PlayerSessionHolder;
+import lombok.extern.slf4j.Slf4j;
+import org.cloudburstmc.protocol.bedrock.data.payload.structure.StructureEditorData;
 import org.cloudburstmc.protocol.bedrock.packet.StructureBlockUpdatePacket;
+import org.cloudburstmc.math.vector.Vector3i;
 
 import static org.powernukkitx.block.property.CommonBlockProperties.STRUCTURE_BLOCK_TYPE;
 
 /**
  * @author Kaooot
  */
+@Slf4j
 public class StructureBlockUpdateHandler implements PacketHandler<StructureBlockUpdatePacket> {
 
     @Override
     public void handle(StructureBlockUpdatePacket packet, PlayerSessionHolder holder, Server server) {
         PlayerHandle playerHandle = holder.getPlayerHandle();
-        if (playerHandle.player.isOp() && playerHandle.player.isCreative()) {
-            BlockEntity blockEntity = playerHandle.player.level.getBlockEntity(
-                    new Vector3(
-                            packet.getBlockPosition().getX(),
-                            packet.getBlockPosition().getY(),
-                            packet.getBlockPosition().getZ()
-                    )
-            );
-            if (blockEntity instanceof BlockEntityStructBlock structBlock) {
-                Block sBlock = structBlock.getLevelBlock();
-                sBlock.setPropertyValue(STRUCTURE_BLOCK_TYPE, StructureBlockType.valueOf(packet.getStructureData().getStructureBlockType().name()));
-                structBlock.updateSetting(packet);
-                playerHandle.player.level.setBlock(structBlock, sBlock, true);
-                structBlock.spawnTo(playerHandle.player);
-            }
+        if (!playerHandle.player.isOp() || !playerHandle.player.isCreative()) {
+            return;
+        }
+
+        final Vector3i blockPosition = packet.getBlockPosition();
+        final StructureEditorData structureData = packet.getStructureData();
+        if (blockPosition == null || structureData == null || structureData.getStructureBlockType() == null) {
+            log.debug("Player {} sent a malformed StructureBlockUpdatePacket", playerHandle.player.getName());
+            return;
+        }
+
+        final StructureBlockType blockType;
+        try {
+            blockType = StructureBlockType.valueOf(structureData.getStructureBlockType().name());
+        } catch (IllegalArgumentException e) {
+            log.debug("Player {} sent an unknown structure block type {}", playerHandle.player.getName(),
+                    structureData.getStructureBlockType());
+            return;
+        }
+
+        BlockEntity blockEntity = playerHandle.player.level.getBlockEntity(
+                new Vector3(blockPosition.getX(), blockPosition.getY(), blockPosition.getZ())
+        );
+        if (blockEntity instanceof BlockEntityStructBlock structBlock) {
+            Block sBlock = structBlock.getLevelBlock();
+            sBlock.setPropertyValue(STRUCTURE_BLOCK_TYPE, blockType);
+            structBlock.updateSetting(packet);
+            playerHandle.player.level.setBlock(structBlock, sBlock, true);
+            structBlock.spawnTo(playerHandle.player);
         }
     }
 }


### PR DESCRIPTION
## What does this PR do?

Adds input validation and exception handling to several network packet handlers to prevent crashes and cheat vectors from malformed/malicious client packets

Player.java: getPing() handles a null network channel during disconnection, returns -1 instead of crashing
Network.java: guards against a null pong, fixes STOPPING state in shutdown()
NetworkPacketHandler.java: adds try/catch around packet processing to stop crashes
ActorEventHandler.java: null checks event type, verifies held item is a milk bucket for DRINK_MILK
AnimateHandler.java: re-validates animation type after plugin event to block server only animations
BookEditHandler.java: validates book slot and operation before processing
LoginHandler.java: null checks authentication type, handles exceptions during login
MapInfoRequestHandler.java: moves map rendering into onCompletion and checks player is still online and alive before running
MobEquipmentHandler.java: catches malformed item deserialization, validates selected slot
ModalFormResponseHandler.java: global try/catch, null checks unknown elements, validates bounds for dropdown, slider and step slider
PlayerActionHandler.java: null checks block position for CREATIVE_DESTROY_BLOCK
PlayerAuthInputHandler.java: fixes rotation read from wrong packet field, fixes PlayerHandle being recreated every loop
PlayerHotbarHandler.java: validates selected hotbar slot
PlayerSkinHandler.java: catches skin parsing errors, null checks skin data
SetDifficultyHandler.java: fixes broadcast applying difficulty to the wrong packet
ShowCreditsHandler.java: adds spawned and alive check before processing
StructureBlockUpdateHandler.java: handles invalid structure block type properly
QueryPacketHandler.java: global try/catch and exceptionCaught to prevent crash on malformed query packet
SkinUtils.java: strict validation of image dimensions and data size for skin, cape and animations

## Why?

Several packet handlers trusted client-supplied data (indices, item ids, event types) without validation, which could crash the server

## Type of change

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 6f11514
- **Bedrock client version:** 26.44
- **Plugins loaded:** none

**Steps performed and results:**

1. join the server
2. test with map

- [X] I built the server and ran it with this change
- [] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|   Claude Fable 5 / Opus 5   |    Identified vulnerabilities/bugs in packet handlers, proposed fixes        |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
