### PR TITLE
fix: discard a vehicle that falls out of the world instead of killing it

### DIFF
--- a/src/main/java/org/powernukkitx/entity/item/EntityBoat.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityBoat.java
@@ -244,14 +244,8 @@ public class EntityBoat extends EntityVehicle {
             setRollingAmplitude(getRollingAmplitude() - 1);
         }
 
-        // A killer task
-        if (this.level != null) {
-            if (y < this.level.getMinHeight() - 16) {
-                kill();
-                return false;
-            }
-        } else if (y < -16) {
-            kill();
+        if (y < (this.level == null ? -16 : this.level.getMinHeight() - 16)) {
+            this.close();
             return false;
         }
 

--- a/src/main/java/org/powernukkitx/entity/item/EntityMinecartAbstract.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityMinecartAbstract.java
@@ -140,6 +140,10 @@ public abstract class EntityMinecartAbstract extends EntityVehicle {
         if (isAlive()) {
             super.onUpdate(currentTick);
 
+            if (this.closed) {
+                return false;
+            }
+
             // The damage token
             if (getHealthCurrent() < 20) {
                 setHealthCurrent(getHealthCurrent() + 1);

--- a/src/main/java/org/powernukkitx/entity/item/EntityVehicle.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityVehicle.java
@@ -86,13 +86,9 @@ public abstract class EntityVehicle extends Entity implements EntityInteractable
             setRollingAmplitude(getRollingAmplitude() - 1);
         }
 
-        // A killer task
-        if (this.level != null) {
-            if (y < this.level.getMinHeight() - 16) {
-                kill();
-            }
-        } else if (y < -16) {
-            kill();
+        if (y < (this.level == null ? -16 : this.level.getMinHeight() - 16)) {
+            this.close();
+            return false;
         }
         // Movement code
         updateMovement();


### PR DESCRIPTION
## What does this PR do?

In title

## Why?

_Not written yet._

No linked issue.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** `7703efb8c` (branch `fix/vehicle-void-drops`, one commit on top of upstream `7583f4f37`)
- **Bedrock client version:** 26.44

Automated only, so far:
- `./gradlew compileJava compileTestJava` passes
- `./gradlew test` on `7703efb8c`: **1019 tests, 0 failures, 0 errors**

- [ ] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

  No unit test added: the behaviour needs a live client or a generated world to observe, which the test fixture does not provide.

## Breaking changes / API impact

None. Behaviour change: a vehicle falling out of the world is discarded instead of killed, so
it no longer drops its contents.

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| Claude Opus 5 (Claude Code, autonomous agent) | Rebased my fork on `upstream/master`, split my pre-existing fixes into one branch per bug, removed my explanatory comments and Javadoc from the diff, translated my French commit messages into English, and ran the build and the test suite. |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [ ] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
