### PR TITLE
feat: custom level provider registry

### DIFF
--- a/src/main/java/org/powernukkitx/Server.java
+++ b/src/main/java/org/powernukkitx/Server.java
@@ -67,6 +67,7 @@ import org.powernukkitx.level.Level;
 import org.powernukkitx.level.Position;
 import org.powernukkitx.level.format.LevelConfig;
 import org.powernukkitx.level.format.LevelProvider;
+import org.powernukkitx.level.format.LevelProviderFactory;
 import org.powernukkitx.level.format.LevelProviderManager;
 import org.powernukkitx.level.format.leveldb.LevelDBProvider;
 import org.powernukkitx.level.tickingarea.manager.SimpleTickingAreaManager;
@@ -2585,7 +2586,7 @@ public class Server {
             }
         } else {
             // verify the provider
-            Class<? extends LevelProvider> provider = LevelProviderManager.getProvider(path);
+            LevelProviderFactory provider = LevelProviderManager.getProviderFactory(path);
             if (provider == null) {
                 log.error(this.getLanguage().tr("nukkit.level.loadError", levelFolderName, "Unknown provider"));
                 return null;
@@ -2599,7 +2600,7 @@ public class Server {
                 DimensionEnum.NETHER.getDimensionData(), Collections.emptyMap()));
             map.put(2, new LevelConfig.GeneratorConfig("the_end", seed, false, LevelConfig.AntiXrayMode.LOW, true,
                 DimensionEnum.THE_END.getDimensionData(), Collections.emptyMap()));
-            levelConfig = new LevelConfig(LevelProviderManager.getProviderName(provider), true, map);
+            levelConfig = new LevelConfig(provider.getName(), true, map);
             try {
                 config.createNewFile();
                 FileUtils.write(config, JSONUtils.toPretty(levelConfig), StandardCharsets.UTF_8);
@@ -2629,9 +2630,9 @@ public class Server {
         }
         String pathS = Path.of(path).toString();
 
-        Class<? extends LevelProvider> provider = LevelProviderManager.getProvider(pathS);
+        LevelProviderFactory provider = LevelProviderManager.getProviderFactory(pathS);
         if (provider == null) {
-            provider = LevelProviderManager.getProviderByName(levelConfig.format());
+            provider = LevelProviderManager.getProviderFactoryByName(levelConfig.format());
         }
 
         Map<Integer, LevelConfig.GeneratorConfig> generators = levelConfig.generators();
@@ -2711,11 +2712,15 @@ public class Server {
         }
         for (var entry : levelConfig.generators().entrySet()) {
             LevelConfig.GeneratorConfig generatorConfig = entry.getValue();
-            var provider = LevelProviderManager.getProviderByName(levelConfig.format());
+            var provider = LevelProviderManager.getProviderFactoryByName(levelConfig.format());
+            if (provider == null) {
+                log.error(this.getLanguage().tr("nukkit.level.generationError", name,
+                    "Unknown provider " + levelConfig.format()));
+                return false;
+            }
             Level level;
             try {
-                provider.getMethod("generate", String.class, String.class, LevelConfig.GeneratorConfig.class)
-                    .invoke(null, path, name, generatorConfig);
+                provider.generate(path, name, generatorConfig);
                 String levelName = name
                     + (levelConfig.generators().size() > 1 ? entry.getValue().dimensionData().getSuffix() : "");
                 if (this.isLevelLoaded(levelName)) {

--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -51,6 +51,9 @@ import org.powernukkitx.level.format.ChunkState;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.level.format.LevelConfig;
 import org.powernukkitx.level.format.LevelProvider;
+import org.powernukkitx.level.format.LevelProviderFactory;
+import org.powernukkitx.level.format.LevelProviderManager;
+import org.powernukkitx.level.format.ReflectiveLevelProviderFactory;
 import org.powernukkitx.level.format.UnsafeChunk;
 import org.powernukkitx.level.format.leveldb.LevelDBProvider;
 import org.powernukkitx.level.generator.BiomedGenerator;
@@ -452,6 +455,12 @@ public class Level implements Metadatable {
     ///
 
     public Level(Server server, String name, String path, int dimSum, Class<? extends LevelProvider> provider, LevelConfig.GeneratorConfig generatorConfig) {
+        this(server, name, path, dimSum,
+                new ReflectiveLevelProviderFactory(LevelProviderManager.getProviderName(provider), provider),
+                generatorConfig);
+    }
+
+    public Level(Server server, String name, String path, int dimSum, LevelProviderFactory providerFactory, LevelConfig.GeneratorConfig generatorConfig) {
         this.levelId = levelIdCounter++;
         this.dimensionCount = dimSum;
         this.blockMetadata = new BlockMetadataStore(this);
@@ -474,9 +483,9 @@ public class Level implements Metadatable {
         }
 
         try {
-            this.provider = new AtomicReference<>(provider.getConstructor(Level.class, String.class).newInstance(this, path));
-        } catch (ReflectiveOperationException e) {
-            throw new LevelException("Constructor of " + provider + " failed", e);
+            this.provider = new AtomicReference<>(providerFactory.create(this, path));
+        } catch (Exception e) {
+            throw new LevelException("Level provider " + providerFactory.getName() + " failed to open " + path, e);
         }
         LevelProvider levelProvider = requireProvider();
         //to be changed later as the Dim0 will be deleted to be put in a config.json file of the world

--- a/src/main/java/org/powernukkitx/level/format/LevelProviderFactory.java
+++ b/src/main/java/org/powernukkitx/level/format/LevelProviderFactory.java
@@ -1,0 +1,45 @@
+package org.powernukkitx.level.format;
+
+import org.powernukkitx.level.Level;
+
+/**
+ * Creates {@link LevelProvider} instances for a world format.
+ * <p>
+ * Plugins can implement this interface and register it through
+ * {@link LevelProviderManager#registerProvider(LevelProviderFactory)} to add their own world format.
+ */
+public interface LevelProviderFactory {
+    /**
+     * @return the name of the format, as it is written in the {@code format} field of the level config.json
+     */
+    String getName();
+
+    /**
+     * @return the provider type created by this factory
+     */
+    Class<? extends LevelProvider> getProviderClass();
+
+    /**
+     * Opens the world stored at the given path.
+     *
+     * @param level the level the provider belongs to
+     * @param path  the world folder
+     * @return the opened provider
+     */
+    LevelProvider create(Level level, String path) throws Exception;
+
+    /**
+     * @param path the world folder
+     * @return whether the world at the given path is stored in this format
+     */
+    boolean isValid(String path);
+
+    /**
+     * Writes the files a world of this format needs before it can be opened.
+     *
+     * @param path            the world folder
+     * @param name            the world name
+     * @param generatorConfig the config of the dimension being created
+     */
+    void generate(String path, String name, LevelConfig.GeneratorConfig generatorConfig) throws Exception;
+}

--- a/src/main/java/org/powernukkitx/level/format/LevelProviderManager.java
+++ b/src/main/java/org/powernukkitx/level/format/LevelProviderManager.java
@@ -1,8 +1,10 @@
 package org.powernukkitx.level.format;
 
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -11,19 +13,38 @@ import java.util.Map;
  */
 @Slf4j
 public abstract class LevelProviderManager {
-    protected static final Map<String, Class<? extends LevelProvider>> providers = new HashMap<>();
+    protected static final Map<String, LevelProviderFactory> providers = new LinkedHashMap<>();
 
-    public static void addProvider(String name, Class<? extends LevelProvider> clazz) {
-        if (providers.putIfAbsent(name.trim().toLowerCase(Locale.ENGLISH), clazz) != null) {
-            log.error("Duplicate registration Level Provider {}", clazz);
+    /**
+     * Registers a world format. The name is the value plugins and worlds use in the {@code format} field of
+     * their config.json.
+     *
+     * @param factory the factory creating the providers of the format
+     */
+    public static void registerProvider(LevelProviderFactory factory) {
+        if (providers.putIfAbsent(factory.getName().trim().toLowerCase(Locale.ENGLISH), factory) != null) {
+            log.error("Duplicate registration Level Provider {}", factory.getName());
         }
     }
 
-    public static Class<? extends LevelProvider> getProvider(String path) {
-        for (Class<? extends LevelProvider> provider : providers.values()) {
+    /**
+     * Registers a world format from a provider class following the legacy contract.
+     *
+     * @see ReflectiveLevelProviderFactory
+     */
+    public static void addProvider(String name, Class<? extends LevelProvider> clazz) {
+        registerProvider(new ReflectiveLevelProviderFactory(name, clazz));
+    }
+
+    /**
+     * @param path the world folder
+     * @return the factory able to open the world, or null if no registered format matches it
+     */
+    public static @Nullable LevelProviderFactory getProviderFactory(String path) {
+        for (LevelProviderFactory factory : providers.values()) {
             try {
-                if ((boolean) provider.getMethod("isValid", String.class).invoke(null, path)) {
-                    return provider;
+                if (factory.isValid(path)) {
+                    return factory;
                 }
             } catch (Exception e) {
                 log.error("An error occurred while getting the provider {}", path, e);
@@ -32,18 +53,31 @@ public abstract class LevelProviderManager {
         return null;
     }
 
+    public static @Nullable LevelProviderFactory getProviderFactoryByName(String name) {
+        return providers.get(name.trim().toLowerCase(Locale.ENGLISH));
+    }
+
+    public static Map<String, LevelProviderFactory> getProviderFactories() {
+        return Collections.unmodifiableMap(providers);
+    }
+
+    public static @Nullable Class<? extends LevelProvider> getProvider(String path) {
+        LevelProviderFactory factory = getProviderFactory(path);
+        return factory == null ? null : factory.getProviderClass();
+    }
+
     public static String getProviderName(Class<? extends LevelProvider> clazz) {
         for (var entry : providers.entrySet()) {
-            if (clazz == entry.getValue()) {
+            if (clazz == entry.getValue().getProviderClass()) {
                 return entry.getKey();
             }
         }
         return "unknown";
     }
 
-    public static Class<? extends LevelProvider> getProviderByName(String name) {
-        name = name.trim().toLowerCase(Locale.ENGLISH);
-        return providers.getOrDefault(name, null);
+    public static @Nullable Class<? extends LevelProvider> getProviderByName(String name) {
+        LevelProviderFactory factory = getProviderFactoryByName(name);
+        return factory == null ? null : factory.getProviderClass();
     }
 
 }

--- a/src/main/java/org/powernukkitx/level/format/ReflectiveLevelProviderFactory.java
+++ b/src/main/java/org/powernukkitx/level/format/ReflectiveLevelProviderFactory.java
@@ -1,0 +1,54 @@
+package org.powernukkitx.level.format;
+
+import org.powernukkitx.level.Level;
+import lombok.Getter;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * Adapts a {@link LevelProvider} class following the legacy contract - a {@code (Level, String)} constructor plus
+ * the static {@code isValid(String)} and {@code generate(String, String, GeneratorConfig)} methods - to the
+ * {@link LevelProviderFactory} API.
+ */
+public class ReflectiveLevelProviderFactory implements LevelProviderFactory {
+    @Getter
+    private final String name;
+    @Getter
+    private final Class<? extends LevelProvider> providerClass;
+    private final Constructor<? extends LevelProvider> constructor;
+    private final Method isValidMethod;
+    private final Method generateMethod;
+
+    public ReflectiveLevelProviderFactory(String name, Class<? extends LevelProvider> providerClass) {
+        this.name = name;
+        this.providerClass = providerClass;
+        try {
+            this.constructor = providerClass.getConstructor(Level.class, String.class);
+            this.isValidMethod = providerClass.getMethod("isValid", String.class); // TODO: this doesn't looks great, we should find a great way
+            this.generateMethod = providerClass.getMethod("generate", String.class, String.class, LevelConfig.GeneratorConfig.class);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalArgumentException(providerClass.getName() + " does not follow the level provider contract", e);
+        }
+    }
+
+    @Override
+    public LevelProvider create(Level level, String path) throws Exception {
+        return this.constructor.newInstance(level, path);
+    }
+
+    @Override
+    public boolean isValid(String path) {
+        try {
+            return (boolean) this.isValidMethod.invoke(null, path);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new IllegalStateException("Failed to validate " + path + " with " + this.providerClass.getName(), e);
+        }
+    }
+
+    @Override
+    public void generate(String path, String name, LevelConfig.GeneratorConfig generatorConfig) throws Exception {
+        this.generateMethod.invoke(null, path, name, generatorConfig);
+    }
+}


### PR DESCRIPTION
<!--
  Read CONTRIBUTING.md before submitting:
  https://github.com/PowerNukkitX/PowerNukkitX/blob/master/CONTRIBUTING.md

  PRs that leave this template unfilled, or fill it with generated filler,
  are closed without review. Delete the HTML comments as you go.

  SECURITY: never report a vulnerability in a public PR. See SECURITY.md.
-->

## What does this PR do?

This PR adds custom level provider registry.

## Why?

Some people can want to add their own level provider.

## Type of change

<!-- Tick what applies. -->

- [ ] Bug Fix
- [x] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** Non-related
- **Bedrock client version:** 1.26.44.3
- **Plugins loaded:** None

**Steps performed and results:**

1. Joined the game with custom provider
2. Moved around the world
3. Left the game

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
| Claude Opus 5      | Javadoc descriptions            |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
