### PR TITLE
fix: do not leave invisible water in layer 1 when a block is broken

### DIFF
--- a/src/main/java/org/powernukkitx/block/BlockLiquid.java
+++ b/src/main/java/org/powernukkitx/block/BlockLiquid.java
@@ -225,22 +225,35 @@ public abstract class BlockLiquid extends BlockTransparent {
         return 1;
     }
 
+    public static boolean normalizeWaterloggedLayer(Level level, int x, int y, int z) {
+        if (!(level.getBlock(x, y, z, 1) instanceof BlockLiquid liquid)) {
+            return false;
+        }
+        Block layer0 = level.getBlock(x, y, z, 0);
+        if (layer0.isAir()) {
+            level.setBlock(x, y, z, 1, Block.get(BlockID.AIR), false, false);
+            level.setBlock(x, y, z, 0, liquid, false, false);
+            return true;
+        }
+        if (layer0.getWaterloggingLevel() <= 0
+                || layer0.getWaterloggingLevel() == 1 && liquid.getLiquidDepth() > 0) {
+            level.setBlockStateAt(x, y, z, 1, BlockAir.STATE);
+            return true;
+        }
+        return false;
+    }
+
     @Override
     public int onUpdate(int type) {
+        if (type == Level.BLOCK_UPDATE_NORMAL && layer > 0
+                && normalizeWaterloggedLayer(this.level, getFloorX(), getFloorY(), getFloorZ())) {
+            return 0;
+        }
         if (!this.level.getGameplaySettings().enableLiquidFlow()) {
             return 0;
         }
         if (type == Level.BLOCK_UPDATE_NORMAL) {//for normal update tick
             this.checkForMixing();
-            if (usesWaterLogging() && layer > 0) {
-                Block layer0 = this.level.getBlock(this, 0);
-                if (layer0.isAir()) {
-                    this.level.setBlock(this, 1, Block.get(BlockID.AIR), false, false);
-                    this.level.setBlock(this, 0, this, false, false);
-                } else if (layer0.getWaterloggingLevel() <= 0 || layer0.getWaterloggingLevel() == 1 && getLiquidDepth() > 0) {
-                    this.level.setBlockStateAt(getFloorX(), getFloorY(), getFloorZ(), 1, BlockAir.STATE);
-                }
-            }
             this.level.scheduleUpdate(this, this.tickRate());
             return 0;
         } else if (type == Level.BLOCK_UPDATE_SCHEDULED) {

--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -3277,6 +3277,11 @@ public class Level implements Metadatable {
 
         blockPrevious.afterRemoval(block, update);
 
+        if (layer == 0 && !(block instanceof BlockLiquid) && !(blockPrevious instanceof BlockLiquid)
+                && chunk.getBlockState(x & 0xF, y, z & 0xF, 1) != BlockAir.STATE) {
+            BlockLiquid.normalizeWaterloggedLayer(this, x, y, z);
+        }
+
         if (block instanceof CustomBlock customBlock) {
             CustomBlockDefinition def = customBlock.getDefinition();
             if (def != null && def.tickSettings() != null) {

--- a/src/test/java/org/powernukkitx/level/WaterloggedLayerTest.java
+++ b/src/test/java/org/powernukkitx/level/WaterloggedLayerTest.java
@@ -1,0 +1,85 @@
+package org.powernukkitx.level;
+
+import org.powernukkitx.ServerMockFixture;
+import org.powernukkitx.block.Block;
+import org.powernukkitx.block.BlockID;
+import org.powernukkitx.block.BlockLiquid;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class WaterloggedLayerTest {
+
+    static Level level;
+    static boolean liquidFlowBefore;
+
+    @BeforeAll
+    static void boot() {
+        ServerMockFixture.boot();
+        level = ServerMockFixture.level;
+        liquidFlowBefore = level.getGameplaySettings().enableLiquidFlow();
+        level.getGameplaySettings().enableLiquidFlow(false);
+    }
+
+    @AfterAll
+    static void restore() {
+        level.getGameplaySettings().enableLiquidFlow(liquidFlowBefore);
+    }
+
+    @Test
+    void orphanLiquidMovesBackToLayer0() {
+        int x = 1000, y = 70, z = 1000;
+        level.setBlock(x, y, z, 0, Block.get(BlockID.AIR), false, false);
+        level.setBlock(x, y, z, 1, Block.get(BlockID.WATER), false, false);
+
+        Assertions.assertTrue(BlockLiquid.normalizeWaterloggedLayer(level, x, y, z));
+        Assertions.assertInstanceOf(BlockLiquid.class, level.getBlock(x, y, z, 0));
+        Assertions.assertTrue(level.getBlock(x, y, z, 1).isAir());
+    }
+
+    @Test
+    void liquidUnderABlockThatCannotBeWaterloggedIsDropped() {
+        int x = 1002, y = 70, z = 1000;
+        level.setBlock(x, y, z, 0, Block.get(BlockID.STONE), false, false);
+        level.setBlock(x, y, z, 1, Block.get(BlockID.WATER), false, false);
+
+        Assertions.assertTrue(BlockLiquid.normalizeWaterloggedLayer(level, x, y, z));
+        Assertions.assertTrue(level.getBlock(x, y, z, 1).isAir());
+    }
+
+    @Test
+    void clearingLayer0WithoutBlockUpdatesCannotStrandTheLiquid() {
+        int x = 1004, y = 70, z = 1000;
+        level.setBlock(x, y, z, 0, Block.get(BlockID.STONE), false, false);
+        level.setBlock(x, y, z, 1, Block.get(BlockID.WATER), false, false);
+
+        level.setBlock(x, y, z, 0, Block.get(BlockID.AIR), false, false);
+
+        Assertions.assertInstanceOf(BlockLiquid.class, level.getBlock(x, y, z, 0));
+        Assertions.assertTrue(level.getBlock(x, y, z, 1).isAir());
+    }
+
+    @Test
+    void makingRoomForABlockAboutToBePlacedIsNotUndone() {
+        int x = 1006, y = 70, z = 1000;
+        level.setBlock(x, y, z, 0, Block.get(BlockID.WATER), false, false);
+        level.setBlock(x, y, z, 1, Block.get(BlockID.WATER), false, false);
+        level.setBlock(x, y, z, 0, Block.get(BlockID.AIR), false, false);
+
+        Assertions.assertInstanceOf(BlockLiquid.class, level.getBlock(x, y, z, 1));
+
+        level.setBlock(x, y, z, 0, Block.get(BlockID.OAK_SLAB), false, false);
+        Assertions.assertInstanceOf(BlockLiquid.class, level.getBlock(x, y, z, 1));
+    }
+
+    @Test
+    void legitimateWaterloggingIsLeftAlone() {
+        int x = 1026, y = 70, z = 1024;
+        level.setBlock(x, y, z, 0, Block.get(BlockID.OAK_FENCE), false, false);
+        level.setBlock(x, y, z, 1, Block.get(BlockID.WATER), false, false);
+
+        Assertions.assertFalse(BlockLiquid.normalizeWaterloggedLayer(level, x, y, z));
+        Assertions.assertInstanceOf(BlockLiquid.class, level.getBlock(x, y, z, 1));
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Break ice and the water is invisible after try remove

No linked issue.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** `a5325e257` (branch `fix/waterlogged-layer-left-behind`, one commit on top of upstream `7583f4f37`)
- **Bedrock client version:** 26.44

**Steps performed and results:**

_Not written yet - no on-server test run for this branch yet._

Automated only, so far:
- `./gradlew compileJava compileTestJava` passes
- `./gradlew test` on `a5325e257`: **1024 tests, 0 failures, 0 errors**

- [ ] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [x] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

Adds the static `BlockLiquid.normalizeWaterloggedLayer(Level, int, int, int)`.
Behaviour change: the layer 0 / layer 1 consistency check now also runs when `enableLiquidFlow`
is off, and from `Level.setBlock`. No config or save-format change.

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| Claude Opus 5 (Claude Code, autonomous agent) | Rebased my fork on `upstream/master`, split my pre-existing fixes into one branch per bug, removed my explanatory comments and Javadoc from the diff, translated my French commit messages into English, and ran the build and the test suite. |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [ ] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [ ] Public API additions/changes have Javadoc <!-- not done: this branch adds public methods without Javadoc -->
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
