### PR TITLE
fix: Enable projectile collisions with projectiles.

### DIFF
--- a/src/main/java/org/powernukkitx/entity/projectile/EntityProjectile.java
+++ b/src/main/java/org/powernukkitx/entity/projectile/EntityProjectile.java
@@ -169,7 +169,7 @@ public abstract class EntityProjectile extends Entity {
 
     @Override
     public boolean canCollideWith(Entity entity) {
-        return (entity instanceof EntityLiving || entity instanceof EntityEnderCrystal || entity instanceof EntityMinecartAbstract || entity instanceof EntityBoat) && !this.onGround;
+        return (entity instanceof EntityLiving || entity instanceof EntityProjectile || entity instanceof EntityEnderCrystal || entity instanceof EntityMinecartAbstract || entity instanceof EntityBoat) && !this.onGround;
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?

It fix that the projectiles doesn't got collisions with other projectiles.

## Why?

This matches vanilla Minecraft behavior.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** <!-- commit hash -->
- **Bedrock client version:** 26.40
- **Plugins loaded:** none

**Steps performed and results:**

1. Launched a ender pearl.
2. Then launched a wind charge on it.
3. The wind charge exploded and enderpearl teleported me.

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [x] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|       |             |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
