### PR TITLE
fix: item air sync with client / mobile cursor inventory

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -36,6 +36,7 @@ import org.cloudburstmc.protocol.bedrock.data.command.CommandOriginType;
 import org.cloudburstmc.protocol.bedrock.data.command.CommandOutputType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerId;
 import org.cloudburstmc.protocol.bedrock.data.inventory.InventoryLayout;
+import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.bedrock.data.inventory.InventoryLeftTabIndex;
 import org.cloudburstmc.protocol.bedrock.data.inventory.InventoryRightTabIndex;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemUseMethod;
@@ -6948,17 +6949,34 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         packet.setContainerId(ContainerId.UI);
 
         for (int i = 0; i < 54; ++i) {
-            packet.getSlots().add(Item.AIR.toNetwork());
+            packet.getSlots().add(ItemData.AIR);
         }
 
-        packet.getSlots().set(0, this.getCursorInventory().getUnclonedItem(0).toNetwork());
+        final Item cursorItem = this.getCursorInventory().getUnclonedItem(0);
+        packet.getSlots().set(
+                0,
+                cursorItem.isNull()
+                        ? ItemData.AIR
+                        : cursorItem.toNetwork()
+        );
 
         for (int i = 0; i < 4; ++i) {
-            packet.getSlots().set(28 + i, this.getCraftingGrid().getUnclonedItem(i).toNetwork());
+            final Item craftingItem = this.getCraftingGrid().getUnclonedItem(i);
+            packet.getSlots().set(
+                    28 + i,
+                    craftingItem.isNull()
+                            ? ItemData.AIR
+                            : craftingItem.toNetwork()
+            );
         }
 
         final Item creativeOutput = this.getCreativeOutputInventory().getUnclonedItem(0);
-        packet.getSlots().set(50, creativeOutput == null ? Item.AIR.toNetwork() : creativeOutput.toNetwork());
+        packet.getSlots().set(
+                50,
+                creativeOutput == null || creativeOutput.isNull()
+                        ? ItemData.AIR
+                        : creativeOutput.toNetwork()
+        );
 
         this.sendPacketImmediately(packet);
     }
@@ -6972,7 +6990,9 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
 
         final Item offhandItem = this.getOffhandInventory().getUnclonedItem(0);
         packet.getSlots().add(
-                offhandItem == null ? Item.AIR.toNetwork() : offhandItem.toNetwork()
+                offhandItem == null || offhandItem.isNull()
+                        ? ItemData.AIR
+                        : offhandItem.toNetwork()
         );
 
         this.sendPacketImmediately(packet);

--- a/src/main/java/org/powernukkitx/inventory/HumanInventory.java
+++ b/src/main/java/org/powernukkitx/inventory/HumanInventory.java
@@ -748,7 +748,9 @@ public class HumanInventory extends BaseInventory {
         inventoryContentPacket.setContainerId(ContainerId.INVENTORY);
 
         for (int i = 0; i < ARMORS_INDEX; ++i) {
-            inventoryContentPacket.getSlots().add(this.getUnclonedItem(i).toNetwork());
+            final Item item = this.getUnclonedItem(i);
+            inventoryContentPacket.getSlots().add(item.isNull() ? ItemData.AIR : item.toNetwork()
+            );
         }
 
         player.sendPacketImmediately(inventoryContentPacket);
@@ -769,10 +771,12 @@ public class HumanInventory extends BaseInventory {
         inventoryContentPacket.setContainerId(ContainerId.ARMOR);
 
         for (final Item item : this.getArmorContents()) {
-            inventoryContentPacket.getSlots().add(item.toNetwork());
+            inventoryContentPacket.getSlots().add(
+                    item.isNull() ? ItemData.AIR : item.toNetwork()
+            );
         }
 
-        inventoryContentPacket.getSlots().add(Item.AIR.toNetwork());
+        inventoryContentPacket.getSlots().add(ItemData.AIR);
 
         player.sendPacketImmediately(inventoryContentPacket);
     }

--- a/src/main/java/org/powernukkitx/item/ConstAirItem.java
+++ b/src/main/java/org/powernukkitx/item/ConstAirItem.java
@@ -7,9 +7,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class ConstAirItem extends Item {
     public ConstAirItem() {
-        super("minecraft:air");
-        this.meta = 0;
-        this.count = 0;
+        super("minecraft:air", 0, 0, null, false);
         this.netId = 0;
     }
 

--- a/src/main/java/org/powernukkitx/item/Item.java
+++ b/src/main/java/org/powernukkitx/item/Item.java
@@ -2774,7 +2774,7 @@ public abstract class Item implements Cloneable, ItemID {
     }
 
     public static Item fromNetwork(ItemData itemData) {
-        if (itemData.getDefinition() == null) {
+        if (itemData == null || itemData.isNull() || itemData.getDefinition() == null) {
             return Item.AIR;
         }
         final ItemDefinition definition = itemData.getDefinition();

--- a/src/main/java/org/powernukkitx/registry/CreativeGroupsRegistry.java
+++ b/src/main/java/org/powernukkitx/registry/CreativeGroupsRegistry.java
@@ -2,10 +2,8 @@ package org.powernukkitx.registry;
 
 import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import lombok.extern.slf4j.Slf4j;
-import org.cloudburstmc.protocol.bedrock.data.inventory.CreativeItemData;
 import org.cloudburstmc.protocol.bedrock.data.payload.creative.CreativeGroupInfoPayload;
 import org.cloudburstmc.protocol.bedrock.data.payload.creative.CreativeItemEntryPayload;
-import org.cloudburstmc.protocol.bedrock.data.payload.creative.CreativeItemNetId;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.customitem.data.CreativeCategory;
 import org.powernukkitx.network.protocol.types.inventory.creative.CreativeCustomGroups;


### PR DESCRIPTION
## What does this PR do?

Fix initial inventory AIR serialization for Bedrock parity

## Why?

Mobile users were most affected because incorrect AIR serialization broke touch inventory interactions until respawn.

Closes #

## Type of change

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** 56f25ebc06efa3b2192fdf1bdf57608b684ee33c
- **Bedrock client version:** 26.44
- **Plugins loaded:** none

**Steps performed and results:**

1.
2.

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [X] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
|    codex   |   packet correlation          |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [ ] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
