### PR TITLE
fix: never declare an optional message parameter to the client

### DIFF
--- a/src/main/java/org/powernukkitx/command/data/CommandParameter.java
+++ b/src/main/java/org/powernukkitx/command/data/CommandParameter.java
@@ -327,6 +327,22 @@ public class CommandParameter {
         return result;
     }
 
+    public boolean isRestOfLine() {
+        return this.enumData == null
+                && (this.type == CommandParamType.MESSAGE
+                || this.type == CommandParamType.MESSAGE_ROOT
+                || this.type == CommandParamType.MESSAGE_EXP);
+    }
+
+    public CommandParameter asRequired() {
+        if (!this.optional) {
+            return this;
+        }
+        final CommandParameter copy = new CommandParameter(this.name, false, this.type, this.enumData, this.postFix, this.paramNode);
+        copy.paramOptions = this.paramOptions;
+        return copy;
+    }
+
     public CommandParamData toNetwork() {
         final CommandParamData data = new CommandParamData();
         data.setName(this.name);

--- a/src/main/java/org/powernukkitx/command/data/NukkitCommandData.java
+++ b/src/main/java/org/powernukkitx/command/data/NukkitCommandData.java
@@ -10,6 +10,7 @@ import org.cloudburstmc.protocol.bedrock.data.command.CommandParamData;
 import org.cloudburstmc.protocol.bedrock.data.command.CommandPermissionLevel;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -173,6 +174,26 @@ public class NukkitCommandData implements Cloneable {
         }
     }
 
+    private static List<CommandParameter[]> expandOptionalRestOfLine(CommandParameter[] parameters) {
+        int greedy = -1;
+        for (int i = 0; i < parameters.length; i++) {
+            if (parameters[i] != null && parameters[i].optional && parameters[i].isRestOfLine()) {
+                greedy = i;
+                break;
+            }
+        }
+        if (greedy < 0) {
+            return List.<CommandParameter[]>of(parameters);
+        }
+
+        final CommandParameter[] without = Arrays.copyOfRange(parameters, 0, greedy);
+        final CommandParameter[] with = new CommandParameter[parameters.length];
+        for (int i = 0; i < parameters.length; i++) {
+            with[i] = i <= greedy ? parameters[i].asRequired() : parameters[i];
+        }
+        return List.of(without, with);
+    }
+
     public CommandData toNetwork() {
         final Set<CommandData.Flag> flags = new ObjectOpenHashSet<>();
         for (Flag flag : this.flags) {
@@ -185,16 +206,18 @@ public class NukkitCommandData implements Cloneable {
         final List<CommandOverloadData> overloadDataList = new ObjectArrayList<>();
         for (Map.Entry<String, CommandOverload> entry : this.overloads.entrySet()) {
             final CommandOverload value = entry.getValue();
-            final List<CommandParamData> params = new ObjectArrayList<>();
-            for (CommandParameter parameter : value.input.parameters) {
-                params.add(parameter.toNetwork());
+            for (CommandParameter[] parameters : expandOptionalRestOfLine(value.input.parameters)) {
+                final List<CommandParamData> params = new ObjectArrayList<>();
+                for (CommandParameter parameter : parameters) {
+                    params.add(parameter.toNetwork());
+                }
+                overloadDataList.add(
+                        new CommandOverloadData(
+                                value.chaining,
+                                params.toArray(CommandParamData[]::new)
+                        )
+                );
             }
-            overloadDataList.add(
-                    new CommandOverloadData(
-                            value.chaining,
-                            params.toArray(CommandParamData[]::new)
-                    )
-            );
         }
         return new CommandData(
                 this.name,


### PR DESCRIPTION
## What does this PR do?

In the title

## Why?

Client crash

No linked issue.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** `40bee04f2` (branch `fix/optional-message-parameter`, one commit on top of upstream `7583f4f37`)

Automated only, so far:
- `./gradlew compileJava compileTestJava` passes
- `./gradlew test` on `40bee04f2`: **1023 tests, 0 failures, 0 errors**

- [ ] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

  A unit test was included; removed at the reviewer's request.

## Breaking changes / API impact

Adds two public methods to `CommandParameter`: `isRestOfLine()` and `asRequired()`.
Behaviour change: an overload declaring an optional MESSAGE parameter is now sent to the
client as two overloads instead of one. No config or save-format change.

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| Claude Opus 5 (Claude Code, autonomous agent) | Rebased my fork on `upstream/master`, split my pre-existing fixes into one branch per bug, removed my explanatory comments and Javadoc from the diff, translated my French commit messages into English, and ran the build and the test suite. It also wrote this checklist, the API-impact note above and this table.|

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [ ] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [ ] Public API additions/changes have Javadoc <!-- not done: this branch adds public methods without Javadoc -->
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled

