### PR TITLE
fix: send a message parameter as the grammar root, not as its inner node

### DIFF
--- a/src/main/java/org/powernukkitx/command/data/CommandParameter.java
+++ b/src/main/java/org/powernukkitx/command/data/CommandParameter.java
@@ -337,6 +337,9 @@ public class CommandParameter {
             if (type == null) {
                 type = CommandParamType.RAW_TEXT;
             }
+            if (type == CommandParamType.MESSAGE) {
+                type = CommandParamType.MESSAGE_ROOT;
+            }
             final Field field = CommandParam.class.getDeclaredField(type.name());
             final CommandParam param = (CommandParam) field.get(null);
             data.setType(param);

--- a/src/test/java/org/powernukkitx/command/data/CommandParameterTest.java
+++ b/src/test/java/org/powernukkitx/command/data/CommandParameterTest.java
@@ -1,5 +1,7 @@
 package org.powernukkitx.command.data;
 
+import org.cloudburstmc.protocol.bedrock.data.command.CommandParam;
+import org.cloudburstmc.protocol.bedrock.data.command.CommandParamData;
 import org.cloudburstmc.protocol.bedrock.data.command.CommandParamType;
 import org.junit.jupiter.api.Test;
 
@@ -87,5 +89,22 @@ class CommandParameterTest {
         CommandParameter p = CommandParameter.newEnum("c", data);
         assertEquals(data, p.enumData);
         assertNull(p.type);
+    }
+
+    @Test
+    void messageIsSentAsTheGrammarRootAndNotAsItsInnerNode() {
+        CommandParamData data = CommandParameter.newType("message", CommandParamType.MESSAGE).toNetwork();
+        assertEquals(CommandParam.MESSAGE_ROOT, data.getType());
+        assertNotEquals(CommandParam.MESSAGE, data.getType());
+    }
+
+    @Test
+    void otherTypesAreSentAsDeclared() {
+        assertEquals(CommandParam.SELECTION,
+                CommandParameter.newType("player", CommandParamType.SELECTION).toNetwork().getType());
+        assertEquals(CommandParam.ID,
+                CommandParameter.newType("duration", CommandParamType.ID).toNetwork().getType());
+        assertEquals(CommandParam.RAW_TEXT,
+                CommandParameter.newType("text", CommandParamType.RAW_TEXT).toNetwork().getType());
     }
 }


### PR DESCRIPTION
## What does this PR do?

In the title

No linked issue.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** `d71468a0f` (branch `fix/message-parameter-grammar-root`, one commit on top of upstream `7583f4f37`)

Automated only, so far:
- `./gradlew compileJava compileTestJava` passes
- `./gradlew test` on `d71468a0f`: **1021 tests, 0 failures, 0 errors**

- [ ] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [x] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

No API change. Behaviour change on the wire: a parameter declared as `MESSAGE` is now sent
as `MESSAGE_ROOT`. No config or save-format change.

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| Claude Opus 5 (Claude Code, autonomous agent) | Rebased my fork on `upstream/master`, split my pre-existing fixes into one branch per bug, removed my explanatory comments and Javadoc from the diff, translated my French commit messages into English, and ran the build and the test suite. It also wrote this checklist, the API-impact note above and this table.|

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [ ] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
