### PR TITLE
Add BadPacketHandler

### DIFF
--- a/src/main/java/org/powernukkitx/event/player/PlayerHackDetectedEvent.java
+++ b/src/main/java/org/powernukkitx/event/player/PlayerHackDetectedEvent.java
@@ -33,6 +33,7 @@ public class PlayerHackDetectedEvent extends PlayerEvent {
         PACKET_FLOOD,
         PERMISSION_REQUEST,
         INVALID_PVP,
-        INVALID_PVE
+        INVALID_PVE,
+        BAD_PACKET
     }
 }

--- a/src/main/java/org/powernukkitx/network/Network.java
+++ b/src/main/java/org/powernukkitx/network/Network.java
@@ -1,17 +1,5 @@
 package org.powernukkitx.network;
 
-import org.powernukkitx.Player;
-import org.powernukkitx.Server;
-import org.powernukkitx.config.category.NetworkSettings;
-import org.powernukkitx.event.server.ServerBotnetAttackEvent;
-import org.powernukkitx.network.process.NetworkPacketHandler;
-import org.powernukkitx.network.process.NetworkState;
-import org.powernukkitx.network.process.PlayerSessionHolder;
-import org.powernukkitx.network.query.codec.QueryPacketCodec;
-import org.powernukkitx.network.query.handler.QueryPacketHandler;
-import org.powernukkitx.network.security.BotnetDetector;
-import org.powernukkitx.plugin.InternalPlugin;
-import org.powernukkitx.utils.Utils;
 import com.google.common.base.Strings;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.bootstrap.ServerBootstrap;
@@ -38,8 +26,23 @@ import org.cloudburstmc.netty.channel.raknet.config.RakServerCookieMode;
 import org.cloudburstmc.protocol.bedrock.BedrockPong;
 import org.cloudburstmc.protocol.bedrock.BedrockServerSession;
 import org.cloudburstmc.protocol.bedrock.codec.BedrockCodec;
+import org.cloudburstmc.protocol.bedrock.netty.codec.packet.BedrockPacketCodec;
+import org.cloudburstmc.protocol.bedrock.netty.codec.packet.BedrockPacketCodec_v3;
 import org.cloudburstmc.protocol.bedrock.netty.initializer.BedrockServerInitializer;
 import org.jetbrains.annotations.Nullable;
+import org.powernukkitx.Player;
+import org.powernukkitx.Server;
+import org.powernukkitx.config.category.NetworkSettings;
+import org.powernukkitx.event.server.ServerBotnetAttackEvent;
+import org.powernukkitx.network.process.BadPacketHandler;
+import org.powernukkitx.network.process.NetworkPacketHandler;
+import org.powernukkitx.network.process.NetworkState;
+import org.powernukkitx.network.process.PlayerSessionHolder;
+import org.powernukkitx.network.query.codec.QueryPacketCodec;
+import org.powernukkitx.network.query.handler.QueryPacketHandler;
+import org.powernukkitx.network.security.BotnetDetector;
+import org.powernukkitx.plugin.InternalPlugin;
+import org.powernukkitx.utils.Utils;
 import oshi.SystemInfo;
 import oshi.hardware.NetworkIF;
 
