### PR TITLE
feat: add ChunkTickEvent

### DIFF
--- a/src/main/java/org/powernukkitx/event/level/ChunkTickEvent.java
+++ b/src/main/java/org/powernukkitx/event/level/ChunkTickEvent.java
@@ -1,0 +1,28 @@
+package org.powernukkitx.event.level;
+
+import lombok.Getter;
+import org.powernukkitx.event.Cancellable;
+import org.powernukkitx.event.HandlerList;
+import org.powernukkitx.level.Level;
+import org.powernukkitx.level.format.IChunk;
+
+@Getter
+public class ChunkTickEvent extends LevelEvent implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    public static HandlerList getHandlers() {
+        return handlers;
+    }
+
+    private final long index;
+
+    public ChunkTickEvent(Level level, long index) {
+        super(level);
+        this.index = index;
+    }
+
+    public IChunk getChunk() {
+        return getLevel().getChunk(Level.getHashX(index), Level.getHashZ(index));
+    }
+}

--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -14,6 +14,7 @@ import org.powernukkitx.block.property.CommonBlockProperties;
 import org.powernukkitx.blockentity.BlockEntity;
 import org.powernukkitx.blockentity.BlockEntitySpawnable;
 import org.powernukkitx.config.category.GameplaySettings;
+import org.powernukkitx.event.level.ChunkTickEvent;
 import org.powernukkitx.level.tickingarea.TickingArea;
 import org.powernukkitx.level.tickingarea.manager.TickingAreaManager;
 import org.powernukkitx.entity.Entity;
@@ -2176,6 +2177,11 @@ public class Level implements Metadatable {
      * runs first to reject them before the four-lookup neighbour check.
      */
     private void addResolvedTickChunk(long index, List<IChunk> resolved) {
+        if (!ChunkTickEvent.getHandlers().isEmpty()) {
+            ChunkTickEvent event = new ChunkTickEvent(this, index);
+            getServer().getPluginManager().callEvent(event);
+            if (event.isCancelled()) return;
+        }
         IChunk chunk = this.getChunk(getHashX(index), getHashZ(index), false);
         if (chunk == null) {
             return;


### PR DESCRIPTION
## What does this PR do?

Adds ChunkTickEvent

## Why?

You cannot cancel chunks from being ticked / loaded by ticking

## Type of change

- [ ] Bug Fix
- [x] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

Tested with plugin. (Cancelling event)
And without cancelling

- [x] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

No AI used

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [ ] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
