### PR TITLE
fix: do not throw from getPing on a closed session

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -3001,13 +3001,16 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
     /**
      * Get the network latency of the player.
      *
-     * @return long
+     * @return the latency in milliseconds, or -1 if the connection can no longer be measured
      */
     public long getPing() {
         var rakServerChannel = (RakServerChannel) this.session.getPeer().getChannel().parent();
         var childChannel = rakServerChannel.getChildChannel(getSocketAddress());
+        if (childChannel == null) {
+            return -1;
+        }
         var rakSessionCodec = childChannel.rakPipeline().get(RakSessionCodec.class);
-        return rakSessionCodec.getPing();
+        return rakSessionCodec == null ? -1 : rakSessionCodec.getPing();
     }
 
     public boolean sleepOn(Vector3 pos) {


### PR DESCRIPTION
## What does this PR do?

In the title

No linked issue.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** `ab8db9770` (branch `fix/get-ping-closed-session`, one commit on top of upstream `7583f4f37`)
- **Bedrock client version:** 26.44

Automated only, so far:
- `./gradlew compileJava compileTestJava` passes
- `./gradlew test` on `ab8db9770`: **1019 tests, 0 failures, 0 errors**

- [ ] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

  No unit test added: the behaviour needs a live client or a generated world to observe, which the test fixture does not provide.

## Breaking changes / API impact

`Player.getPing()` now returns `-1` when the connection can no longer be measured instead of
throwing a `NullPointerException`. Callers that relied on the throw would need updating, but
the Javadoc `@return` is updated to state the sentinel.

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| Claude Opus 5 (Claude Code, autonomous agent) | Rebased my fork on `upstream/master`, split my pre-existing fixes into one branch per bug, removed my explanatory comments and Javadoc from the diff, translated my French commit messages into English, and ran the build and the test suite. |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [ ] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
