### PR TITLE
fix: stop queueing packets for a player whose session is gone

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -1194,6 +1194,16 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         this.pendingClose = reason;
     }
 
+    private boolean closeIfRequested() {
+        final String closeReason = this.pendingClose;
+        if (closeReason == null) {
+            return false;
+        }
+        this.pendingClose = null;
+        this.close(closeReason);
+        return true;
+    }
+
     /**
      * Offers a new movement task to the player, considering distance and rotation thresholds.
      * Also handles the special case where an erroneous position may be received right after teleportation.
@@ -2992,6 +3002,11 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
      * @param packet packet to send
      */
     public void sendPacket(BedrockPacket packet) {
+        // Deliberately the session's flag and not isConnected(): close() clears the player's own
+        // flag on entry and still sends packets while it tears the player down.
+        if (!this.session.isConnected()) {
+            return;
+        }
         final PacketSendEvent event = new PacketSendEvent(this, packet);
         this.server.getPluginManager().callEvent(event);
         if (event.isCancelled()) {
@@ -3446,6 +3461,9 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
 
         if (!this.isAlive() && this.spawned) {
             this.drainInboundPackets();
+            if (this.closeIfRequested()) {
+                return true;
+            }
             if (this.isAlive()) {
                 return true;
             }
@@ -3470,10 +3488,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
                 return true;
             }
 
-            if (this.pendingClose != null) {
-                final String closeReason = this.pendingClose;
-                this.pendingClose = null;
-                this.close(closeReason);
+            if (this.closeIfRequested()) {
                 return true;
             }
 

--- a/src/main/java/org/powernukkitx/network/process/PlayerSessionHolder.java
+++ b/src/main/java/org/powernukkitx/network/process/PlayerSessionHolder.java
@@ -457,6 +457,9 @@ public class PlayerSessionHolder {
             this.player.setInboundProcessor(networkPacketHandler::processInbound);
         }
         Server.getInstance().onPlayerLogin((InetSocketAddress) this.session.getSocketAddress(), player);
+        if (!this.player.isConnected()) {
+            return;
+        }
         this.playerHandle.processLogin();
     }
 


### PR DESCRIPTION
A closed session never drains its send queue - BedrockPeer.onTick returns on the closed flag - and that queue is unbounded. Every packet still handed to a player whose connection is already gone therefore stays in memory until the server stops, and one player left behind in a busy world collects every broadcast aimed at it: three of them held 5.7 million packets between them. sendPacket now drops a packet aimed at a session that is no longer connected, as sendPacketImmediately already does. The test is on the session alone rather than on isConnected(), because close() clears the connected flag on entry and still has packets to send while it tears the player down.

Two paths left such a player behind. The network thread can only ask for a close by setting pendingClose, and onUpdate read it from inside the branch that handles a spawned, living player. A player who lost the connection while dead took the branch above it, which always returns, so the close never happened: the player stayed in Level.players with a dead peer for the rest of the server's life. The check now runs before anything that can return early.

PlayerSessionHolder.doPlayerCreation went on to processLogin even when Server.onPlayerLogin had cancelled the login, closed the player and taken it out of the server lists. processLogin ends in Entity.init, which puts the player back into Level.players, and nothing takes it out again because close() cannot run a second time.

It's a bug of RAM.