### PR TITLE
fix: keep chunk delivery and movement consistent across a teleport

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -229,6 +229,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
     public static final int PERMISSION_VISITOR = 0;
     private static final byte PLAYER_FLAG_SLEEP = 0x2;
     private static final long POST_TELEPORT_GRACE_MS = 1000L;
+    private static final double TELEPORT_ACK_DISTANCE = 2;
     /// static fields
     public boolean playedBefore;
     public boolean spawned = false;
@@ -417,6 +418,8 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
 
     // TODO: hack for receive a error position after teleport
     private Pair<Location, Long> lastTeleportMessage;
+    private Location teleportOrigin;
+    private boolean awaitingTeleportAck;
 
     private Color locatorBarColor;
     private final @NotNull PlayerInfo info;
@@ -1199,21 +1202,32 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
             return;
         }
 
-        long now = System.currentTimeMillis();
-
-        if (lastTeleportMessage != null && now - lastTeleportMessage.right() < POST_TELEPORT_GRACE_MS) {
-            Location teleportDestination = lastTeleportMessage.left();
-            double destinationDistance = newPosition.distance(teleportDestination);
-
-            if (destinationDistance > movementDistanceThreshold) {
+        if (this.awaitingTeleportAck) {
+            if (!acknowledgesTeleport(newPosition)) {
                 return;
             }
+            this.awaitingTeleportAck = false;
         }
 
         this.newPosition = newPosition;
         if (!this.clientMovements.offer(newPosition)) {
             log.warn("Failed to enqueue movement task for player {} at position {}", this.getName(), newPosition);
         }
+    }
+
+    private boolean acknowledgesTeleport(Location clientPosition) {
+        final Pair<Location, Long> teleport = this.lastTeleportMessage;
+        if (teleport == null
+            || System.currentTimeMillis() - teleport.right() >= POST_TELEPORT_GRACE_MS) {
+            return true;
+        }
+
+        final Location destination = teleport.left();
+        final Location origin = this.teleportOrigin;
+        if (origin != null && origin.getLevel() == destination.getLevel()) {
+            return clientPosition.distanceSquared(destination) <= clientPosition.distanceSquared(origin);
+        }
+        return clientPosition.distanceSquared(destination) <= TELEPORT_ACK_DISTANCE * TELEPORT_ACK_DISTANCE;
     }
 
 
@@ -2886,10 +2900,13 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
             return;
         }
 
-        this.chunkLoadCount++;
         synchronized (playerChunkManager) {
-            this.playerChunkManager.getUsedChunks().add(Level.chunkHash(x, z));
+            if (!this.playerChunkManager.isSentChunk(Level.chunkHash(x, z))) {
+                return;
+            }
         }
+
+        this.chunkLoadCount++;
         this.sendPacket(packet);
 
         if (this.spawned && this.level.getProvider() != null) {
@@ -5255,6 +5272,8 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
                 to.clone(),
                 System.currentTimeMillis()
         );