@@ -84,8 +87,8 @@ public class Network implements NetworkInterface {
         this.server = server;
         var bns = server.getSettings().networkSettings().botnetSettings();
         this.botnetDetector = bns.detectionEnabled()
-                ? new BotnetDetector(bns.suspiciousThreshold(), bns.minSuspiciousIps(), bns.minScore())
-                : null;
+            ? new BotnetDetector(bns.suspiciousThreshold(), bns.minSuspiciousIps(), bns.minScore())
+            : null;
         server.getScheduler().scheduleTask(InternalPlugin.INSTANCE, () -> {
             List<NetworkIF> tmpIfs = null;
             try {
@@ -121,67 +124,78 @@ public class Network implements NetworkInterface {
         final BedrockCodec codec = NetworkConstants.CODEC;
 
         this.pong = new BedrockPong()
-                .edition("MCPE")
-                .motd(server.getMotd())
-                .subMotd(server.getSubMotd())
-                .playerCount(server.getOnlinePlayers().size())
-                .maximumPlayerCount(server.getMaxPlayers())
-                .serverId(UUID.randomUUID().getMostSignificantBits())
-                .gameType(Server.getGamemodeString(server.getDefaultGamemode(), true))
-                .nintendoLimited(false)
-                .protocolVersion(codec.getProtocolVersion())
-                .ipv4Port(server.getPort())
-                .ipv6Port(server.getPort());
+            .edition("MCPE")
+            .motd(server.getMotd())
+            .subMotd(server.getSubMotd())
+            .playerCount(server.getOnlinePlayers().size())
+            .maximumPlayerCount(server.getMaxPlayers())
+            .serverId(UUID.randomUUID().getMostSignificantBits())
+            .gameType(Server.getGamemodeString(server.getDefaultGamemode(), true))
+            .nintendoLimited(false)
+            .protocolVersion(codec.getProtocolVersion())
+            .ipv4Port(server.getPort())
+            .ipv6Port(server.getPort());
 
         final NetworkSettings net = server.getSettings().networkSettings();
         this.channel = (RakServerChannel) new ServerBootstrap()
-                .channelFactory(RakChannelFactory.server(oclass))
-                .option(RakChannelOption.RAK_ADVERTISEMENT, getAdvertisement())
-                .option(RakChannelOption.RAK_SUPPORTED_PROTOCOLS, new int[]{codec.getRaknetProtocolVersion()})
-                .option(RakChannelOption.RAK_PACKET_LIMIT, net.packetLimit())
-                .option(RakChannelOption.RAK_SERVER_COOKIE_MODE, parseCookieMode(net.cookieMode()))
-                .childOption(RakChannelOption.RAK_AUTO_FLUSH, net.autoFlush())
-                .childOption(RakChannelOption.RAK_FLUSH_INTERVAL, net.flushInterval())
-                .childOption(RakChannelOption.RAK_MAX_QUEUED_BYTES, net.maxQueuedBytes())
-                .group(eventloopgroup)
-                .childHandler(new BedrockServerInitializer() {
-                    @Override
-                    protected void postInitChannel(Channel channel) {
-                        if (Network.this.server.getSettings().networkSettings().enableQuery()) {
-                            channel.pipeline().addLast("queryPacketCodec", new QueryPacketCodec())
-                                    .addLast("queryPacketHandler", new QueryPacketHandler(address -> Network.this.server.getQueryInformation()));
-                        }
+            .channelFactory(RakChannelFactory.server(oclass))
+            .option(RakChannelOption.RAK_ADVERTISEMENT, getAdvertisement())
+            .option(RakChannelOption.RAK_SUPPORTED_PROTOCOLS, new int[]{codec.getRaknetProtocolVersion()})
+            .option(RakChannelOption.RAK_PACKET_LIMIT, net.packetLimit())
+            .option(RakChannelOption.RAK_SERVER_COOKIE_MODE, parseCookieMode(net.cookieMode()))
+            .childOption(RakChannelOption.RAK_AUTO_FLUSH, net.autoFlush())
+            .childOption(RakChannelOption.RAK_FLUSH_INTERVAL, net.flushInterval())
+            .childOption(RakChannelOption.RAK_MAX_QUEUED_BYTES, net.maxQueuedBytes())
+            .group(eventloopgroup)
+            .childHandler(new BedrockServerInitializer() {
+                @Override
+                protected void postInitChannel(Channel channel) {
+                    if (Network.this.server.getSettings().networkSettings().enableQuery()) {
+                        channel.pipeline().addLast("queryPacketCodec", new QueryPacketCodec())
+                            .addLast("queryPacketHandler", new QueryPacketHandler(address -> Network.this.server.getQueryInformation()));
                     }
+                }
 
-                    @Override
-                    protected void initSession(BedrockServerSession session) {
-                        final InetSocketAddress address = (InetSocketAddress) session.getSocketAddress();
-                        if (Network.this.getState() == NetworkState.STARTING || Network.this.getState() == NetworkState.STOPPING) {
-                            return;
-                        }
-                        if (isAddressBlocked(address)) {
-                            session.close("Your IP address has been blocked by this server!");
-                        } else {
-                            session.setCodec(NetworkConstants.CODEC);
-                            session.setPacketHandler(new NetworkPacketHandler(server,
-                                    new PlayerSessionHolder(
-                                            session,
-                                            Network.this.server.getSettings().networkSettings().rateLimitSettings()
-                                    )
-                            ));
-                            final Channel sessionChannel = session.getPeer().getChannel();
-                            Network.this.sessionMap.put(address, session);
-                            sessionChannel.closeFuture().addListener(future -> {
-                                if (!Network.this.sessionMap.remove(address, session)) {
-                                    Network.this.sessionMap.values().remove(session);
-                                }
-                            });
-                        }
+                @Override
+                protected void initSession(BedrockServerSession session) {
+                    session.getPeer().getChannel().pipeline().replace(
+                        BedrockPacketCodec.NAME,
+                        BedrockPacketCodec.NAME,
+                        new BedrockPacketCodec_v3(false)
+                    );
+                    session.getPeer().getChannel().pipeline().addAfter(
+                        BedrockPacketCodec.NAME,
+                        "badPacketHandler",
+                        new BadPacketHandler(session)
+                    );
+
+                    final InetSocketAddress address = (InetSocketAddress) session.getSocketAddress();
+                    if (Network.this.getState() == NetworkState.STARTING || Network.this.getState() == NetworkState.STOPPING) {
+                        return;
                     }
-                })
-                .bind(bindAddress)
-                .awaitUninterruptibly()
-                .channel();
+                    if (isAddressBlocked(address)) {
+                        session.close("Your IP address has been blocked by this server!");
+                    } else {
+                        session.setCodec(NetworkConstants.CODEC);
+                        session.setPacketHandler(new NetworkPacketHandler(server,
+                            new PlayerSessionHolder(
+                                session,
+                                Network.this.server.getSettings().networkSettings().rateLimitSettings()
+                            )
+                        ));
+                        final Channel sessionChannel = session.getPeer().getChannel();
+                        Network.this.sessionMap.put(address, session);
+                        sessionChannel.closeFuture().addListener(future -> {
+                            if (!Network.this.sessionMap.remove(address, session)) {
+                                Network.this.sessionMap.values().remove(session);
+                            }
+                        });
+                    }
+                }
+            })
+            .bind(bindAddress)
+            .awaitUninterruptibly()
+            .channel();
     }
 
     // Verifies the UDP port is free before RakNet binds, so the server refuses to start when another process holds it.
@@ -353,7 +367,7 @@ public class Network implements NetworkInterface {
             var bns = server.getSettings().networkSettings().botnetSettings();
             botnetDetector.tick().ifPresent(report -> {
                 ServerBotnetAttackEvent event = new ServerBotnetAttackEvent(
-                        report, bns.autoBlock(), bns.autoBlockDurationSeconds());
+                    report, bns.autoBlock(), bns.autoBlockDurationSeconds());
                 server.getPluginManager().callEvent(event);
                 if (event.isAutoBlock()) {
                     int durationMs = event.getBlockDurationSeconds() * 1000;

--- a/src/main/java/org/powernukkitx/network/Network.java
+++ b/src/main/java/org/powernukkitx/network/Network.java
@@ -161,7 +161,7 @@ public class Network implements NetworkInterface {
                     session.getPeer().getChannel().pipeline().replace(
                         BedrockPacketCodec.NAME,
                         BedrockPacketCodec.NAME,
-                        new BedrockPacketCodec_v3(false)
+                        new BedrockPacketCodec_v3(log.isDebugEnabled())
                     );
                     session.getPeer().getChannel().pipeline().addAfter(
                         BedrockPacketCodec.NAME,

--- a/src/main/java/org/powernukkitx/network/process/BadPacketHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/BadPacketHandler.java
@@ -1,0 +1,46 @@
+package org.powernukkitx.network.process;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import lombok.RequiredArgsConstructor;
+import org.cloudburstmc.protocol.bedrock.BedrockServerSession;
+import org.cloudburstmc.protocol.bedrock.codec.PacketSerializeException;
+import org.powernukkitx.Player;
+import org.powernukkitx.Server;
+import org.powernukkitx.event.player.PlayerHackDetectedEvent;
+
+/**
+ * @author Kaooot
+ */
+@RequiredArgsConstructor
+public class BadPacketHandler extends ChannelInboundHandlerAdapter {
+
+    private final BedrockServerSession session;
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable throwable) {
+        while (throwable != null) {
+            if (throwable instanceof PacketSerializeException e) {
+                for (final Player player : Server.getInstance().getOnlinePlayers().values()) {
+                    if (player.getSession().getSocketAddress().equals(this.session.getSocketAddress())) {
+                        final PlayerHackDetectedEvent event = new PlayerHackDetectedEvent(
+                            player,
+                            PlayerHackDetectedEvent.HackType.BAD_PACKET
+                        );
+
+                        Server.getInstance().getPluginManager().callEvent(event);
+
+                        if (event.isKick()) {
+                            player.close("Bad Packet");
+                        }
+
+                        Server.getInstance().getLogger().warning(player.getName() + " sent a bad packet", e);
+                        return;
+                    }
+                }
+                this.session.close("Bad Packet");
+            }
+            throwable = throwable.getCause();
+        }
+    }
+}

--- a/src/main/java/org/powernukkitx/network/process/handler/RequestChunkRadiusHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/RequestChunkRadiusHandler.java
@@ -1,11 +1,9 @@
 package org.powernukkitx.network.process.handler;
 
+import org.cloudburstmc.protocol.bedrock.packet.RequestChunkRadiusPacket;
 import org.powernukkitx.Server;
 import org.powernukkitx.network.process.PacketHandler;
 import org.powernukkitx.network.process.PlayerSessionHolder;
-import org.powernukkitx.network.process.SessionState;
-import org.cloudburstmc.protocol.bedrock.data.DisconnectFailReason;
-import org.cloudburstmc.protocol.bedrock.packet.RequestChunkRadiusPacket;
 
 /**
  * @author Kaooot
@@ -16,10 +14,6 @@ public class RequestChunkRadiusHandler implements PacketHandler<RequestChunkRadi
 
     @Override
     public void handle(RequestChunkRadiusPacket packet, PlayerSessionHolder holder, Server server) {
-        if (!holder.getState().equals(SessionState.CHUNKS)) {
-            holder.disconnect(DisconnectFailReason.UNEXPECTED_PACKET);
-            return;
-        }
         final int viewDistance = server.getSettings().gameplaySettings().viewDistance();
         final int radius = Math.max(MIN_CHUNK_RADIUS, Math.min(packet.getChunkRadius(), viewDistance));
         holder.getPlayer().setViewDistance(radius);


### PR DESCRIPTION
- **Added bad packet handling**
  - Introduced a new `BadPacketHandler` that catches `PacketSerializeException`.
  - Invalid packets are reported as `BAD_PACKET` through `PlayerHackDetectedEvent`.
  - Plugins can react to the event, including kicking the player.
  - If no player is associated with the packet, the session is closed with `"Bad Packet"`.
  - The error is also logged.

- **Added `BAD_PACKET` hack type**
  - `PlayerHackDetectedEvent.HackType` now includes `BAD_PACKET`.

- **Updated the network pipeline**
  - Sessions now use `BedrockPacketCodec_v3(log.isDebugEnabled())`
  - The new `BadPacketHandler` is added to the pipeline to handle malformed packets.