### PR TITLE
fix: only send soft enum updates to clients that were told about the enum

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -31,9 +31,12 @@ import org.cloudburstmc.protocol.bedrock.data.actor.ActorEvent;
 import org.cloudburstmc.protocol.bedrock.data.actor.ActorFlags;
 import org.cloudburstmc.protocol.bedrock.data.actor.PropertySyncData;
 import org.cloudburstmc.protocol.bedrock.data.command.CommandData;
+import org.cloudburstmc.protocol.bedrock.data.command.CommandEnumData;
 import org.cloudburstmc.protocol.bedrock.data.command.CommandOriginData;
 import org.cloudburstmc.protocol.bedrock.data.command.CommandOriginType;
 import org.cloudburstmc.protocol.bedrock.data.command.CommandOutputType;
+import org.cloudburstmc.protocol.bedrock.data.command.CommandOverloadData;
+import org.cloudburstmc.protocol.bedrock.data.command.CommandParamData;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerId;
 import org.cloudburstmc.protocol.bedrock.data.inventory.InventoryLayout;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
@@ -196,6 +199,7 @@ import java.util.*;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -434,6 +438,8 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
     protected EnumSet<ClientInputLockComponent> clientInputLocks = EnumSet.noneOf(ClientInputLockComponent.class);
 
     private final Map<Long, Runnable> ackRunnables = new HashMap<>();
+
+    private final Set<String> declaredSoftEnums = ConcurrentHashMap.newKeySet();
 
     @UsedByReflection
     public Player(@NotNull BedrockServerSession session, @NotNull PlayerInfo info) {
@@ -6902,8 +6908,29 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
 
                 pk.getCommands().addAll(commandData);
                 this.sendPacketImmediately(pk);
+                this.trackDeclaredSoftEnums(commandData);
             }
         }
