### PR TITLE
fix: use player rotation for packet rotation

### DIFF
--- a/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
@@ -48,7 +48,7 @@ public class PlayerAuthInputHandler implements PacketHandler<PlayerAuthInputPack
         }
 
         Vector3f pos = Vector3f.fromNetwork(packet.getPosition());
-        Vector3f rot = Vector3f.fromNetwork(packet.getPosition());
+        Vector3f rot = Vector3f.fromNetwork(packet.getPlayerRotation());
         if (!Float.isFinite(pos.getX()) || !Float.isFinite(pos.getY()) || !Float.isFinite(pos.getZ()) || !Float.isFinite(rot.getX()) || !Float.isFinite(rot.getY()) || !Float.isFinite(rot.getZ())) {
             log.debug("Player {} sent invalid movement values (NaN or Infinite)", player.getName());
             return;


### PR DESCRIPTION
## What does this PR do?

bugfix

## Why?

bugfix

## Type of change

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** a521145
- **Bedrock client version:** 26.44
- **Plugins loaded:** none

**Steps performed and results:**

1. join server

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
|       |             |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
