### PR TITLE
perf: skip event allocation when no handlers are registered

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -1022,22 +1022,26 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
                 return;
             }
 
-            PlayerMoveEvent.Type moveType;
+            PlayerMoveEvent ev = null;
 
-            if (positionChanged && rotationChanged) {
-                moveType = PlayerMoveEvent.Type.ALL;
-            } else if (positionChanged) {
-                moveType = PlayerMoveEvent.Type.POSITION_CHANGE;
-            } else {
-                moveType = PlayerMoveEvent.Type.ROTATE;
+            if (!PlayerMoveEvent.getHandlers().isEmpty()) {
+                PlayerMoveEvent.Type moveType;
+
+                if (positionChanged && rotationChanged) {
+                    moveType = PlayerMoveEvent.Type.ALL;
+                } else if (positionChanged) {
+                    moveType = PlayerMoveEvent.Type.POSITION_CHANGE;
+                } else {
+                    moveType = PlayerMoveEvent.Type.ROTATE;
+                }
+
+                ev = new PlayerMoveEvent(this, last, now, true, moveType);
+
+                this.server.getPluginManager().callEvent(ev);
             }
 
-            PlayerMoveEvent ev = new PlayerMoveEvent(this, last, now, true, moveType);
-
-            this.server.getPluginManager().callEvent(ev);
-
-            if (!(invalidMotion = ev.isCancelled())) { //Yes, this is intended
-                if (!now.equals(ev.getTo()) && this.riding == null) { //If plugins modify the destination
+            if (!(invalidMotion = ev != null && ev.isCancelled())) { //Yes, this is intended
+                if (ev != null && !now.equals(ev.getTo()) && this.riding == null) { //If plugins modify the destination
                     if (this.getGamemode() != Player.SPECTATOR)
                         this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, ev.getTo().clone(), VibrationType.TELEPORT));
                     this.teleport(ev.getTo(), null);

--- a/src/main/java/org/powernukkitx/entity/Entity.java
+++ b/src/main/java/org/powernukkitx/entity/Entity.java
@@ -5658,7 +5658,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
      * @return boolean
      */
     public boolean setMotion(Vector3 motion) {
-        if (!this.justCreated) {
+        if (!this.justCreated && !EntityMotionEvent.getHandlers().isEmpty()) {
             EntityMotionEvent ev = new EntityMotionEvent(this, motion);
             this.server.getPluginManager().callEvent(ev);
             if (ev.isCancelled()) {

--- a/src/main/java/org/powernukkitx/entity/item/EntityBoat.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityBoat.java
@@ -296,7 +296,9 @@ public class EntityBoat extends EntityVehicle {
                 }
             }
         }
-        this.getServer().getPluginManager().callEvent(new VehicleUpdateEvent(this));
+        if (!VehicleUpdateEvent.getHandlers().isEmpty()) {
+            this.getServer().getPluginManager().callEvent(new VehicleUpdateEvent(this));
+        }
 
         return hasUpdated;
     }
@@ -335,16 +337,19 @@ public class EntityBoat extends EntityVehicle {
     private void moveBoat() {
         checkObstruction(this.x, this.y, this.z);
 
-        Location from = new Location(lastX, lastY, lastZ, lastYaw, lastPitch, level);
+        boolean fireMoveEvent = !VehicleMoveEvent.getHandlers().isEmpty();
+        Location from = fireMoveEvent ? new Location(lastX, lastY, lastZ, lastYaw, lastPitch, level) : null;
 
         if(passengers.isEmpty()) {
             move(this.motionX, this.motionY, this.motionZ);
         }
 
-        Location to = new Location(this.x, this.y, this.z, this.yaw, this.pitch, level);
+        if (fireMoveEvent) {
+            Location to = new Location(this.x, this.y, this.z, this.yaw, this.pitch, level);
 
-        if (!from.equals(to)) {
-            this.getServer().getPluginManager().callEvent(new VehicleMoveEvent(this, from, to));
+            if (!from.equals(to)) {
+                this.getServer().getPluginManager().callEvent(new VehicleMoveEvent(this, from, to));
+            }
         }
     }
 

--- a/src/main/java/org/powernukkitx/entity/item/EntityMinecartAbstract.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityMinecartAbstract.java
@@ -211,12 +211,15 @@ public abstract class EntityMinecartAbstract extends EntityVehicle {
 
             setRotation(yawToChange, pitch);
 
-            Location from = new Location(lastX, lastY, lastZ, lastYaw, lastPitch, level);
-            Location to = new Location(this.x, this.y, this.z, this.yaw, this.pitch, level);
+            boolean fireMoveEvent = !VehicleMoveEvent.getHandlers().isEmpty();
+            Location from = fireMoveEvent ? new Location(lastX, lastY, lastZ, lastYaw, lastPitch, level) : null;
+            Location to = fireMoveEvent ? new Location(this.x, this.y, this.z, this.yaw, this.pitch, level) : null;
 
-            this.getServer().getPluginManager().callEvent(new VehicleUpdateEvent(this));
+            if (!VehicleUpdateEvent.getHandlers().isEmpty()) {
+                this.getServer().getPluginManager().callEvent(new VehicleUpdateEvent(this));
+            }
 
-            if (!from.equals(to)) {
+            if (fireMoveEvent && !from.equals(to)) {
                 this.getServer().getPluginManager().callEvent(new VehicleMoveEvent(this, from, to));
             }
 

--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -1498,10 +1498,14 @@ public class Level implements Metadatable {
 
                 // Only tick if the chunk is in use, helps to keep block ticks in sync when reload chunk
                 if (isChunkInUse(hash)) {
-                    BlockUpdateEvent event = new BlockUpdateEvent(block);
-                    this.server.getPluginManager().callEvent(event);
+                    boolean cancelled = false;
+                    if (!BlockUpdateEvent.getHandlers().isEmpty()) {
+                        BlockUpdateEvent event = new BlockUpdateEvent(block);
+                        this.server.getPluginManager().callEvent(event);
+                        cancelled = event.isCancelled();
+                    }
 
-                    if (!event.isCancelled()) {
+                    if (!cancelled) {
                         block.onUpdate(BLOCK_UPDATE_NORMAL);
                         if (queuedUpdate.neighbor != null) {
                             block.onNeighborChange(queuedUpdate.neighbor.getOpposite());
@@ -3226,8 +3230,9 @@ public class Level implements Metadatable {
         blockPrevious.level = this;
         blockPrevious.layer = layer;
 
-        BlockChangeEvent blockChangeEvent = new BlockChangeEvent(block, blockPrevious);
-        this.server.getPluginManager().callEvent(blockChangeEvent);
+        if (!BlockChangeEvent.getHandlers().isEmpty()) {
+            this.server.getPluginManager().callEvent(new BlockChangeEvent(block, blockPrevious));
+        }
 
         if (layer == 0) {
             this.villageManager.onBlockChange(blockPrevious, block);
@@ -3255,16 +3260,21 @@ public class Level implements Metadatable {
                 updateAllLight(block);
             }
 
-            BlockUpdateEvent ev = new BlockUpdateEvent(block);
-            this.server.getPluginManager().callEvent(ev);
-            if (!ev.isCancelled()) {
+            BlockUpdateEvent ev = null;
+            if (!BlockUpdateEvent.getHandlers().isEmpty()) {
+                ev = new BlockUpdateEvent(block);
+                this.server.getPluginManager().callEvent(ev);
+            }
+            if (ev == null || !ev.isCancelled()) {
                 if (!this.entities.isEmpty()) {
                     for (Entity entity : this.fastNearbyEntities(new SimpleAxisAlignedBB(x - 1, y - 1, z - 1, x + 1, y + 1, z + 1))) {
                         entity.scheduleUpdate();
                     }
                 }
 
-                block = ev.getBlock();
+                if (ev != null) {
+                    block = ev.getBlock();
+                }
                 block.onUpdate(BLOCK_UPDATE_NORMAL);
                 block.getLevelBlockAtLayer(layer == 0 ? 1 : 0).onUpdate(BLOCK_UPDATE_NORMAL);
                 this.updateAround(x, y, z);

--- a/src/main/java/org/powernukkitx/network/process/handler/MoveActorAbsoluteHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/MoveActorAbsoluteHandler.java
@@ -47,11 +47,14 @@ public class MoveActorAbsoluteHandler implements PacketHandler<MoveActorAbsolute
             return;
         }
 
-        Location from = movedEntity.getLocation();
+        boolean fireMoveEvent = !VehicleMoveEvent.getHandlers().isEmpty();
+        Location from = fireMoveEvent ? movedEntity.getLocation() : null;
         movedEntity.setPositionAndRotation(player.temporalVector, rot.getZ(), 0);
-        Location to = movedEntity.getLocation();
-        if (!from.equals(to)) {
-            player.getServer().getPluginManager().callEvent(new VehicleMoveEvent(player, from, to));
+        if (fireMoveEvent) {
+            Location to = movedEntity.getLocation();
+            if (!from.equals(to)) {
+                player.getServer().getPluginManager().callEvent(new VehicleMoveEvent(player, from, to));
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
  Read CONTRIBUTING.md before submitting:
  https://github.com/PowerNukkitX/PowerNukkitX/blob/master/CONTRIBUTING.md

  PRs that leave this template unfilled, or fill it with generated filler,
  are closed without review. Delete the HTML comments as you go.

  SECURITY: never report a vulnerability in a public PR. See SECURITY.md.
-->

## What does this PR do?

This PR skips event allocation when no handlers are registered

## Why?

Performance improvements

## Type of change

<!-- Tick what applies. -->

- [ ] Bug Fix
- [ ] New Feature
- [x] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** Non-related
- **Bedrock client version:** 1.26.44.3
- **Plugins loaded:** None

**Steps performed and results:**

1. Joined the game
2. Tested the events
3. Left the game

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
| Claude Opus 5      | Found the allocated events            |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled