### PR TITLE
fix: send command permission and exception messages as plain text

### DIFF
--- a/src/main/java/org/powernukkitx/command/Command.java
+++ b/src/main/java/org/powernukkitx/command/Command.java
@@ -302,7 +302,7 @@ public abstract class Command {
         }
 
         if (this.permissionMessage == null) {
-            target.sendMessage(new TranslationContainer(TextFormat.RED + "%commands.generic.unknown", this.name));
+            target.sendMessage(TextFormat.RED + target.getServer().getLanguage().tr("commands.generic.unknown", this.name));
         } else if (!this.permissionMessage.isEmpty()) {
             target.sendMessage(this.permissionMessage.replace("<permission>", this.permission));
         }

--- a/src/main/java/org/powernukkitx/command/SimpleCommandMap.java
+++ b/src/main/java/org/powernukkitx/command/SimpleCommandMap.java
@@ -13,7 +13,6 @@ import org.powernukkitx.command.simple.SimpleCommand;
 import org.powernukkitx.command.utils.CommandLogger;
 
 import org.powernukkitx.lang.CommandOutputContainer;
-import org.powernukkitx.lang.TranslationContainer;
 
 import org.powernukkitx.plugin.InternalPlugin;
 
@@ -469,7 +468,7 @@ public class SimpleCommandMap implements CommandMap {
             }
         } catch (Exception e) {
             log.error(this.server.getLanguage().tr("nukkit.command.exception", cmdLine, target.toString(), Utils.getExceptionMessage(e)), e);
-            sender.sendMessage(new TranslationContainer(TextFormat.RED + "%commands.generic.exception"));
+            sender.sendMessage(TextFormat.RED + this.server.getLanguage().tr("commands.generic.exception"));
             output = 0;
         }
 


### PR DESCRIPTION
## What does this PR do?

In title

No linked issue.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** `1ccb1fafa` (branch `fix/command-permission-message`, one commit on top of upstream `7583f4f37`)
- **Bedrock client version:** 26.44

Automated only, so far:
- `./gradlew compileJava compileTestJava` passes
- `./gradlew test` on `1ccb1fafa`: **1019 tests, 0 failures, 0 errors**

- [ ] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

  No unit test added: the behaviour needs a live client or a generated world to observe, which the test fixture does not provide.

## Breaking changes / API impact

None. Behaviour change: the permission-denied and command-exception messages are sent as
resolved text instead of a `TranslationContainer`.

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| Claude Opus 5 (Claude Code, autonomous agent) | Rebased my fork on `upstream/master`, split my pre-existing fixes into one branch per bug, removed my explanatory comments and Javadoc from the diff, translated my French commit messages into English, and ran the build and the test suite. |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [ ] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
