### PR TITLE
fix: honour allow-nether and allow-the-end when loading levels

### DIFF
--- a/src/main/java/org/powernukkitx/Server.java
+++ b/src/main/java/org/powernukkitx/Server.java
@@ -2683,6 +2683,27 @@ public class Server {
         return levelConfig;
     }
 
+    private Map<Integer, LevelConfig.GeneratorConfig> enabledGenerators(LevelConfig levelConfig) {
+        final Map<Integer, LevelConfig.GeneratorConfig> generators = levelConfig.generators();
+        if ((this.allowNether && this.allowTheEnd) || generators == null || generators.isEmpty()) {
+            return generators;
+        }
+
+        final Map<Integer, LevelConfig.GeneratorConfig> enabled = new LinkedHashMap<>(generators);
+        if (!this.allowNether) {
+            enabled.remove(Level.DIMENSION_NETHER);
+        }
+        if (!this.allowTheEnd) {
+            enabled.remove(Level.DIMENSION_THE_END);
+        }
+
+        if (enabled.isEmpty()) {
+            log.warn("Every dimension of this level is disabled by allow-nether/allow-the-end, loading it unchanged");
+            return generators;
+        }
+        return enabled;
+    }
+
     /**
      * Loads the selected level by its folder name
      *
@@ -2707,7 +2728,7 @@ public class Server {
             provider = LevelProviderManager.getProviderFactoryByName(levelConfig.format());
         }
 
-        Map<Integer, LevelConfig.GeneratorConfig> generators = levelConfig.generators();
+        Map<Integer, LevelConfig.GeneratorConfig> generators = enabledGenerators(levelConfig);
         for (var entry : generators.entrySet()) {
             String levelName = levelFolderName
                 + (generators.size() > 1 ? entry.getValue().dimensionData().getSuffix() : "");
@@ -2782,7 +2803,8 @@ public class Server {
             log.error("Could not load level " + name, new LevelException("Level config is not a valid"));
             return false;
         }
-        for (var entry : levelConfig.generators().entrySet()) {
+        Map<Integer, LevelConfig.GeneratorConfig> generators = enabledGenerators(levelConfig);
+        for (var entry : generators.entrySet()) {
             LevelConfig.GeneratorConfig generatorConfig = entry.getValue();
             var provider = LevelProviderManager.getProviderFactoryByName(levelConfig.format());
             if (provider == null) {
@@ -2794,12 +2816,12 @@ public class Server {
             try {
                 provider.generate(path, name, generatorConfig);
                 String levelName = name
-                    + (levelConfig.generators().size() > 1 ? entry.getValue().dimensionData().getSuffix() : "");
+                    + (generators.size() > 1 ? entry.getValue().dimensionData().getSuffix() : "");
                 if (this.isLevelLoaded(levelName)) {
                     log.warn("level {} has already been loaded!", levelName);
                     continue;
                 }
-                level = new Level(this, levelName, path, levelConfig.generators().size(), provider, generatorConfig);
+                level = new Level(this, levelName, path, generators.size(), provider, generatorConfig);
 
                 this.getLevels().put(level.getId(), level);
                 level.initLevel();


### PR DESCRIPTION
## What does this PR do?

No load world nether and end, if is disable.

## Why?

_Not written yet._

No linked issue.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** `10baaa57e` (branch `fix/dimension-toggles-ignored`, one commit on top of upstream `7583f4f37`)
- **Bedrock client version:** 26.44
- **Plugins loaded:** no

Automated only, so far:
- `./gradlew compileJava compileTestJava` passes
- `./gradlew test` on `10baaa57e`: **1019 tests, 0 failures, 0 errors**

- [ ] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

  No unit test added: the behaviour needs a live client or a generated world to observe, which the test fixture does not provide.

## Breaking changes / API impact

None. Behaviour change: `allow-nether` and `allow-the-end` are now honoured, so a server that
had them set to false stops loading and generating those levels. `config.json` on disk is left
untouched, so flipping the setting back restores them.

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| Claude Opus 5 (Claude Code, autonomous agent) | Rebased my fork on `upstream/master`, split my pre-existing fixes into one branch per bug, removed my explanatory comments and Javadoc from the diff, translated my French commit messages into English, and ran the build and the test suite.|

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [ ] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
