### PR TITLE
fix: baby entity size scaled twice

### DIFF
--- a/src/main/java/org/powernukkitx/entity/Entity.java
+++ b/src/main/java/org/powernukkitx/entity/Entity.java
@@ -3897,6 +3897,20 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
     }
 
     /**
+     * The scale applied to this entity while it is a baby.
+     * <p>
+     * Baby size is driven entirely by this factor, so {@link #getWidth()} and {@link #getHeight()}
+     * must always report the adult dimensions. Override this for entities whose baby form is not
+     * half the size of the adult.
+     * </p>
+     *
+     * @return the baby scale factor, {@code 0.5} by default.
+     */
+    public float getBabyScale() {
+        return 0.5f;
+    }
+
+    /**
      * Sets whether this entity is a baby.
      * <p>
      * Updates the {@link ActorFlags#BABY} data flag and applies the corresponding scale.
@@ -3908,7 +3922,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
      */
     public void setBaby(boolean value) {
         this.setDataFlag(ActorFlags.BABY, value);
-        this.setScale(value ? 0.5f : 1f);
+        this.setScale(value ? getBabyScale() : 1f);
 
         if (this.isAgeable()) {
             if (!value) {
@@ -4065,7 +4079,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         boolean baby = left > 0;
 
         setDataFlag(ActorFlags.BABY, baby, false);
-        setScale(baby ? 0.5f : 1f);
+        setScale(baby ? getBabyScale() : 1f);
 
         ticksGrowLeft = left;
 

--- a/src/main/java/org/powernukkitx/entity/mob/EntityHoglin.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityHoglin.java
@@ -91,18 +91,18 @@ public class EntityHoglin extends EntityMob implements EntityWalkable {
     }
 
     @Override
+    public float getBabyScale() {
+        // baby hoglin is 0.85 wide against the adult's 1.4
+        return 0.6071f;
+    }
+
+    @Override
     public float getWidth() {
-        if (this.isBaby()) {
-            return 0.85f;
-        }
         return 1.4f;
     }
 
     @Override
     public float getHeight() {
-        if (this.isBaby()) {
-            return 0.85f;
-        }
         return 1.4f;
     }
 

--- a/src/main/java/org/powernukkitx/entity/mob/EntityHusk.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityHusk.java
@@ -91,12 +91,12 @@ public class EntityHusk extends EntityZombie {
 
     @Override
     public float getWidth() {
-        return this.isBaby() ? 0.3f : 0.6f;
+        return 0.6f;
     }
 
     @Override
     public float getHeight() {
-        return this.isBaby() ? 0.95f : 1.9f;
+        return 1.9f;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityZoglin.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityZoglin.java
@@ -68,18 +68,18 @@ public class EntityZoglin extends EntityMob implements EntityWalkable {
     }
 
     @Override
+    public float getBabyScale() {
+        // baby zoglin is 0.85 wide against the adult's 1.4
+        return 0.6071f;
+    }
+
+    @Override
     public float getWidth() {
-        if (this.isBaby()) {
-            return 0.85f;
-        }
         return 1.4f;
     }
 
     @Override
     public float getHeight() {
-        if (this.isBaby()) {
-            return 0.85f;
-        }
         return 1.4f;
     }
 

--- a/src/main/java/org/powernukkitx/entity/passive/EntityArmadillo.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityArmadillo.java
@@ -251,18 +251,17 @@ public class EntityArmadillo extends EntityAnimal {
     }
 
     @Override
+    public float getBabyScale() {
+        return 0.6f;
+    }
+
+    @Override
     public float getWidth() {
-        if (isBaby()) {
-            return 0.42F;
-        }
         return 0.7f;
     }
 
     @Override
     public float getHeight() {
-        if (isBaby()) {
-            return 0.39f;
-        }
         return 0.65F;
     }
 

--- a/src/main/java/org/powernukkitx/entity/passive/EntityBee.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityBee.java
@@ -155,17 +155,11 @@ public class EntityBee extends EntityAnimal implements EntityFlyable {
 
     @Override
     public float getWidth() {
-        if (this.isBaby()) {
-            return 0.275f;
-        }
         return 0.55f;
     }
 
     @Override
     public float getHeight() {
-        if (this.isBaby()) {
-            return 0.25f;
-        }
         return 0.5f;
     }
 

--- a/src/main/java/org/powernukkitx/entity/passive/EntityCamel.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityCamel.java
@@ -73,18 +73,11 @@ public class EntityCamel extends EntityAnimal implements InventoryHolder {
 
     @Override
     public float getWidth() {
-        if (isBaby()) {
-            return 0.85f;
-        }
         return 1.7f;
     }
 
     @Override
     public float getHeight() {
-        if (isBaby()) {
-            if (isSitting()) return 0.472f;
-            return 1.1875f;
-        }
         if (isSitting()) return 0.945f;
         return 2.375f;
     }

--- a/src/main/java/org/powernukkitx/entity/passive/EntityCat.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityCat.java
@@ -90,12 +90,12 @@ public class EntityCat extends EntityAnimal implements EntityWalkable, EntityCan
     // Cat body sizes from Wiki https://minecraft.wiki/w/Cat
     @Override
     public float getWidth() {
-        return this.isBaby() ? 0.24f : 0.48f;
+        return 0.48f;
     }
 
     @Override
     public float getHeight() {
-        return this.isBaby() ? 0.28f : 0.56f;
+        return 0.56f;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/passive/EntityChicken.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityChicken.java
@@ -91,17 +91,11 @@ public class EntityChicken extends EntityAnimal implements EntityWalkable, Clima
 
     @Override
     public float getWidth() {
-        if (this.isBaby()) {
-            return 0.3f;
-        }
         return 0.6f;
     }
 
     @Override
     public float getHeight() {
-        if (this.isBaby()) {
-            return 0.4f;
-        }
         return 0.8f;
     }
 

--- a/src/main/java/org/powernukkitx/entity/passive/EntityCow.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityCow.java
@@ -77,17 +77,11 @@ public class EntityCow extends EntityAnimal implements EntityWalkable, ClimateVa
 
     @Override
     public float getWidth() {
-        if (this.isBaby()) {
-            return 0.45f;
-        }
         return 0.9f;
     }
 
     @Override
     public float getHeight() {
-        if (this.isBaby()) {
-            return 0.65f;
-        }
         return 1.3f;
     }
 

--- a/src/main/java/org/powernukkitx/entity/passive/EntityDonkey.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityDonkey.java
@@ -75,17 +75,11 @@ public class EntityDonkey extends EntityAnimal implements EntityWalkable, Invent
 
     @Override
     public float getWidth() {
-        if (this.isBaby()) {
-            return 0.7f;
-        }
         return 1.4f;
     }
 
     @Override
     public float getHeight() {
-        if (this.isBaby()) {
-            return 0.8f;
-        }
         return 1.6f;
     }
 

--- a/src/main/java/org/powernukkitx/entity/passive/EntityGoat.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityGoat.java
@@ -46,12 +46,12 @@ public class EntityGoat extends EntityAnimal implements EntityWalkable {
 
     @Override
     public float getHeight() {
-        return this.isBaby() ? 0.65f : 1.3f;
+        return 1.3f;
     }
 
     @Override
     public float getWidth() {
-        return this.isBaby() ? 0.45f : 0.9f;
+        return 0.9f;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/passive/EntityHappyGhast.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityHappyGhast.java
@@ -251,13 +251,19 @@ public class EntityHappyGhast extends EntityAnimal implements EntityFlyable, Inv
     }
 
     @Override
+    public float getBabyScale() {
+        // ghastlings are 0.95 across against the adult's 4.0
+        return 0.2375f;
+    }
+
+    @Override
     public float getWidth() {
-        return isBaby() ? 0.95f : 4f;
+        return 4f;
     }
 
     @Override
     public float getHeight() {
-        return isBaby() ? 0.95f : 4f;
+        return 4f;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/passive/EntityHorse.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityHorse.java
@@ -77,17 +77,11 @@ public class EntityHorse extends EntityAnimal implements EntityWalkable, EntityV
 
     @Override
     public float getWidth() {
-        if (this.isBaby()) {
-            return 0.7f;
-        }
         return 1.4f;
     }
 
     @Override
     public float getHeight() {
-        if (this.isBaby()) {
-            return 0.8f;
-        }
         return 1.6f;
     }
 

--- a/src/main/java/org/powernukkitx/entity/passive/EntityMooshroom.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityMooshroom.java
@@ -107,17 +107,11 @@ public class EntityMooshroom extends EntityAnimal implements EntityWalkable, Ent
 
     @Override
     public float getWidth() {
-        if (isBaby()) {
-            return 0.45f;
-        }
         return 0.9f;
     }
 
     @Override
     public float getHeight() {
-        if (isBaby()) {
-            return 0.65f;
-        }
         return 1.3f;
     }
 

--- a/src/main/java/org/powernukkitx/entity/passive/EntityMule.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityMule.java
@@ -69,17 +69,11 @@ public class EntityMule extends EntityAnimal implements EntityWalkable, Inventor
 
     @Override
     public float getWidth() {
-        if (this.isBaby()) {
-            return 0.7f;
-        }
         return 1.4f;
     }
 
     @Override
     public float getHeight() {
-        if (this.isBaby()) {
-            return 0.8f;
-        }
         return 1.6f;
     }
 

--- a/src/main/java/org/powernukkitx/entity/passive/EntityOcelot.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityOcelot.java
@@ -48,17 +48,11 @@ public class EntityOcelot extends EntityAnimal implements EntityWalkable {
 
     @Override
     public float getWidth() {
-        if (this.isBaby()) {
-            return 0.3f;
-        }
         return 0.6f;
     }
 
     @Override
     public float getHeight() {
-        if (this.isBaby()) {
-            return 0.35f;
-        }
         return 0.7f;
     }
 

--- a/src/main/java/org/powernukkitx/entity/passive/EntityPig.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityPig.java
@@ -84,17 +84,11 @@ public class EntityPig extends EntityAnimal implements EntityWalkable, ClimateVa
 
     @Override
     public float getWidth() {
-        if (this.isBaby()) {
-            return 0.45f;
-        }
         return 0.9f;
     }
 
     @Override
     public float getHeight() {
-        if (this.isBaby()) {
-            return 0.45f;
-        }
         return 0.9f;
     }
 

--- a/src/main/java/org/powernukkitx/entity/passive/EntityPolarBear.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityPolarBear.java
@@ -47,17 +47,11 @@ public class EntityPolarBear extends EntityAnimal implements EntityWalkable {
 
     @Override
     public float getWidth() {
-        if (this.isBaby()) {
-            return 0.65f;
-        }
         return 1.3f;
     }
 
     @Override
     public float getHeight() {
-        if (this.isBaby()) {
-            return 0.7f;
-        }
         return 1.4f;
     }
 

--- a/src/main/java/org/powernukkitx/entity/passive/EntityRabbit.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityRabbit.java
@@ -78,18 +78,18 @@ public class EntityRabbit extends EntityAnimal implements EntityWalkable, Entity
     }
 
     @Override
+    public float getBabyScale() {
+        // baby rabbit is 0.268 across against the adult's 0.402
+        return 0.6667f;
+    }
+
+    @Override
     public float getWidth() {
-        if (this.isBaby()) {
-            return 0.268f;
-        }
         return 0.402f;
     }
 
     @Override
     public float getHeight() {
-        if (this.isBaby()) {
-            return 0.268f;
-        }
         return 0.402f;
     }
 

--- a/src/main/java/org/powernukkitx/entity/passive/EntitySalmon.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntitySalmon.java
@@ -37,9 +37,7 @@ public class EntitySalmon extends EntityFish {
 
     @Override
     public float getWidth() {
-        if (this.isBaby()) {
-            return 0.25f;
-        } else if (this.isLarge()) {
+        if (this.isLarge()) {
             return 0.75f;
         }
         return 0.5f;
@@ -47,9 +45,7 @@ public class EntitySalmon extends EntityFish {
 
     @Override
     public float getHeight() {
-        if (this.isBaby()) {
-            return 0.25f;
-        } else if (this.isLarge()) {
+        if (this.isLarge()) {
             return 0.75f;
         }
         return 0.5f;

--- a/src/main/java/org/powernukkitx/entity/passive/EntitySheep.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntitySheep.java
@@ -69,17 +69,11 @@ public class EntitySheep extends EntityAnimal implements EntityWalkable, EntityS
 
     @Override
     public float getWidth() {
-        if (this.isBaby()) {
-            return 0.45f;
-        }
         return 0.9f;
     }
 
     @Override
     public float getHeight() {
-        if (isBaby()) {
-            return 0.65f;
-        }
         return 1.3f;
     }
 

--- a/src/main/java/org/powernukkitx/entity/passive/EntityTurtle.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityTurtle.java
@@ -118,17 +118,11 @@ public class EntityTurtle extends EntityAnimal implements EntitySwimmable, Entit
 
     @Override
     public float getWidth() {
-        if (this.isBaby()) {
-            return 0.6f;
-        }
         return 1.2f;
     }
 
     @Override
     public float getHeight() {
-        if (this.isBaby()) {
-            return 0.2f;
-        }
         return 0.4f;
     }
 

--- a/src/main/java/org/powernukkitx/entity/passive/EntityVillager.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityVillager.java
@@ -48,17 +48,11 @@ public class EntityVillager extends EntityCreature implements IEntityNPC {
 
     @Override
     public float getWidth() {
-        if (this.isBaby()) {
-            return 0.3f;
-        }
         return 0.6f;
     }
 
     @Override
     public float getHeight() {
-        if (this.isBaby()) {
-            return 0.95f;
-        }
         return 1.9f;
     }
 

--- a/src/main/java/org/powernukkitx/entity/passive/EntityVillagerV2.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityVillagerV2.java
@@ -471,16 +471,10 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
     }
 
     private float getWidthR() {
-        if (this.isBaby()) {
-            return 0.3f;
-        }
         return 0.6f;
     }
 
     private float getHeightR() {
-        if (this.isBaby()) {
-            return 0.95f;
-        }
         return 1.9f;
     }
 

--- a/src/main/java/org/powernukkitx/entity/passive/EntityWolf.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityWolf.java
@@ -126,17 +126,11 @@ public class EntityWolf extends EntityAnimal implements EntityWalkable, EntityCa
 
     @Override
     public float getWidth() {
-        if (isBaby()) {
-            return 0.3f;
-        }
         return 0.6f;
     }
 
     @Override
     public float getHeight() {
-        if (isBaby()) {
-            return 0.425f;
-        }
         return 0.8f;
     }
 


### PR DESCRIPTION
## What does this PR do?

Makes baby entity size come from a single place. `Entity.setBaby()` was applying `setScale(0.5f)` *and* 26 entity classes were separately returning halved values from `getWidth()`/`getHeight()` when `isBaby()`, so the two stacked. Baby size is now driven only by the scale, via a new overridable `Entity#getBabyScale()`.

## Why?

`recalculateBoundingBox()` computes `getWidth() * scale` (`Entity.java:1029-1030`). With both halvings in play a baby chicken ended up 0.15 x 0.20 instead of 0.30 x 0.40 — half the size it should be — and the client got `SCALE = 0.5` on top of the baby geometry the `BABY` actor flag already selects. The visible result is a chick whose head looks oversized against a too-small body.

Only baby-flagged mobs were affected, which is why it looked intermittent: chickens from a thrown egg (`EntityEgg.java:130-131`, 1/8 chance), from breeding (`BreedingExecutor.java:293`), or from a sneak + spawn egg. Naturally spawned chickens are always adults, so they looked fine.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** Non-related
- **Bedrock client version:** 1.26.44.3
- **Plugins loaded:** None

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| Claude Opus 5 | Traced the double-scaling through `Entity.setBaby` / `recalculateBoundingBox`, wrote the `getBabyScale()` change and the 26 call-site edits, wrote this description |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [ ] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [ ] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [ ] "Allow maintainer edits" is enabled

---
