### PR TITLE
fix: only advertise command aliases that still route to the command

### DIFF
--- a/src/main/java/org/powernukkitx/command/Command.java
+++ b/src/main/java/org/powernukkitx/command/Command.java
@@ -188,12 +188,18 @@ public abstract class Command {
         NukkitCommandData customData = this.commandData.clone();
 
         if (getAliases().length > 0) {
-            List<String> aliases = new ArrayList<>(Arrays.asList(getAliases()));
-            if (!aliases.contains(this.name)) {
+            final CommandMap commandMap = player.getServer().getCommandMap();
+            List<String> aliases = new ArrayList<>();
+            for (String alias : getAliases()) {
+                if (commandMap.getCommand(alias) == this) {
+                    aliases.add(alias);
+                }
+            }
+            if (!aliases.contains(this.name) && commandMap.getCommand(this.name) == this) {
                 aliases.add(this.name);
             }
 
-            customData.aliases = new CommandEnum(this.name + "Aliases", aliases);
+            customData.aliases = aliases.isEmpty() ? null : new CommandEnum(this.name + "Aliases", aliases);
         }
 
         if (plugin == InternalPlugin.INSTANCE) {


### PR DESCRIPTION
> [!WARNING]
> **Draft - not ready for review, please do not spend time on it yet.**
> The description and the on-server test report below are deliberately empty: I write
> them myself, and I have not run this build on a server yet. The AI usage disclosure
> is filled in and accurate. Opening early only so the diff is visible.

## What does this PR do?

_Not written yet._

## Why?

_Not written yet._

No linked issue.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** `844e3f081` (branch `fix/stale-command-aliases`, one commit on top of upstream `7583f4f37`)
- **Bedrock client version:** _not filled yet_
- **Plugins loaded:** _not filled yet_

**Steps performed and results:**

_Not written yet - no on-server test run for this branch yet._

Automated only, so far:
- `./gradlew compileJava compileTestJava` passes
- `./gradlew test` on `844e3f081`: **1019 tests, 0 failures, 0 errors**

- [ ] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

  No unit test added: the behaviour needs a live client or a generated world to observe, which the test fixture does not provide.

## Breaking changes / API impact

None. Behaviour change: `AvailableCommandsPacket` no longer advertises aliases that the command
map does not route to the command, and attaches no alias enum when none is left.

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| Claude Opus 5 (Claude Code, autonomous agent) | Rebased my fork on `upstream/master`, split my pre-existing fixes into one branch per bug, removed my explanatory comments and Javadoc from the diff, translated my French commit messages into English, and ran the build and the test suite. It also wrote this checklist, the API-impact note above and this table. It did **not** write the "What / Why" sections or any test report - those are empty until I write them. |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [ ] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
