### PR TITLE
fix: accept self-signed login chain when xboxAuth is disabled

### DIFF
--- a/src/main/java/org/powernukkitx/network/process/handler/LoginHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/LoginHandler.java
@@ -30,6 +30,7 @@ import org.powernukkitx.utils.SkinUtils;
 
 import javax.crypto.SecretKey;
 import java.security.PublicKey;
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -79,27 +80,35 @@ public class LoginHandler implements PacketHandler<LoginPacket> {
             return;
         }
 
-        final boolean xboxAuthRequired = server.getSettings().baseSettings().xboxAuth();
-        if (xboxAuthRequired && (packet.getToken() == null || packet.getToken().isEmpty())) {
+        final boolean hasToken = packet.getToken() != null && !packet.getToken().isEmpty();
+        final List<String> chain = packet.getChain() != null ? List.copyOf(packet.getChain()) : List.of();
+        if (!hasToken && chain.isEmpty()) {
             failLogin(holder, server, DisconnectFailReason.NOT_AUTHENTICATED, null);
             return;
         }
 
-        final Credentials credentials = new Credentials(type, packet.getToken(), packet.getClientJwt());
+        final boolean xboxAuthRequired = server.getSettings().baseSettings().xboxAuth();
+        final Credentials credentials = new Credentials(type, packet.getToken(), chain, packet.getClientJwt());
 
         holder.setState(SessionState.AUTHENTICATING);
 
         offLoop(holder, server,
             () -> validateChain(credentials, server, xboxAuthRequired),
-            chain -> applyChain(chain, credentials, holder, server));
+            outcome -> applyChain(outcome, credentials, holder, server));
     }
 
     /**
      * Verifies the identity chain. First off-loop step, and the only one a login must pass before
      * the server decides whether it wants the player at all.
+     * <p>
+     * A client that is signed in sends a Mojang-issued token, while one that is not sends a
+     * self-signed certificate chain instead, so both forms have to be accepted here. Whether the
+     * identity ended up signed is what the xbox-auth check below reads.
      */
     private ChainOutcome validateChain(Credentials credentials, Server server, boolean xboxAuthRequired) throws Exception {
-        final ChainValidationResult result = EncryptionUtils.validateToken(credentials.authenticationType(), credentials.token());
+        final ChainValidationResult result = credentials.token() == null || credentials.token().isEmpty()
+            ? EncryptionUtils.validateChain(credentials.chain())
+            : EncryptionUtils.validateToken(credentials.authenticationType(), credentials.token());
         final boolean unsignedAllowed = server.getProxyAuthProvider() != null
             && server.getProxyAuthProvider().isUnsignedLoginAllowed();
         if (xboxAuthRequired && !result.signed() && !unsignedAllowed) {
@@ -316,7 +325,8 @@ public class LoginHandler implements PacketHandler<LoginPacket> {
      * The parts of the login packet the off-loop steps need, copied out on the network thread so
      * that nothing reads the packet once the pipeline has moved on from it.
      */
-    private record Credentials(PlayerAuthenticationType authenticationType, String token, String clientJwt) {
+    private record Credentials(PlayerAuthenticationType authenticationType, String token, List<String> chain,
+                               String clientJwt) {
     }
 
     /**


### PR DESCRIPTION
<!--
  Read CONTRIBUTING.md before submitting:
  https://github.com/PowerNukkitX/PowerNukkitX/blob/master/CONTRIBUTING.md

  PRs that leave this template unfilled, or fill it with generated filler,
  are closed without review. Delete the HTML comments as you go.

  SECURITY: never report a vulnerability in a public PR. See SECURITY.md.
-->

## What does this PR do?

This PR fixes people can't join when xboxAuth is disabled

## Why?

Closes #3005

## Type of change

<!-- Tick what applies. -->

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** Non-related
- **Bedrock client version:** 1.26.44.3
- **Plugins loaded:** None

**Steps performed and results:**

1. Joined the game without xboxAuth
2. Left the game

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

No AI used.

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
