### PR TITLE
fix: Patch custom craft with custom item result

### DIFF
--- a/src/main/java/org/powernukkitx/item/Item.java
+++ b/src/main/java/org/powernukkitx/item/Item.java
@@ -2714,17 +2714,7 @@ public abstract class Item implements Cloneable, ItemID {
     }
 
     public ItemData toRecipeNetwork() {
-        final CompoundTag nbt = this.getNbt();
-        final ItemData itemData;
-
-        if (nbt == null || !nbt.contains("Damage") || nbt.getInt("Damage") != 0) {
-            itemData = this.toNetwork();
-        } else {
-            final Item stripped = this.clone();
-            final CompoundTag strippedNbt = nbt.copy().remove("Damage");
-            stripped.setNbt(strippedNbt.isEmpty() ? null : strippedNbt);
-            itemData = stripped.toNetwork();
-        }
+        final ItemData itemData = this.stripZeroDamageTag().toNetwork();
 
         return itemData.toBuilder()
                 .blockDefinition(
@@ -2742,20 +2732,32 @@ public abstract class Item implements Cloneable, ItemID {
     }
 
     public ItemData toCreativeNetwork() {
-        final boolean hasNbt = this.getNbt() != null;
-        final boolean clearCreativeTag = this.isCreativeTagEmpty();
+        final Item item = this.stripZeroDamageTag();
+        final boolean hasNbt = item.getNbt() != null;
+        final boolean clearCreativeTag = item.isCreativeTagEmpty();
 
         return ItemData.builder()
-                .definition(this.getItemDefinition())
-                .damage(this.getDamage())
-                .count(this.getCount())
-                .tag(clearCreativeTag || this.getNbt() == null ? null : this.getNbt().toNetwork())
-                .canPlace(!hasNbt || clearCreativeTag ? new String[0] : listTagToStringArray(this.getCanPlaceOn()))
-                .canBreak(!hasNbt || clearCreativeTag ? new String[0] : listTagToStringArray(this.getCanDestroy()))
-                .blockDefinition(new RuntimeBlockDefinition(this.isCreativeBlockDefinitionEmpty() ? 0 : this.getNetworkBlockRuntimeId()))
+                .definition(item.getItemDefinition())
+                .damage(item.getDamage())
+                .count(item.getCount())
+                .tag(clearCreativeTag || item.getNbt() == null ? null : item.getNbt().toNetwork())
+                .canPlace(!hasNbt || clearCreativeTag ? new String[0] : listTagToStringArray(item.getCanPlaceOn()))
+                .canBreak(!hasNbt || clearCreativeTag ? new String[0] : listTagToStringArray(item.getCanDestroy()))
+                .blockDefinition(new RuntimeBlockDefinition(item.isCreativeBlockDefinitionEmpty() ? 0 : item.getNetworkBlockRuntimeId()))
                 .usingNetId(false)
                 .netId(0)
                 .build();
+    }
+
+    private Item stripZeroDamageTag() {
+        final CompoundTag nbt = this.getNbt();
+        if (nbt == null || !nbt.contains("Damage") || nbt.getInt("Damage") != 0) {
+            return this;
+        }
+        final Item stripped = this.clone();
+        final CompoundTag strippedNbt = nbt.copy().remove("Damage");
+        stripped.setNbt(strippedNbt.isEmpty() ? null : strippedNbt);
+        return stripped;
     }
 
     private int getNetworkBlockRuntimeId() {

--- a/src/main/java/org/powernukkitx/registry/CreativeItemRegistry.java
+++ b/src/main/java/org/powernukkitx/registry/CreativeItemRegistry.java
@@ -9,6 +9,7 @@ import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import lombok.extern.slf4j.Slf4j;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtUtils;
+import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.bedrock.data.payload.creative.CreativeGroupInfoPayload;
 import org.cloudburstmc.protocol.bedrock.data.payload.creative.CreativeItemCategory;
 import org.cloudburstmc.protocol.bedrock.data.payload.creative.CreativeItemEntryPayload;
@@ -311,9 +312,20 @@ public class CreativeItemRegistry implements ItemID, IRegistry<Integer, Item, It
         }
         final CreativeItemEntryPayload entryPayload = new CreativeItemEntryPayload();
         entryPayload.setCreativeNetId(new CreativeItemNetId(MAP.isEmpty() ? 0 : MAP.lastIntKey()));
-        entryPayload.setItemInstance(value.toNetwork());
+        entryPayload.setItemInstance(toCreativeItemData(value));
         entryPayload.setGroupIndex(groupIndex);
         ITEM_DATA.add(entryPayload);
+    }
+
+    private static ItemData toCreativeItemData(Item value) {
+        final CompoundTag nbt = value.getNbt();
+        if (nbt != null && nbt.contains("Damage") && nbt.getInt("Damage") == 0) {
+            final Item pristine = value.clone();
+            final CompoundTag stripped = nbt.copy().remove("Damage");
+            pristine.setNbt(stripped.isEmpty() ? null : stripped);
+            return pristine.toNetwork();
+        }
+        return value.toNetwork();
     }
 
     @Override
@@ -325,7 +337,7 @@ public class CreativeItemRegistry implements ItemID, IRegistry<Integer, Item, It
         } else {
             final CreativeItemEntryPayload entryPayload = new CreativeItemEntryPayload();
             entryPayload.setCreativeNetId(new CreativeItemNetId(MAP.isEmpty() ? 0 : MAP.lastIntKey()));
-            entryPayload.setItemInstance(value.toNetwork());
+            entryPayload.setItemInstance(toCreativeItemData(value));
             entryPayload.setGroupIndex(CreativeItemRegistry.LAST_ITEMS_INDEX);
             ITEM_DATA.add(entryPayload);
         }