+        this.teleportOrigin = from.clone();
+        this.awaitingTeleportAck = true;
 
         //remove inventory, ride,sign editor
         for (Inventory window : new ArrayList<>(this.windows.keySet())) {
@@ -5281,7 +5300,11 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
 
         clientMovements.clear();
         //switch level, update pos and rotation, update aabb
-        if (setPositionAndRotation(to, to.getYaw(), to.getPitch(), to.getHeadYaw())) {
+        final boolean moved = setPositionAndRotation(to, to.getYaw(), to.getPitch(), to.getHeadYaw());
+        if (switchLevel) {
+            refreshChunkRender();
+        }
+        if (moved) {
             //if switch level or the distance teleported is too far
             if (switchLevel) {
                 this.playerChunkManager.handleTeleport();
@@ -5297,18 +5320,23 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
                 this.sendPosition(to, to.yaw, to.pitch, PositionMode.TELEPORT);
             }
             this.newPosition = to;
+            this.lastX = this.x;
+            this.lastY = this.y;
+            this.lastZ = this.z;
+            this.lastYaw = this.yaw;
+            this.lastPitch = this.pitch;
+            this.lastHeadYaw = this.headYaw;
+            this.broadcastMovement(true);
         } else {
             if (sendToSelf) {
                 this.sendPosition(this, to.yaw, to.pitch, PositionMode.TELEPORT);
             }
             this.newPosition = this;
+            this.awaitingTeleportAck = false;
         }
         //state update
         this.positionChanged = true;
 
-        if (switchLevel) {
-            refreshChunkRender();
-        }
         this.resetFallDistance();
         //DummyBossBar
         this.getDummyBossBars().values().forEach(DummyBossBar::reshow);

--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -4759,15 +4759,6 @@ public class Level implements Metadatable {
         }
     }
 
-    private void sendChunk(int x, int z, long index, BedrockPacket packet) {
-        for (Player player : this.chunkSendQueue.get(index).values()) {
-            if (player.isConnected() && player.getPlayerChunkManager().isSentChunk(index)) {
-                player.sendChunk(x, z, packet);
-            }
-        }
-        this.chunkSendQueue.remove(index);
-    }
-
     public void subTick(GameLoop currentTick) {
         try {
             processChunkRequest();
@@ -4804,11 +4795,6 @@ public class Level implements Metadatable {
                     try {
                         for (Player player : playersToSend.values()) {
                             if (player.isConnected()) {
-                                final NetworkChunkPublisherUpdatePacket networkChunkPublisherUpdatePacket = new NetworkChunkPublisherUpdatePacket();
-                                networkChunkPublisherUpdatePacket.setNewPositionForView(player.asBlockVector3().toNetwork());
-                                networkChunkPublisherUpdatePacket.setNewRadiusForView(player.getViewDistance() << 4);
-                                player.sendPacketImmediately(networkChunkPublisherUpdatePacket);
-
                                 final LevelChunkPacket levelChunkPacket;
                                 levelChunkPacket = new LevelChunkPacket();
                                 levelChunkPacket.setChunkX(x);

--- a/src/main/java/org/powernukkitx/level/PlayerChunkManager.java
+++ b/src/main/java/org/powernukkitx/level/PlayerChunkManager.java
@@ -37,6 +37,8 @@ public final class PlayerChunkManager {
      */
     private static final long CHUNK_LOAD_TIMEOUT_MICROS = 10L;
 
+    private static final int CHUNK_VISITS_PER_SEND = 4;
+
     private static final double MIN_FOV_CHECK_DISTANCE_SQUARED = MIN_FOV_CHECK_DISTANCE * MIN_FOV_CHECK_DISTANCE;
 
     private int comparatorLoaderChunkX;
@@ -120,11 +122,12 @@ public final class PlayerChunkManager {
         int loaderChunkZ = player.getChunkZ();
         updateInRadiusChunks(1, loaderChunkX, loaderChunkZ);
         removeOutOfRadiusChunks();
-        updateInRadiusChunks(8, loaderChunkX, loaderChunkZ);
+        updateInRadiusChunks(player.getViewDistance(), loaderChunkX, loaderChunkZ);
         pruneLoadingQueueOutOfRadius();
         pruneQueueOutOfRadius(chunkReadyToSend, true);
         updateChunkSendingQueue();
-        loadQueuedChunks(8, true);
+        sendViewPublisherUpdate();
+        loadQueuedChunks(trySendChunkCountPerTick, true);
         sendChunk();
     }
 
@@ -225,13 +228,15 @@ public final class PlayerChunkManager {
         }
     }
 
-    private void loadQueuedChunks(int trySendChunkCountPerTick, boolean force) {
+    private void loadQueuedChunks(int sendBudget, boolean force) {
         if (chunkSendQueue.isEmpty()) return;
-        int triedSendChunkCount = 0;
+        int readiedChunkCount = 0;
+        int visitedChunkCount = 0;
+        long visitLimit = (long) sendBudget * CHUNK_VISITS_PER_SEND;
         LongOpenHashSet enqueue = requeueScratch;
         enqueue.clear();
         do {
-            triedSendChunkCount++;
+            visitedChunkCount++;
             long chunkHash = chunkSendQueue.dequeueLong();
             int chunkX = Level.getHashX(chunkHash);
             int chunkZ = Level.getHashZ(chunkHash);
@@ -259,6 +264,7 @@ public final class PlayerChunkManager {
                     chunkLoadingQueue.remove(chunkHash);
                     player.level.registerChunkLoader(player, chunkX, chunkZ, false);
                     chunkReadyToSend.enqueue(chunkHash);
+                    readiedChunkCount++;
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     chunkLoadingQueue.remove(chunkHash);
@@ -276,16 +282,22 @@ public final class PlayerChunkManager {
             } else {
                 enqueue.add(chunkHash);
             }
-        } while (!chunkSendQueue.isEmpty() && triedSendChunkCount < trySendChunkCountPerTick);
+        } while (!chunkSendQueue.isEmpty()
+                && readiedChunkCount < sendBudget
+                && visitedChunkCount < visitLimit);
         enqueue.forEach(chunkSendQueue::enqueue);
+    }
+
+    private void sendViewPublisherUpdate() {
+        final NetworkChunkPublisherUpdatePacket packet = new NetworkChunkPublisherUpdatePacket();
+        packet.setNewPositionForView(Vector3i.from(player.getFloorX(), player.getFloorY(), player.getFloorZ()));
+        packet.setNewRadiusForView(player.getViewDistance() << 4);
+        player.sendPacket(packet);
     }
 
     private void sendChunk() {
         if (!chunkReadyToSend.isEmpty()) {
-            final NetworkChunkPublisherUpdatePacket packet = new NetworkChunkPublisherUpdatePacket();
-            packet.setNewPositionForView(Vector3i.from(player.getFloorX(), player.getFloorY(), player.getFloorZ()));
-            packet.setNewRadiusForView(player.getViewDistance() << 4);
-            player.sendPacket(packet);
+            sendViewPublisherUpdate();
             while (!chunkReadyToSend.isEmpty()) {
                 long chunkHash = chunkReadyToSend.dequeueLong();
                 if (!inRadiusChunks.contains(chunkHash)) {

--- a/src/test/java/org/powernukkitx/PlayerFixture.java
+++ b/src/test/java/org/powernukkitx/PlayerFixture.java
@@ -26,14 +26,22 @@ public final class PlayerFixture {
     private PlayerFixture() {
     }
 
+    public static synchronized TestPlayer get() {
+        if (player == null) {
+            player = create();
+        }
+        return player;
+    }
+
+    public static synchronized TestPlayer newPlayer() {
+        return create();
+    }
+
     // Cloudburst's IdentityData/IdentityClaims have package-private constructors and no
     // public factory, so reflection is the only way to build a test identity without a
     // real network login. This is intentional test-only scaffolding.
     @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
-    public static synchronized TestPlayer get() {
-        if (player != null) {
-            return player;
-        }
+    private static TestPlayer create() {
         ServerMockFixture.boot();
         try {
             Class<?> idDataClass = Class.forName("org.cloudburstmc.protocol.bedrock.util.ChainValidationResult$IdentityData");
@@ -59,11 +67,11 @@ public final class PlayerFixture {
             doNothing().when(session).sendPacket(any());
             doNothing().when(session).sendPacketImmediately(any());
 
-            player = new TestPlayer(session, info);
-            player.setLevel(ServerMockFixture.level);
+            TestPlayer created = new TestPlayer(session, info);
+            created.setLevel(ServerMockFixture.level);
             // Normally set by Entity#init, which the fixture player never goes through.
-            player.temporalVector = new Vector3();
-            return player;
+            created.temporalVector = new Vector3();
+            return created;
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }

--- a/src/test/java/org/powernukkitx/player/PlayerChunkSyncTest.java
+++ b/src/test/java/org/powernukkitx/player/PlayerChunkSyncTest.java
@@ -1,0 +1,160 @@
+package org.powernukkitx.player;
+
+import org.powernukkitx.PlayerFixture;
+import org.powernukkitx.ServerMockFixture;
+import org.powernukkitx.TestPlayer;
+import org.powernukkitx.event.player.PlayerTeleportEvent;
+import org.powernukkitx.level.ChunkLoader;
+import org.powernukkitx.level.DimensionEnum;
+import org.powernukkitx.level.Level;
+import org.powernukkitx.level.Location;
+import org.powernukkitx.level.format.IChunk;
+import org.powernukkitx.level.format.LevelConfig;
+import org.powernukkitx.level.format.leveldb.LevelDBProvider;
+import org.powernukkitx.math.Vector3;
+import org.powernukkitx.utils.GameLoop;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import org.apache.commons.io.FileUtils;
+import org.cloudburstmc.protocol.bedrock.packet.LevelChunkPacket;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.util.HashMap;
+
+class PlayerChunkSyncTest {
+
+    private static TestPlayer player;
+    private static Level homeLevel;
+    private static Level otherLevel;
+    private static File otherLevelDir;
+
+    @BeforeAll
+    static void boot() throws Exception {
+
+        player = PlayerFixture.newPlayer();
+        homeLevel = ServerMockFixture.level;
+
+        Mockito.doReturn(true).when(player.getSession()).isConnected();
+        player.loggedIn = true;
+        player.spawned = true;
+
+        player.temporalVector = new Vector3();
+
+        otherLevel = openSecondLevel();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (player != null) {
+            player.unloadAllUsedChunk();
+            Mockito.doReturn(false).when(player.getSession()).isConnected();
+        }
+        if (otherLevel != null) {
+            try {
+                otherLevel.close();
+            } catch (Throwable ignore) {
+            }
+            otherLevel = null;
+        }
+        if (otherLevelDir != null) {
+            FileUtils.deleteQuietly(otherLevelDir);
+            otherLevelDir = null;
+        }
+    }
+
+    @Test
+    void aChunkTheManagerStoppedTrackingIsNotRecordedAsReceived() {
+        player.setLevel(homeLevel);
+        player.setPosition(new Vector3(0.5, 80, 0.5));
+
+        int chunkX = player.getChunkX() + 64;
+        int chunkZ = player.getChunkZ() + 64;
+        long hash = Level.chunkHash(chunkX, chunkZ);
+        Assertions.assertFalse(player.getPlayerChunkManager().isSentChunk(hash));
+
+        player.sendChunk(chunkX, chunkZ, new LevelChunkPacket());
+
+        Assertions.assertFalse(player.getUsedChunks().contains(hash),
+                "a chunk the player is not registered as a loader for must not be marked as received");
+    }
+
+    @Test
+    void aCrossLevelTeleportLeavesEveryReceivedChunkRegistered() throws InterruptedException {
+
+        generateAround(otherLevel, player.getViewDistance() + 1);
+
+        player.setLevel(homeLevel);
+        player.setPosition(new Vector3(0.5, 80, 0.5));
+
+        Assertions.assertTrue(player.teleport(
+                new Location(0.5, 80, 0.5, otherLevel),
+                PlayerTeleportEvent.TeleportCause.PLUGIN));
+        Assertions.assertSame(otherLevel, player.getLevel());
+        Assertions.assertFalse(player.getUsedChunks().isEmpty(),
+                "the teleport should have sent the player chunks of the destination");
+        assertEveryReceivedChunkIsRegistered();
+
+        final GameLoop loop = GameLoop.builder().build();
+        for (int i = 0; i < 20; i++) {
+            otherLevel.subTick(loop);
+            assertEveryReceivedChunkIsRegistered();
+            player.getPlayerChunkManager().tick();
+            assertEveryReceivedChunkIsRegistered();
+        }
+    }
+
+    private static void assertEveryReceivedChunkIsRegistered() {
+        final Level level = player.getLevel();
+        final LongOpenHashSet received;
+        synchronized (player.getPlayerChunkManager()) {
+            received = new LongOpenHashSet(player.getPlayerChunkManager().getUsedChunks());
+        }
+        for (long hash : received) {
+            int chunkX = Level.getHashX(hash);
+            int chunkZ = Level.getHashZ(hash);
+            boolean registered = false;
+            for (ChunkLoader loader : level.getChunkLoaders(chunkX, chunkZ)) {
+                if (loader == player) {
+                    registered = true;
+                    break;
+                }
+            }
+            Assertions.assertTrue(registered, "chunk " + chunkX + ", " + chunkZ
+                    + " is marked as received but the player is not registered as a loader for it");
+        }
+    }
+
+    private static void generateAround(Level level, int radius) throws InterruptedException {
+        final long deadline = System.currentTimeMillis() + 60_000;
+        for (int chunkX = -radius; chunkX <= radius; chunkX++) {
+            for (int chunkZ = -radius; chunkZ <= radius; chunkZ++) {
+                IChunk chunk = level.getChunk(chunkX, chunkZ, true);
+                while (!chunk.getChunkState().canSend() || !chunk.isInitiated()) {
+                    Assertions.assertTrue(System.currentTimeMillis() < deadline,
+                            "timed out generating chunk " + chunkX + ", " + chunkZ);
+                    level.generateChunk(chunkX, chunkZ, true);
+                    Thread.sleep(5);
+                    chunk = level.getChunk(chunkX, chunkZ, true);
+                }
+            }
+        }
+    }
+
+    private static Level openSecondLevel() throws Exception {
+
+        String name = "chunk_sync_" + ProcessHandle.current().pid() + "_" + System.nanoTime();
+        otherLevelDir = new File("src/test/resources/" + name);
+        FileUtils.copyDirectory(new File("src/test/resources/level"), otherLevelDir);
+
+        Level level = new Level(ServerMockFixture.server, name, otherLevelDir.getPath(), 1,
+                LevelDBProvider.class,
+                new LevelConfig.GeneratorConfig("flat", 114514L, false, LevelConfig.AntiXrayMode.LOW,
+                        true, DimensionEnum.OVERWORLD.getDimensionData(), new HashMap<>()));
+        level.initLevel();
+        return level;
+    }
+}

--- a/src/test/java/org/powernukkitx/player/PlayerTeleportMovementTest.java
+++ b/src/test/java/org/powernukkitx/player/PlayerTeleportMovementTest.java
@@ -1,0 +1,76 @@
+package org.powernukkitx.player;
+
+import org.powernukkitx.PlayerFixture;
+import org.powernukkitx.TestPlayer;
+import org.powernukkitx.event.player.PlayerTeleportEvent;
+import org.powernukkitx.level.Level;
+import org.powernukkitx.level.Location;
+import org.powernukkitx.level.Position;
+import org.powernukkitx.math.Vector3;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class PlayerTeleportMovementTest {
+
+    private static final Vector3 ORIGIN = new Vector3(0.5, 80, 0.5);
+    private static final Vector3 DESTINATION = new Vector3(40.5, 80, 40.5);
+
+    static TestPlayer player;
+    static Level level;
+
+    @BeforeAll
+    static void boot() {
+
+        player = PlayerFixture.newPlayer();
+        level = player.getLevel();
+    }
+
+    @BeforeEach
+    void teleportAway() {
+        player.loggedIn = true;
+        player.spawned = true;
+        player.setHealth(20);
+
+        player.temporalVector = new Vector3();
+        player.setPosition(ORIGIN);
+
+        Assertions.assertTrue(player.teleport(
+                Location.fromObject(DESTINATION, level),
+                PlayerTeleportEvent.TeleportCause.ENDER_PEARL));
+    }
+
+    @Test
+    void movesSentBeforeTheTeleportWasAppliedAreDropped() {
+        player.offerMovementTask(Location.fromObject(ORIGIN.add(0.2, 0, 0), level));
+
+        assertNextPositionIs(DESTINATION);
+    }
+
+    @Test
+    void theFirstStepAfterLandingIsAcceptedImmediately() {
+        Vector3 afterLanding = DESTINATION.add(0.8, 0, 0);
+
+        player.offerMovementTask(Location.fromObject(afterLanding, level));
+
+        assertNextPositionIs(afterLanding);
+    }
+
+    @Test
+    void movementKeepsFlowingOnceTheTeleportIsConfirmed() {
+        player.offerMovementTask(Location.fromObject(DESTINATION.add(0.8, 0, 0), level));
+
+        Vector3 walkedOff = DESTINATION.add(6, 0, 0);
+        player.offerMovementTask(Location.fromObject(walkedOff, level));
+
+        assertNextPositionIs(walkedOff);
+    }
+
+    private static void assertNextPositionIs(Vector3 expected) {
+        Position next = player.getNextPosition();
+        Assertions.assertEquals(expected.getX(), next.getX(), 1e-6);
+        Assertions.assertEquals(expected.getY(), next.getY(), 1e-6);
+        Assertions.assertEquals(expected.getZ(), next.getZ(), 1e-6);
+    }
+}


### PR DESCRIPTION
> [!WARNING]
> **Draft - not ready for review, please do not spend time on it yet.**
> The description and the on-server test report below are deliberately empty: I write
> them myself, and I have not run this build on a server yet. The AI usage disclosure
> is filled in and accurate. Opening early only so the diff is visible.

## What does this PR do?

_Not written yet._

## Why?

_Not written yet._

No linked issue.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [x] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** `56fcc7797` (branch `fix/chunk-sync-on-teleport`, one commit on top of upstream `7583f4f37`)
- **Bedrock client version:** _not filled yet_
- **Plugins loaded:** _not filled yet_

**Steps performed and results:**

_Not written yet - no on-server test run for this branch yet._

Automated only, so far:
- `./gradlew compileJava compileTestJava` passes
- `./gradlew test` on `56fcc7797`: **1024 tests, 0 failures, 0 errors**

- [ ] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [x] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

Removes the private and unused `Level.sendChunk(int, int, long, BedrockPacket)`; nothing public
changes. Adds `PlayerFixture.newPlayer()` in the test sources. Behaviour change: post-teleport
client movement is filtered until the client confirms the teleport, rather than for a fixed
one second window.

## Performance notes

The chunk send budget now counts chunks actually delivered rather than chunks visited, and the
view publisher update is sent once per batch instead of once per chunk. Not benchmarked with
numbers; the per-chunk publisher packet it removes was one compressed out-of-band packet per
chunk per player.

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| Claude Opus 5 (Claude Code, autonomous agent) | Rebased my fork on `upstream/master`, split my pre-existing fixes into one branch per bug, removed my explanatory comments and Javadoc from the diff, translated my French commit messages into English, and ran the build and the test suite. It also wrote this checklist, the API-impact note above and this table. It did **not** write the "What / Why" sections or any test report - those are empty until I write them. |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [ ] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
