### PR TITLE
fix: Fix ender-chest open animation

### DIFF
--- a/src/main/java/org/powernukkitx/inventory/HumanEnderChestInventory.java
+++ b/src/main/java/org/powernukkitx/inventory/HumanEnderChestInventory.java
@@ -68,14 +68,14 @@ public class HumanEnderChestInventory extends BaseInventory implements BlockEnti
         this.sendContents(who);
 
         final BlockEventPacket blockEventPacket = new BlockEventPacket();
-        blockEventPacket.setBlockPosition(Vector3i.from(this.getHolder().getX(), this.getHolder().getY(), this.getHolder().getZ()));
+        blockEventPacket.setBlockPosition(Vector3i.from(enderChest.getX(), enderChest.getY(), enderChest.getZ()));
         blockEventPacket.setEventType(1);
         blockEventPacket.setEventValue(2);
 
-        Level level = this.getHolder().getLevel();
+        Level level = enderChest.getLevel();
         if (level != null) {
-            level.addSound(this.getHolder().getVector3().add(0.5, 0.5, 0.5), Sound.RANDOM_ENDERCHESTOPEN);
-            level.addChunkPacket((int) this.getHolder().getX() >> 4, (int) this.getHolder().getZ() >> 4, blockEventPacket);
+            level.addSound(enderChest.getVector3().add(0.5, 0.5, 0.5), Sound.RANDOM_ENDERCHESTOPEN);
+            level.addChunkPacket((int) enderChest.getX() >> 4, (int) enderChest.getZ() >> 4, blockEventPacket);
         }
     }
 
@@ -106,10 +106,10 @@ public class HumanEnderChestInventory extends BaseInventory implements BlockEnti
         blockEventPacket.setEventType(1);
         blockEventPacket.setEventValue(0);
 
-        Level level = this.getHolder().getLevel();
+        Level level = enderChest.getLevel();
         if (level != null) {
-            level.addSound(this.getHolder().getVector3().add(0.5, 0.5, 0.5), Sound.RANDOM_ENDERCHESTCLOSED);
-            level.addChunkPacket((int) this.getHolder().getX() >> 4, (int) this.getHolder().getZ() >> 4, blockEventPacket);
+            level.addSound(enderChest.getVector3().add(0.5, 0.5, 0.5), Sound.RANDOM_ENDERCHESTCLOSED);
+            level.addChunkPacket((int) enderChest.getX() >> 4, (int) enderChest.getZ() >> 4, blockEventPacket);
         }
         setBlockEntityEnderChest(who, null);
         super.onClose(who);


### PR DESCRIPTION
## What does this PR do?

Fixed the block that wouldn't open

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 
- **Bedrock client version:** 26.44
- **Plugins loaded:** none

**Steps performed and results:**

1. Place an ender-chest
2. Open it