### PR TITLE
fix: summon entity autocomplete missing custom entities

### DIFF
--- a/src/main/java/org/powernukkitx/command/data/CommandEnum.java
+++ b/src/main/java/org/powernukkitx/command/data/CommandEnum.java
@@ -84,6 +84,17 @@ public class CommandEnum {
     public static final CommandEnum ENUM_ENTITY = new CommandEnum("Entity", Collections.emptyList());
 
     /**
+     * Every summonable entity identifier, resolved lazily so entities registered by plugins after startup are included.
+     */
+    public static final CommandEnum ENUM_SUMMONABLE_ENTITY = new CommandEnum("EntityType", () -> Registries.ENTITY.getKnownEntities().keySet().stream()
+            .filter(id -> {
+                var definition = Registries.ENTITY.getEntityDefinition(id);
+                return definition != null && definition.isSummonable();
+            })
+            .map(id -> id.startsWith(Identifier.DEFAULT_NAMESPACE) ? id.substring(10) : id)
+            .toList());
+
+    /**
      * The name of the enum, used for display and identification.
      */
     private final String name;

--- a/src/main/java/org/powernukkitx/command/defaults/SummonCommand.java
+++ b/src/main/java/org/powernukkitx/command/defaults/SummonCommand.java
@@ -1,6 +1,7 @@
 package org.powernukkitx.command.defaults;
 
 import org.powernukkitx.command.CommandSender;
+import org.powernukkitx.command.data.CommandEnum;
 import org.powernukkitx.command.data.CommandParameter;
 import org.powernukkitx.command.selector.args.impl.Type;
 import org.powernukkitx.command.tree.ParamList;
@@ -13,7 +14,6 @@ import org.powernukkitx.registry.EntityRegistry;
 import org.powernukkitx.registry.Registries;
 import org.cloudburstmc.protocol.bedrock.data.command.CommandParamType;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -25,22 +25,16 @@ public class SummonCommand extends VanillaCommand {
         this.setPermission("nukkit.command.summon");
         this.commandParameters.clear();
 
-        List<String> entity_key = new ArrayList<>();
-        for (String key : Registries.ENTITY.getKnownEntities().keySet()) {
-            entity_key.add(key.replace("minecraft:", ""));
-        }
-        String[] entities = entity_key.toArray(new String[0]);
-
         // Syntax 1: /summon <entityType> <nameTag> [spawnPos]
         this.commandParameters.put("BasicWithName", new CommandParameter[]{
-                CommandParameter.newEnum("entityType", false, entities, true),
+                CommandParameter.newEnum("entityType", false, CommandEnum.ENUM_SUMMONABLE_ENTITY),
                 CommandParameter.newType("nameTag", false, CommandParamType.ID),
                 CommandParameter.newType("spawnPos", true, CommandParamType.POSITION)
         });
 
         // Syntax 2: /summon <entityType> [spawnPos] [yRot] [xRot] [nameTag]
         this.commandParameters.put("WithRotation", new CommandParameter[]{
-                CommandParameter.newEnum("entityType", false, entities, true),
+                CommandParameter.newEnum("entityType", false, CommandEnum.ENUM_SUMMONABLE_ENTITY),
                 CommandParameter.newType("spawnPos", true, CommandParamType.POSITION),
                 CommandParameter.newType("yRot", true, CommandParamType.VAL),
                 CommandParameter.newType("xRot", true, CommandParamType.VAL),
@@ -49,7 +43,7 @@ public class SummonCommand extends VanillaCommand {
 
         // Syntax 3: /summon <entityType> [spawnPos] facing <lookAtEntity> [nameTag]
         this.commandParameters.put("FacingEntity", new CommandParameter[]{
-                CommandParameter.newEnum("entityType", false, entities, true),
+                CommandParameter.newEnum("entityType", false, CommandEnum.ENUM_SUMMONABLE_ENTITY),
                 CommandParameter.newType("spawnPos", true, CommandParamType.POSITION),
                 CommandParameter.newEnum("facing", false, new String[]{"facing"}),
                 CommandParameter.newType("lookAtEntity", CommandParamType.SELECTION),
@@ -58,7 +52,7 @@ public class SummonCommand extends VanillaCommand {
 
         // Syntax 4: /summon <entityType> [spawnPos] facing <lookAtPosition> [nameTag]
         this.commandParameters.put("FacingPos", new CommandParameter[]{
-                CommandParameter.newEnum("entityType", false, entities, true),
+                CommandParameter.newEnum("entityType", false, CommandEnum.ENUM_SUMMONABLE_ENTITY),
                 CommandParameter.newType("spawnPos", true, CommandParamType.POSITION),
                 CommandParameter.newEnum("facing", false, new String[]{"facing"}),
                 CommandParameter.newType("lookAtPosition", CommandParamType.POSITION),


### PR DESCRIPTION
<!--
  Read CONTRIBUTING.md before submitting:
  https://github.com/PowerNukkitX/PowerNukkitX/blob/master/CONTRIBUTING.md

  PRs that leave this template unfilled, or fill it with generated filler,
  are closed without review. Delete the HTML comments as you go.

  SECURITY: never report a vulnerability in a public PR. See SECURITY.md.
-->

## What does this PR do?

This PR fixes summon command auto-completion for entities.

## Type of change

<!-- Tick what applies. -->

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** Non-related
- **Bedrock client version:** 1.26.44.3
- **Plugins loaded:** None

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

No AI used.

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
