### PR TITLE
 fix: paramList NPE and wrong args parsing in CommandTree

### DIFF
--- a/src/main/java/org/powernukkitx/command/route/RouteTree.java
+++ b/src/main/java/org/powernukkitx/command/route/RouteTree.java
@@ -140,7 +140,7 @@ public class RouteTree {
                 return child.isExecutable() ? child : null;
             }
 
-            RouteNode result = match(child, args, index + 1, context);
+            RouteNode result = match(child, args, index + child.getParamNode().getUsedArgs(), context);
             if (result != null) {
                 return result;
             }

--- a/src/main/java/org/powernukkitx/command/route/RouteTree.java
+++ b/src/main/java/org/powernukkitx/command/route/RouteTree.java
@@ -116,10 +116,8 @@ public class RouteTree {
             return node.isExecutable() ? node : null;
         }
 
-        String arg = args[index];
-
         for (RouteNode child : node.getChildren()) {
-            if (child.getType() == NodeType.LITERAL && child.getName().equalsIgnoreCase(arg)) {
+            if (child.getType() == NodeType.LITERAL && child.getName().equalsIgnoreCase(args[index])) {
                 RouteNode result = match(child, args, index + 1, context);
                 if (result != null) {
                     return result;
@@ -131,11 +129,17 @@ public class RouteTree {
             if (child.getType() != NodeType.ARGUMENT) {
                 continue;
             }
-            Object parsed = parseArg(child, arg);
+
+            Object parsed = parseArg(child, args, index, context.getSender());
             if (parsed == null) {
                 continue;
             }
             context.putArg(child.getName(), parsed);
+
+            if (child.getParamNode().getUsedArgs() == -1) {        // If the node consumes all the tokens, then...
+                return child.isExecutable() ? child : null;
+            }
+
             RouteNode result = match(child, args, index + 1, context);
             if (result != null) {
                 return result;
@@ -146,19 +150,38 @@ public class RouteTree {
     }
 
     /**
-     * Parses a single token against the node's param node, returning the parsed value or
+     * Parses a certain number of tokens (defined by {@link org.powernukkitx.command.tree.node.IParamNode#getUsedArgs()}) against the node's param node, returning the parsed value or
      * {@code null} if it does not match. The fill/get/reset sequence is synchronized on the
      * (shared, per-node) param node so concurrent dispatches do not corrupt each other.
+     * 
+     * @see org.powernukkitx.command.tree.node.IParamNode#getUsedArgs()
      */
-    private Object parseArg(RouteNode child, String arg) {
+    private Object parseArg(RouteNode child, String args[], int index, CommandSender sender) {
         IParamNode<?> paramNode = child.getParamNode();
+
         synchronized (paramNode) {
             paramNode.reset();
-            paramNode.fill(arg);
+
+            if (paramNode.getUsedArgs() == -1) {        // If the node consumes all the tokens, then...
+                if (index >= args.length) {
+                    return null;
+                }
+                for (int i = index; i < args.length; i++) {
+                    paramNode.fill(args[i], sender, i == args.length - 1);
+                }
+            } else {
+                if (index + paramNode.getUsedArgs() > args.length) {
+                    return null;
+                }
+                for (int i = 0; i < paramNode.getUsedArgs(); i++) {
+                    paramNode.fill(args[index + i], sender);
+                }
+            }
+
             boolean matched = paramNode.hasResult();
-            Object parsed = matched ? paramNode.get() : null;
+            Object parsed = matched ? paramNode.get(sender) : null;
             paramNode.reset();
-            return matched ? parsed : null;
+            return parsed;
         }
     }
 

--- a/src/main/java/org/powernukkitx/command/tree/node/ChainedCommandNode.java
+++ b/src/main/java/org/powernukkitx/command/tree/node/ChainedCommandNode.java
@@ -7,6 +7,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.StringJoiner;
 
+import org.powernukkitx.command.CommandSender;
+
 
 /**
  * Represents a node for parsing chained subcommands in the context of the {@link org.powernukkitx.command.defaults.ExecuteCommand}.
@@ -46,7 +48,21 @@ public class ChainedCommandNode extends EnumNode {
     private final List<String> TMP = new ArrayList<>();
 
     @Override
+    public int getUsedArgs() {
+        return -1;
+    }
+
+    @Override
     public void fill(String arg) {
+        fill(
+            arg, 
+            paramList.getParamTree().getSender(), 
+            paramList.getIndex() == paramList.getParamTree().getArgs().length
+        );
+    }
+
+    @Override
+    public void fill(String arg, CommandSender sender, boolean isLastArg) {
         if (arg.contains(" ")) {
             arg = "\"" + arg + "\"";
         }
@@ -58,9 +74,8 @@ public class ChainedCommandNode extends EnumNode {
             TMP.add(arg);
             remain = true;
         } else {
-            if (this.paramList.getIndex() != this.paramList.getParamTree().getArgs().length) TMP.add(arg);
-            else {
-                TMP.add(arg);
+            TMP.add(arg);
+            if (isLastArg) {
                 var join = new StringJoiner(" ", "execute ", "");
                 TMP.forEach(join::add);
                 this.value = join.toString();

--- a/src/main/java/org/powernukkitx/command/tree/node/CommandNode.java
+++ b/src/main/java/org/powernukkitx/command/tree/node/CommandNode.java
@@ -1,6 +1,7 @@
 package org.powernukkitx.command.tree.node;
 
 import org.powernukkitx.Server;
+import org.powernukkitx.command.CommandSender;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,7 +43,21 @@ public class CommandNode extends ParamNode<String> {
     private boolean first = true;
 
     @Override
+    public int getUsedArgs() {
+        return -1;
+    }
+
+    @Override
     public void fill(String arg) {
+        fill(
+            arg, 
+            paramList.getParamTree().getSender(), 
+            paramList.getIndex() == paramList.getParamTree().getArgs().length
+        );
+    }
+
+    @Override 
+    public void fill(String arg, CommandSender sender, boolean isLastArg) {
         if (arg.contains(" ")) {
             arg = "\"" + arg + "\"";
         }
@@ -50,11 +65,9 @@ public class CommandNode extends ParamNode<String> {
             this.error("commands.generic.unknown", arg);
             return;
         }
-        if (this.paramList.getIndex() != this.paramList.getParamTree().getArgs().length) {
-            first = false;
-            TMP.add(arg);
-        } else {
-            TMP.add(arg);
+        first = false;
+        TMP.add(arg);
+        if (isLastArg) {
             this.value = String.join(" ", TMP);
             first = true;
         }

--- a/src/main/java/org/powernukkitx/command/tree/node/EntitiesNode.java
+++ b/src/main/java/org/powernukkitx/command/tree/node/EntitiesNode.java
@@ -2,6 +2,7 @@ package org.powernukkitx.command.tree.node;
 
 import org.powernukkitx.Player;
 import org.powernukkitx.command.Command;
+import org.powernukkitx.command.CommandSender;
 import org.powernukkitx.command.exceptions.SelectorSyntaxException;
 import org.powernukkitx.command.selector.EntitySelectorAPI;
 import org.powernukkitx.entity.Entity;
@@ -42,15 +43,20 @@ import java.util.List;
  */
 public class EntitiesNode extends TargetNode<Entity> {
 
-    // TODO: Support UUID or xuid
     @Override
     public void fill(String arg) {
+        fill(arg, paramList.getParamTree().getSender());
+    }
+
+    // TODO: Support UUID or xuid
+    @Override
+    public void fill(String arg, CommandSender sender) {
         List<Entity> entities;
         if (arg.isBlank()) {
             this.error();
         } else if (EntitySelectorAPI.getAPI().checkValid(arg)) {
             try {
-                entities = EntitySelectorAPI.getAPI().matchEntities(paramList.getParamTree().getSender(), arg);
+                entities = EntitySelectorAPI.getAPI().matchEntities(sender, arg);
             } catch (SelectorSyntaxException exception) {
                 error(exception.getMessage());
                 return;
@@ -58,7 +64,7 @@ public class EntitiesNode extends TargetNode<Entity> {
             this.value = entities;
         } else {
             entities = Lists.newArrayList();
-            Player player = Command.resolveTargetPlayer(paramList.getParamTree().getSender(), arg);
+            Player player = Command.resolveTargetPlayer(sender, arg);
             if (player != null) {
                 entities.add(player);
             }

--- a/src/main/java/org/powernukkitx/command/tree/node/IParamNode.java
+++ b/src/main/java/org/powernukkitx/command/tree/node/IParamNode.java
@@ -1,5 +1,6 @@
 package org.powernukkitx.command.tree.node;
 
+import org.powernukkitx.command.CommandSender;
 import org.powernukkitx.command.data.CommandEnum;
 import org.powernukkitx.command.tree.ParamList;
 import org.powernukkitx.lang.CommandOutputContainer;
@@ -44,16 +45,64 @@ public interface IParamNode<T> {
     /**
      * Responsible for filling this parameter node. Overriding this method must implement validation of the accepted argument arg and parsing it into a result of the corresponding type T
      * <br>
+     * Only used by ParamTree
+     * <br>
      * When validation or parsing fails, call the {@link #error(String)} method to flag the error, for example {@code this.error()}
      *
      * @param arg the arg
      */
     void fill(String arg);
+    
+    /**
+     * Variation of {@link #fill(String)} that takes as parameter {@code sender} the command sender<br>
+     * Only used by CommandTree<br>
+     * By default, it executes {@link #fill(String)}
+     * 
+     * @param arg the arg
+     * @param sender the command sender
+     */
+    default void fill(String arg, CommandSender sender) {
+        fill(arg);
+    }
+
+    /**
+     * Variation of {@link #fill(String, CommandSender)} that takes as parameter {@code isLastArg} a boolean indicating whether the accepted token is the last one<br>
+     * Only used by CommandTree, for nodes which have {@link #getUsedArgs()} returning -1<br>
+     * By default, it executes {@link #fill(String, CommandSender)}
+     * 
+     * @param arg the arg
+     * @param sender the command sender
+     * @param isLastArg {@code true} if the accepted token {@code arg} is the last one
+     */
+    default void fill(String arg, CommandSender sender, boolean isLastArg) {
+        fill(arg, sender);
+    }
+
+    /**
+     * The number of tokens consumed by the node (e.g., {@link PositionNode} consumes 3 tokens associated to the x,y,z coordinates of a position)<br>
+     * If the node consumes all the remaining tokens (e.g., {@link MessageStringNode}), then this method returns -1
+     * 
+     * @return the number of tokens consumed by the node
+     */
+    default int getUsedArgs() {
+        return 1;
+    }
 
     /**
      * Gets the node value after it has been filled by {@link #fill(String)}. It is automatically cast to the accepting type E without checking whether the cast can succeed<br>and may throw {@link ClassCastException}
+     * <br>
+     * Only used by ParamTree
      */
     <E> E get();
+
+    /**
+     * Variation of {@link #get()} that takes as parameter {@code sender} the command sender<br>
+     * Only used by CommandTree
+     * By default, it executes {@link #get()}
+     */
+    default <E> E get(CommandSender sender) {
+        return get();
+    }
 
     /**
      * Resets the node back to its initial state, ready for the next fill {@link #fill(String)}
@@ -102,8 +151,10 @@ public interface IParamNode<T> {
      */
     default void error(String key, String... params) {
         var list = this.getParamList();
-        list.error();
-        list.addMessage(key, params);
+        if (list != null) {
+            list.error();
+            list.addMessage(key, params);
+        }
     }
 
     /**
@@ -113,8 +164,10 @@ public interface IParamNode<T> {
      */
     default void error(CommandOutputMessage... messages) {
         var list = this.getParamList();
-        list.error();
-        list.addMessage(messages);
+        if (list != null) {
+            list.error();
+            list.addMessage(messages);
+        }
     }
 
     /**

--- a/src/main/java/org/powernukkitx/command/tree/node/IPlayersNode.java
+++ b/src/main/java/org/powernukkitx/command/tree/node/IPlayersNode.java
@@ -2,6 +2,7 @@ package org.powernukkitx.command.tree.node;
 
 import org.powernukkitx.IPlayer;
 import org.powernukkitx.Server;
+import org.powernukkitx.command.CommandSender;
 import org.powernukkitx.command.exceptions.SelectorSyntaxException;
 import org.powernukkitx.command.selector.EntitySelectorAPI;
 import org.powernukkitx.entity.Entity;
@@ -46,13 +47,18 @@ import java.util.stream.Collectors;
 public class IPlayersNode extends ParamNode<List<IPlayer>> {
     @Override
     public void fill(String arg) {
+        fill(arg, paramList.getParamTree().getSender());
+    }
+
+    @Override
+    public void fill(String arg, CommandSender sender) {
         if (arg.isBlank()) {
             this.error();
         } else if (EntitySelectorAPI.getAPI().checkValid(arg)) {
             List<Entity> entities;
             List<IPlayer> result;
             try {
-                entities = EntitySelectorAPI.getAPI().matchEntities(paramList.getParamTree().getSender(), arg);
+                entities = EntitySelectorAPI.getAPI().matchEntities(sender, arg);
             } catch (SelectorSyntaxException exception) {
                 error(exception.getMessage());
                 return;

--- a/src/main/java/org/powernukkitx/command/tree/node/MessageStringNode.java
+++ b/src/main/java/org/powernukkitx/command/tree/node/MessageStringNode.java
@@ -1,5 +1,6 @@
 package org.powernukkitx.command.tree.node;
 
+import org.powernukkitx.command.CommandSender;
 import org.powernukkitx.command.exceptions.SelectorSyntaxException;
 import org.powernukkitx.command.selector.EntitySelectorAPI;
 import org.powernukkitx.entity.Entity;
@@ -46,11 +47,23 @@ public class MessageStringNode extends ParamNode<String> {
     private final List<String> TMP = new ArrayList<>();
 
     @Override
-    public void fill(String arg) {
-        if (this.paramList.getIndex() != paramList.getParamTree().getArgs().length) TMP.add(arg);
-        else {
-            TMP.add(arg);
+    public int getUsedArgs() {
+        return -1;
+    }
 
+    @Override
+    public void fill(String arg) {
+        if (paramList.getIndex() != paramList.getParamTree().getArgs().length) TMP.add(arg);
+        else {
+            fill(arg, paramList.getParamTree().getSender(), true);
+        }
+    }
+
+    @Override
+    public void fill(String arg, CommandSender sender, boolean isLastArg) {
+        TMP.add(arg);
+
+        if (isLastArg) {
             String str = String.join(" ", TMP);
             Matcher match = EntitySelectorAPI.ENTITY_SELECTOR.matcher(str);
             this.value = match.replaceAll(r -> {
@@ -68,7 +81,7 @@ public class MessageStringNode extends ParamNode<String> {
                 if (EntitySelectorAPI.getAPI().checkValid(m)) {
                     StringJoiner join = new StringJoiner(", ");
                     try {
-                        for (Entity entity : EntitySelectorAPI.getAPI().matchEntities(paramList.getParamTree().getSender(), m)) {
+                        for (Entity entity : EntitySelectorAPI.getAPI().matchEntities(sender, m)) {
                             String name = entity.getName();
                             if (name.isBlank()) name = entity.getOriginalName();
                             join.add(name);

--- a/src/main/java/org/powernukkitx/command/tree/node/MessageStringNode.java
+++ b/src/main/java/org/powernukkitx/command/tree/node/MessageStringNode.java
@@ -53,10 +53,11 @@ public class MessageStringNode extends ParamNode<String> {
 
     @Override
     public void fill(String arg) {
-        if (paramList.getIndex() != paramList.getParamTree().getArgs().length) TMP.add(arg);
-        else {
-            fill(arg, paramList.getParamTree().getSender(), true);
-        }
+        fill(
+            arg, 
+            paramList.getParamTree().getSender(), 
+            paramList.getIndex() == paramList.getParamTree().getArgs().length
+        );
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/command/tree/node/PlayersNode.java
+++ b/src/main/java/org/powernukkitx/command/tree/node/PlayersNode.java
@@ -2,6 +2,7 @@ package org.powernukkitx.command.tree.node;
 
 import org.powernukkitx.Player;
 import org.powernukkitx.command.Command;
+import org.powernukkitx.command.CommandSender;
 import org.powernukkitx.command.exceptions.SelectorSyntaxException;
 import org.powernukkitx.command.selector.EntitySelectorAPI;
 import org.powernukkitx.entity.Entity;
@@ -41,16 +42,21 @@ import java.util.stream.Collectors;
  * @since PowerNukkitX 1.19.50
  */
 public class PlayersNode extends TargetNode<Player> {
-    //todo support uuid or xuid
     @Override
     public void fill(String arg) {
+        fill(arg, paramList.getParamTree().getSender());
+    }
+
+    //todo support uuid or xuid
+    @Override
+    public void fill(String arg, CommandSender sender) {
         if (arg.isBlank()) {
             this.error();
         } else if (EntitySelectorAPI.getAPI().checkValid(arg)) {
             List<Entity> entities;
             List<Player> result;
             try {
-                entities = EntitySelectorAPI.getAPI().matchEntities(paramList.getParamTree().getSender(), arg);
+                entities = EntitySelectorAPI.getAPI().matchEntities(sender, arg);
             } catch (SelectorSyntaxException exception) {
                 error(exception.getMessage());
                 return;
@@ -58,7 +64,7 @@ public class PlayersNode extends TargetNode<Player> {
             result = entities.stream().filter(entity -> entity instanceof Player).map(entity -> (Player) entity).collect(Collectors.toList());
             this.value = result;
         } else {
-            Player player = Command.resolveTargetPlayer(paramList.getParamTree().getSender(), arg);
+            Player player = Command.resolveTargetPlayer(sender, arg);
             this.value = player != null ? Collections.singletonList(player) : Collections.emptyList();
         }
     }

--- a/src/main/java/org/powernukkitx/command/tree/node/PositionNode.java
+++ b/src/main/java/org/powernukkitx/command/tree/node/PositionNode.java
@@ -1,5 +1,6 @@
 package org.powernukkitx.command.tree.node;
 
+import org.powernukkitx.command.CommandSender;
 import org.powernukkitx.level.Location;
 import org.powernukkitx.level.Position;
 import org.powernukkitx.math.BVector3;
@@ -58,6 +59,11 @@ public abstract class PositionNode extends ParamNode<Position> {
         return this.get(paramList.getParamTree().getSender().getPosition());
     }
 
+    @Override
+    public <E> E get(CommandSender sender) {
+        return this.get(sender.getPosition());
+    }
+
     @SuppressWarnings("unchecked")
     public <E> E get(Position basePos) {
         if (this.value == null) return null;
@@ -74,7 +80,17 @@ public abstract class PositionNode extends ParamNode<Position> {
     }
 
     @Override
+    public int getUsedArgs() {
+        return 3;
+    }
+
+    @Override
     public void fill(String arg) {
+        fill(arg, paramList.getParamTree().getSender());
+    }
+
+    @Override
+    public void fill(String arg, CommandSender sender) {
         TMP.clear();
         //check
         var matcher = pattern.matcher(arg);
@@ -87,7 +103,7 @@ public abstract class PositionNode extends ParamNode<Position> {
         else {
             //parse
             try {
-                Location loc = paramList.getParamTree().getSender().getLocation();
+                Location loc = sender.getLocation();
                 for (String s : TMP) {
                     if (s.charAt(0) == '~') {
                         this.setRelative(index);

--- a/src/main/java/org/powernukkitx/command/tree/node/RemainStringNode.java
+++ b/src/main/java/org/powernukkitx/command/tree/node/RemainStringNode.java
@@ -3,6 +3,8 @@ package org.powernukkitx.command.tree.node;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.powernukkitx.command.CommandSender;
+
 /**
  * Parses all remaining command arguments as a single {@code String} value for PowerNukkitX command trees.
  * <p>
@@ -41,10 +43,23 @@ public class RemainStringNode extends ParamNode<String> {
     private final List<String> TMP = new ArrayList<>();
 
     @Override
+    public int getUsedArgs() {
+        return -1;
+    }
+
+    @Override
     public void fill(String arg) {
-        if (this.paramList.getIndex() != paramList.getParamTree().getArgs().length) TMP.add(arg);
-        else {
-            TMP.add(arg);
+        fill(
+            arg, 
+            paramList.getParamTree().getSender(), 
+            paramList.getIndex() == paramList.getParamTree().getArgs().length
+        );
+    }
+
+    @Override
+    public void fill(String arg, CommandSender sender, boolean isLastArg) {
+        TMP.add(arg);
+        if (isLastArg) {
             this.value = String.join("", TMP);
         }
     }


### PR DESCRIPTION
## What does this PR do?

Fixes two interdependent bugs related to the CommandTree system: paramList access NPE and wrong args parsing.

## Why?

The IParamNode.fill method (called by RouteTree.parseArg method) called sometimes its paramList variable which however wasn't initialized by IParamNode.init method (it's for ParamTree), causing a NPE; moreover the RouteTree.match and RouteTree.parseArg methods didn't consider the case when a node needs more calls of the fill method to get multiple args (e.g. MessageStringNode gets all the remaining args, IntPositionNode gets 3 args), so the fill method accumulates only one arg but the CommandTree system goes forward and doesn't accumulate all the necessary args.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** a83d88d
- **Bedrock client version:** 1.26.44
- **Plugins loaded:** own plugin

**Steps performed and results:**


Built three ad hoc commands: one equipped with MessageStringNode (but later tested also with RemainStringNode), one equipped with IntPositionNode, one equipped with EntitiesNode. All commands successfully parsed the arguments without errors and executed their tasks (respectively: sendMessage of the whole string, teleport to a position, sendMessage of the entities collection .toString). 
1) MessageStringNode and the other nodes with getUsedArgs() returning -1 share the same structure built upon the untouched original code that parses the args, therefore i assume this group of nodes work well as a whole.
2) FloatPositionNode shares the same structure as IntPositionNode (both implementation of PositionNode class, which is the only edited class of these three). 
3) PlayersNode and IPlayersNode shares the same structure as EntitiesNode.

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|   Claude Sonnet 5 (web)    |       Explaining relations between PNX classes, suggesting code (no AI code pasted, all manual, verified or edited or ignored)      |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
