### PR TITLE
feat(Player): add `command executing` to `chat(String message)`.

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -3715,6 +3715,11 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
             message = TextFormat.clean(message, true);
         }
 
+        if (message.startsWith("/")) {
+            Server.getInstance().executeCommand(this, message);
+            return true;
+        }
+
         for (String msg : message.split("\n")) {
             if (!msg.trim().isEmpty() && msg.length() <= 512 && this.messageLimitCounter-- > 0) {
                 PlayerChatEvent chatEvent = new PlayerChatEvent(this, msg);


### PR DESCRIPTION
## What does this PR do?

The documentation of this method states that it will treat messages which start with a '/' as commands, but it doesn't. This commit aims to implement the required handling.

## Why?

This PR was created because of a wrong documentation.

Closes #

## Type of change

- [ ] Bug Fix
- [X] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** git-3fd0d14
- **Bedrock client version:** e.g. 1.21.44
- **Plugins loaded:** a private plugin/ core

**Steps performed and results:**

1. Did `Player.chat("adksdajflkasd")` -> Wrote "adksdajflkasd" in the chat.
2. Did `Player.chat("/test")`-> Executed the command `/test`

- [X] I built the server and ran it with this change
- [] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [X] Existing unit tests pass (`gradlew test`)
- [] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