+    }
+
+    private void trackDeclaredSoftEnums(List<CommandData> commandData) {
+        final Set<String> declared = new HashSet<>();
+        for (CommandData command : commandData) {
+            for (CommandOverloadData overload : command.getOverloads()) {
+                for (CommandParamData param : overload.getOverloads()) {
+                    CommandEnumData enumData = param.getEnumData();
+                    if (enumData != null && enumData.isSoft()) {
+                        declared.add(enumData.getName());
+                    }
+                }
+            }
+        }
+        this.declaredSoftEnums.retainAll(declared);
+        this.declaredSoftEnums.addAll(declared);
+    }
+
+    public boolean knowsSoftEnum(String name) {
+        return this.declaredSoftEnums.contains(name);
     }
 
     private @NotNull Map<String, CommandDataVersions> getStringCommandDataVersionsMap(Map<String, CommandDataVersions> data) {

--- a/src/main/java/org/powernukkitx/command/data/CommandEnum.java
+++ b/src/main/java/org/powernukkitx/command/data/CommandEnum.java
@@ -1,5 +1,6 @@
 package org.powernukkitx.command.data;
 
+import org.powernukkitx.Player;
 import org.powernukkitx.Server;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.registry.Registries;
@@ -7,6 +8,7 @@ import org.powernukkitx.utils.DefaultCameraPresets;
 import org.powernukkitx.utils.Identifier;
 import com.google.common.collect.ImmutableList;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.cloudburstmc.protocol.bedrock.data.camera.CameraPreset;
 import org.cloudburstmc.protocol.bedrock.data.command.CommandEnumConstraint;
 import org.cloudburstmc.protocol.bedrock.data.command.CommandEnumData;
@@ -193,9 +195,9 @@ public class CommandEnum {
     public void updateSoftEnum(SoftEnumUpdateType mode, String... value) {
         if (!this.soft) return;
         final UpdateSoftEnumPacket packet = new UpdateSoftEnumPacket();
-        packet.setSoftEnum(this.toNetwork());
+        packet.setSoftEnum(value.length == 0 ? this.toNetwork() : this.toNetwork(Arrays.asList(value)));
         packet.setUpdateType(mode);
-        Server.broadcastPacket(Server.getInstance().getOnlinePlayers().values(), packet);
+        Server.broadcastPacket(this.recipients(), packet);
     }
 
     /**
@@ -208,7 +210,17 @@ public class CommandEnum {
         final UpdateSoftEnumPacket packet = new UpdateSoftEnumPacket();
         packet.setSoftEnum(this.toNetwork());
         packet.setUpdateType(SoftEnumUpdateType.REPLACE);
-        Server.broadcastPacket(Server.getInstance().getOnlinePlayers().values(), packet);
+        Server.broadcastPacket(this.recipients(), packet);
+    }
+
+    private Collection<Player> recipients() {
+        final List<Player> recipients = new ObjectArrayList<>();
+        for (Player player : Server.getInstance().getOnlinePlayers().values()) {
+            if (player.knowsSoftEnum(this.name)) {
+                recipients.add(player);
+            }
+        }
+        return recipients;
     }
 
     /**
@@ -222,13 +234,17 @@ public class CommandEnum {
     }
 
     public CommandEnumData toNetwork() {
-        final Map<String, Set<CommandEnumConstraint>> values = new Object2ObjectOpenHashMap<>();
-        for (String value : this.getValues()) {
-            values.put(value, Collections.emptySet());
+        return this.toNetwork(this.getValues());
+    }
+
+    public CommandEnumData toNetwork(Collection<String> values) {
+        final Map<String, Set<CommandEnumConstraint>> networkValues = new Object2ObjectOpenHashMap<>();
+        for (String value : values) {
+            networkValues.put(value, Collections.emptySet());
         }
         return new CommandEnumData(
                 this.name,
-                values,
+                networkValues,
                 this.soft
         );
     }

--- a/src/test/java/org/powernukkitx/command/data/CommandEnumTest.java
+++ b/src/test/java/org/powernukkitx/command/data/CommandEnumTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -43,6 +44,15 @@ class CommandEnumTest {
     void hashCodeIsBasedOnName() {
         CommandEnum e = new CommandEnum("Same", "a");
         assertEquals("Same".hashCode(), e.hashCode());
+    }
+
+    @Test
+    void toNetworkCanCarryADeltaInsteadOfEveryValue() {
+        CommandEnum e = new CommandEnum("Colors", Arrays.asList("red", "green"), true);
+        var data = e.toNetwork(List.of("green"));
+        assertEquals("Colors", data.getName());
+        assertTrue(data.isSoft());
+        assertEquals(Set.of("green"), data.getValues().keySet());
     }
 
     @Test


### PR DESCRIPTION
## What does this PR do?

In the title

No linked issue.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** `c8f622961` (branch `fix/soft-enum-broadcast`, one commit on top of upstream `7583f4f37`)
- **Bedrock client version:** 26.44

Automated only, so far:
- `./gradlew compileJava compileTestJava` passes
- `./gradlew test` on `c8f622961`: **1020 tests, 0 failures, 0 errors**

- [ ] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [x] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

Adds `Player.knowsSoftEnum(String)` and a `CommandEnum.toNetwork(Collection<String>)` overload.
Behaviour change: `UpdateSoftEnumPacket` is no longer broadcast to every online player, only
to those the enum was declared to, and ADD/REMOVE now carry the named values instead of the
whole enum. No config or save-format change.

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| Claude Opus 5 (Claude Code, autonomous agent) | Rebased my fork on `upstream/master`, split my pre-existing fixes into one branch per bug, removed my explanatory comments and Javadoc from the diff, translated my French commit messages into English, and ran the build and the test suite. It also wrote this checklist, the API-impact note above and this table. |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [ ] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [ ] Public API additions/changes have Javadoc <!-- not done: this branch adds public methods without Javadoc -->
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
