### PR TITLE
fix: paramList NPE related to CommandTree in IParamNode

### DIFF
--- a/src/main/java/org/powernukkitx/command/tree/node/IParamNode.java
+++ b/src/main/java/org/powernukkitx/command/tree/node/IParamNode.java
@@ -131,7 +131,10 @@ public interface IParamNode<T> {
      * Flags an error in this node's {@link #fill(String)} and outputs the default error message
      */
     default void error() {
-        this.getParamList().error();
+        var list = this.getParamList();
+        if (list != null) {
+            list.error();
+        }
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?

Fixes a NPE in IParamNode thrown when error() is called by a command developed using CommandTree. Integrates #3022.

## Why?

Didn't see this bug in the precedent bug fix (#3022) related to the same thing, and in its testing phase i forgot to test error.
During the development of a new feature (#3000), the testing showed this bug.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** ed42571
- **Bedrock client version:** 26.44
- **Plugins loaded:** own

Tested a custom command affected by this bug.

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

No AI used.

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
