### PR TITLE
feat: fire PacketReceiveEvent for login phase packets

### DIFF
--- a/src/main/java/org/powernukkitx/event/server/PacketReceiveEvent.java
+++ b/src/main/java/org/powernukkitx/event/server/PacketReceiveEvent.java
@@ -4,9 +4,12 @@ import org.powernukkitx.Player;
 import org.powernukkitx.event.Cancellable;
 import org.powernukkitx.event.HandlerList;
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
+import org.jetbrains.annotations.Nullable;
 
 /**
- * Called for every packet that is sent by the client once the player has been created at the end of the resource pack sequence.
+ * Called for every packet that is sent by the client, including the packets exchanged during the login and
+ * resource pack sequence. The player is only available once it has been created at the end of that sequence,
+ * so {@link #getPlayer()} returns null for the earlier packets.
  */
 public class PacketReceiveEvent extends ServerEvent implements Cancellable {
 
@@ -19,7 +22,7 @@ public class PacketReceiveEvent extends ServerEvent implements Cancellable {
     private final BedrockPacket packet;
     private final Player player;
 
-    public PacketReceiveEvent(Player player, BedrockPacket packet) {
+    public PacketReceiveEvent(@Nullable Player player, BedrockPacket packet) {
         this.packet = packet;
         this.player = player;
     }
@@ -28,6 +31,10 @@ public class PacketReceiveEvent extends ServerEvent implements Cancellable {
         return packet;
     }
 
+    /**
+     * @return the player the packet was received from, or null when it has not been created yet
+     */
+    @Nullable
     public Player getPlayer() {
         return player;
     }

--- a/src/main/java/org/powernukkitx/network/process/NetworkPacketHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/NetworkPacketHandler.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacketHandler;
 import org.cloudburstmc.protocol.common.PacketSignal;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * @author Kaooot
@@ -34,7 +35,7 @@ public class NetworkPacketHandler implements BedrockPacketHandler {
             return PacketSignal.HANDLED;
         }
 
-        if (player != null && firePacketReceive(player, packet)) {
+        if (firePacketReceive(player, packet)) {
             return PacketSignal.UNHANDLED;
         }
         if (packetHandler != null) {
@@ -63,7 +64,7 @@ public class NetworkPacketHandler implements BedrockPacketHandler {
         packetHandler.handle(packet, this.session, this.server);
     }
 
-    private boolean firePacketReceive(Player player, BedrockPacket packet) {
+    private boolean firePacketReceive(@Nullable Player player, BedrockPacket packet) {
         if (PacketReceiveEvent.getHandlers().isEmpty()) {
             return false;
         }


### PR DESCRIPTION
<!--
  Read CONTRIBUTING.md before submitting:
  https://github.com/PowerNukkitX/PowerNukkitX/blob/master/CONTRIBUTING.md

  PRs that leave this template unfilled, or fill it with generated filler,
  are closed without review. Delete the HTML comments as you go.

  SECURITY: never report a vulnerability in a public PR. See SECURITY.md.
-->

## What does this PR do?

This PR allows PacketReceiveEvent to be usable for login phase packets.

## Why?

Because using some of packets in login phase could be useful for developers.

## Type of change

<!-- Tick what applies. -->

- [ ] Bug Fix
- [x] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** Non-related
- **Bedrock client version:** 1.26.44.3
- **Plugins loaded:** None

**Steps performed and results:**

1. Joined the game
2. Logged the login phase packets
3. Left the game

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

No AI used.

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
