### PR TITLE
fix: client crash on /execute chained command parameter

### DIFF
--- a/src/main/java/org/powernukkitx/command/data/GenericParameter.java
+++ b/src/main/java/org/powernukkitx/command/data/GenericParameter.java
@@ -56,9 +56,13 @@ public interface GenericParameter {
     CommandParameterSupplier<CommandParameter> ITEM_NAME = (optional) -> CommandParameter.newEnum("itemName", optional, CommandEnum.ENUM_ITEM, new ItemNode());
     /**
      * Supplier for chained command parameters.
-     * Produces a parameter named "chainedCommand" using {@link CommandEnum#CHAINED_COMMAND_ENUM}, {@link org.powernukkitx.command.tree.node.ChainedCommandNode}, and {@link CommandParamOption#ENUM_AS_CHAINED_COMMAND}.
+     * Produces a parameter named "chainedCommand" using {@link CommandEnum#CHAINED_COMMAND_ENUM} and {@link org.powernukkitx.command.tree.node.ChainedCommandNode}.
+     * <p>
+     * The {@link CommandParamOption#ENUM_AS_CHAINED_COMMAND} option is deliberately not set: it makes the client resolve
+     * the enum value against the command's chained subcommand table, which the server never sends, and the client crashes
+     * on the empty lookup.
      */
-    CommandParameterSupplier<CommandParameter> CHAINED_COMMAND = (optional) -> CommandParameter.newEnum("chainedCommand", optional, CommandEnum.CHAINED_COMMAND_ENUM, new ChainedCommandNode(), CommandParamOption.ENUM_AS_CHAINED_COMMAND);
+    CommandParameterSupplier<CommandParameter> CHAINED_COMMAND = (optional) -> CommandParameter.newEnum("chainedCommand", optional, CommandEnum.CHAINED_COMMAND_ENUM, new ChainedCommandNode());
     /**
      * Supplier for origin selector parameters.
      * Produces a parameter named "origin" using {@link CommandParamType#SELECTION}.


### PR DESCRIPTION
<!--
  Read CONTRIBUTING.md before submitting:
  https://github.com/PowerNukkitX/PowerNukkitX/blob/master/CONTRIBUTING.md

  PRs that leave this template unfilled, or fill it with generated filler,
  are closed without review. Delete the HTML comments as you go.

  SECURITY: never report a vulnerability in a public PR. See SECURITY.md.
-->

## What does this PR do?

Fixes client crashing on /execute chained command parameter

## Why?

It was a bug that crashes the client.

## Type of change

<!-- Tick what applies. -->

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** Non-related
- **Bedrock client version:** 1.26.44.3
- **Plugins loaded:** None

**Steps performed and results:**

1. Joined the game
2. Tested /execute @a run
3. Left the game

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

No AI used.

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
