### PR TITLE
fix: block break

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -491,14 +491,6 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         return gamemode != SPECTATOR ? gamemode : GameType.SPECTATOR.ordinal();
     }
 
-    private static int breakAnimationData(double miningTimeRequiredSeconds) {
-        double breakTimeTicks = miningTimeRequiredSeconds * 20.0;
-        if (breakTimeTicks <= 1.0) {
-            return 65535;
-        }
-        return (int) (65535 / breakTimeTicks);
-    }
-
     protected void onBlockBreakContinue(Vector3 pos, BlockFace face) {
         if (this.isBreakingBlock()) {
             var time = System.currentTimeMillis();
@@ -509,13 +501,13 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
             } else miningTimeRequired = this.breakingBlock.calculateBreakTime(this.inventory.getItemInMainHand(), this);
 
             if (miningTimeRequired > 0) {
-                 int breakTick = Math.max(1, (int) Math.ceil(miningTimeRequired * 20));
+                int breakTick = Math.max(1, (int) Math.ceil(miningTimeRequired * 20));
 
-                 if (breakTick != this.lastSentBreakTick) {
+                if (breakTick != this.lastSentBreakTick) {
                     final LevelEventPacket pk = new LevelEventPacket();
                     pk.setType(LevelEvent.BLOCK_UPDATE_BREAK);
                     pk.setPosition(Vector3f.from(this.breakingBlock.x, this.breakingBlock.y, this.breakingBlock.z));
-                    pk.setData(breakAnimationData(miningTimeRequired));
+                    pk.setData(65535 / breakTick);
                     this.getLevel().addChunkPacket(this.breakingBlock.getFloorX() >> 4, this.breakingBlock.getFloorZ() >> 4, pk);
                     this.lastSentBreakTick = breakTick;
                 }
@@ -613,7 +605,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
                 final LevelEventPacket pk = new LevelEventPacket();
                 pk.setType(LevelEvent.BLOCK_START_BREAK);
                 pk.setPosition(pos.toNetwork());
-                pk.setData(breakAnimationData(miningTimeRequired));
+                pk.setData(65535 / breakTime);
                 this.getLevel().addChunkPacket(pos.getFloorX() >> 4, pos.getFloorZ() >> 4, pk);
                 this.lastSentBreakTick = breakTime;
 
@@ -647,7 +639,6 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
     }
 
     public void onBlockBreakComplete(BlockVector3 blockPos, BlockFace face) {
-            this.level.getBlock(blockPos.asVector3()).getId(), System.currentTimeMillis() - this.lastBreak, this.blockBreakProgress);
         if (!this.spawned || !this.isAlive()) {
             return;
         }

--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -251,6 +251,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
     public long lastSkinChange;
     protected long breakingBlockTime = 0;
     protected double blockBreakProgress = 0;
+    protected int lastSentBreakTick = 0;
     protected final BedrockServerSession session;
     protected final InetSocketAddress rawSocketAddress;
     protected final Map<UUID, Player> hiddenPlayers = new HashMap<>();
@@ -490,6 +491,14 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         return gamemode != SPECTATOR ? gamemode : GameType.SPECTATOR.ordinal();
     }
 
+    private static int breakAnimationData(double miningTimeRequiredSeconds) {
+        double breakTimeTicks = miningTimeRequiredSeconds * 20.0;
+        if (breakTimeTicks <= 1.0) {
+            return 65535;
+        }
+        return (int) (65535 / breakTimeTicks);
+    }
+
     protected void onBlockBreakContinue(Vector3 pos, BlockFace face) {
         if (this.isBreakingBlock()) {
             var time = System.currentTimeMillis();
@@ -500,18 +509,15 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
             } else miningTimeRequired = this.breakingBlock.calculateBreakTime(this.inventory.getItemInMainHand(), this);
 
             if (miningTimeRequired > 0) {
-                Item hand = this.inventory.getItemInMainHand();
-                boolean hasCustomDigger = hand != null && !hand.isNull() && hand.getCustomItemComponent("minecraft:digger") != null;
-                boolean useServerSideBreakVisuals = this.breakingBlock instanceof CustomBlock || hasCustomDigger;
+                 int breakTick = Math.max(1, (int) Math.ceil(miningTimeRequired * 20));
 
-                if (useServerSideBreakVisuals) {
-                    int breakTick = (int) Math.ceil(miningTimeRequired * 20);
-
+                 if (breakTick != this.lastSentBreakTick) {
                     final LevelEventPacket pk = new LevelEventPacket();
                     pk.setType(LevelEvent.BLOCK_UPDATE_BREAK);
                     pk.setPosition(Vector3f.from(this.breakingBlock.x, this.breakingBlock.y, this.breakingBlock.z));
-                    pk.setData(65535 / breakTick);
+                    pk.setData(breakAnimationData(miningTimeRequired));
                     this.getLevel().addChunkPacket(this.breakingBlock.getFloorX() >> 4, this.breakingBlock.getFloorZ() >> 4, pk);
+                    this.lastSentBreakTick = breakTick;
                 }
 
                 if (face != null && !this.server.getSettings().miscSettings().overrideServerAuthBlockBreaking()) {
@@ -519,19 +525,18 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
                 }
 
                 long timeDiff = time - breakingBlockTime;
-                blockBreakProgress += timeDiff / (miningTimeRequired * 1000.0);
+                blockBreakProgress += timeDiff / (breakTick * 50.0);
 
-                if (blockBreakProgress >= 0.99) {
-                    if (useServerSideBreakVisuals) {
-                        final LevelEventPacket stopPk = new LevelEventPacket();
-                        stopPk.setType(LevelEvent.BLOCK_STOP_BREAK);
-                        stopPk.setPosition(pos.toNetwork());
-                        this.getLevel().addChunkPacket(pos.getFloorX() >> 4, pos.getFloorZ() >> 4, stopPk);
-                    }
+                if (blockBreakProgress >= 1.0) {
+                    final LevelEventPacket stopPk = new LevelEventPacket();
+                    stopPk.setType(LevelEvent.BLOCK_STOP_BREAK);
+                    stopPk.setPosition(pos.toNetwork());
+                    this.getLevel().addChunkPacket(pos.getFloorX() >> 4, pos.getFloorZ() >> 4, stopPk);
 
                     this.blockBreakProgress = 0;
                     this.breakingBlock = null;
                     this.breakingBlockFace = null;
+                    this.lastSentBreakTick = 0;
 
                     this.onBlockBreakComplete(pos.asBlockVector3(), face);
                     return;
@@ -608,8 +613,9 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
                 final LevelEventPacket pk = new LevelEventPacket();
                 pk.setType(LevelEvent.BLOCK_START_BREAK);
                 pk.setPosition(pos.toNetwork());
-                pk.setData(65535 / breakTime);
+                pk.setData(breakAnimationData(miningTimeRequired));
                 this.getLevel().addChunkPacket(pos.getFloorX() >> 4, pos.getFloorZ() >> 4, pk);
+                this.lastSentBreakTick = breakTime;
 
                 if (this.getLevel().isAntiXrayEnabled() && this.getLevel().getAntiXraySystem().isPreDeObfuscate()) {
                     this.getLevel().getAntiXraySystem().deObfuscateBlock(this, face, target);
@@ -627,6 +633,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         this.blockBreakProgress = 0;
         this.breakingBlock = null;
         this.breakingBlockFace = null;
+        this.lastSentBreakTick = 0;
     }
 
     public void onBlockBreakAbort(Vector3 pos) {
@@ -640,6 +647,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
     }
 
     public void onBlockBreakComplete(BlockVector3 blockPos, BlockFace face) {
+            this.level.getBlock(blockPos.asVector3()).getId(), System.currentTimeMillis() - this.lastBreak, this.blockBreakProgress);
         if (!this.spawned || !this.isAlive()) {
             return;
         }

--- a/src/main/java/org/powernukkitx/block/BlockObsidian.java
+++ b/src/main/java/org/powernukkitx/block/BlockObsidian.java
@@ -41,7 +41,7 @@ public class BlockObsidian extends BlockSolid {
 
     @Override
     public double getHardness() {
-        return 50;
+        return 35; /* 50 in PC */
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/block/BlockObsidian.java
+++ b/src/main/java/org/powernukkitx/block/BlockObsidian.java
@@ -41,7 +41,7 @@ public class BlockObsidian extends BlockSolid {
 
     @Override
     public double getHardness() {
-        return 35; //TODO Should be 50 but the break time calculation is broken
+        return 50;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/block/BlockObsidian.java
+++ b/src/main/java/org/powernukkitx/block/BlockObsidian.java
@@ -41,7 +41,7 @@ public class BlockObsidian extends BlockSolid {
 
     @Override
     public double getHardness() {
-        return 35; /* 50 in PC */
+        return 35;
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?

It resets obsidian's hardness to 50 (vanilla value) and fixes the crack animation, which used to cut off before the block broke

## Why?

bugfix

## Type of change

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 6c98300
- **Bedrock client version:** 26.44
- **Plugins loaded:** none

**Steps performed and results:**

1. join a server
2. break a obsidian (It looks the same as on BDS)
3. break a stone with diamond pickaxe efficiency 4 (It looks the same as on BDS)

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|       |             |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