--- a/src/main/java/org/powernukkitx/registry/CreativeItemRegistry.java
+++ b/src/main/java/org/powernukkitx/registry/CreativeItemRegistry.java
@@ -9,7 +9,6 @@ import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import lombok.extern.slf4j.Slf4j;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtUtils;
-import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.bedrock.data.payload.creative.CreativeGroupInfoPayload;
 import org.cloudburstmc.protocol.bedrock.data.payload.creative.CreativeItemCategory;
 import org.cloudburstmc.protocol.bedrock.data.payload.creative.CreativeItemEntryPayload;
@@ -312,20 +311,9 @@ public class CreativeItemRegistry implements ItemID, IRegistry<Integer, Item, It
         }
         final CreativeItemEntryPayload entryPayload = new CreativeItemEntryPayload();
         entryPayload.setCreativeNetId(new CreativeItemNetId(MAP.isEmpty() ? 0 : MAP.lastIntKey()));
-        entryPayload.setItemInstance(toCreativeItemData(value));
+        entryPayload.setItemInstance(value.toCreativeNetwork());
         entryPayload.setGroupIndex(groupIndex);
         ITEM_DATA.add(entryPayload);
-    }
-
-    private static ItemData toCreativeItemData(Item value) {
-        final CompoundTag nbt = value.getNbt();
-        if (nbt != null && nbt.contains("Damage") && nbt.getInt("Damage") == 0) {
-            final Item pristine = value.clone();
-            final CompoundTag stripped = nbt.copy().remove("Damage");
-            pristine.setNbt(stripped.isEmpty() ? null : stripped);
-            return pristine.toNetwork();
-        }
-        return value.toNetwork();
     }
 
     @Override
@@ -337,7 +325,7 @@ public class CreativeItemRegistry implements ItemID, IRegistry<Integer, Item, It
         } else {
             final CreativeItemEntryPayload entryPayload = new CreativeItemEntryPayload();
             entryPayload.setCreativeNetId(new CreativeItemNetId(MAP.isEmpty() ? 0 : MAP.lastIntKey()));
-            entryPayload.setItemInstance(toCreativeItemData(value));
+            entryPayload.setItemInstance(value.toCreativeNetwork());
             entryPayload.setGroupIndex(CreativeItemRegistry.LAST_ITEMS_INDEX);
             ITEM_DATA.add(entryPayload);
         }


### PR DESCRIPTION
## What does this PR do?

my pr fixes custom items in craft results

## Why?

bugfix

## Type of change

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 35d0be78d
- **Bedrock client version:** 26.44
- **Plugins loaded:** custom plugin

**Steps performed and results:**

1. join a server with a recipe that gives a custom item as the result
2. check if the craft is shown in the preselection

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

no ai used

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
