### PR TITLE
fix: handle empty descriptors in auto crafting

### DIFF
--- a/src/main/java/org/powernukkitx/inventory/request/CraftRecipeAutoProcessor.java
+++ b/src/main/java/org/powernukkitx/inventory/request/CraftRecipeAutoProcessor.java
@@ -2,6 +2,7 @@ package org.powernukkitx.inventory.request;
 
 import lombok.extern.slf4j.Slf4j;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
+import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.EmptyDescriptor;
 import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.ItemDescriptor;
 import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.ItemTagDescriptor;
 import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.NameDescriptor;
@@ -16,7 +17,6 @@ import org.powernukkitx.event.inventory.CraftItemEvent;
 import org.powernukkitx.inventory.CreativeOutputInventory;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.recipe.UserDataShapelessRecipe;
-import org.powernukkitx.recipe.descriptor.InvalidDescriptor;
 import org.powernukkitx.registry.Registries;
 import org.powernukkitx.tags.ItemTags;
 
@@ -58,7 +58,7 @@ public class CraftRecipeAutoProcessor implements ItemStackRequestActionProcessor
                     match = this.match(serverExpect, tagDescriptor, clientInputItem);
                 } else if (serverExpect.getDescriptor() instanceof NameDescriptor descriptor) {
                     match = this.match(serverExpect, descriptor, clientInputItem);
-                } else if (serverExpect.getDescriptor() instanceof InvalidDescriptor) {
+                } else if (serverExpect.getDescriptor() instanceof EmptyDescriptor) {
                     match = clientInputItem.equals(Item.AIR);
                 }
                 if (match) {


### PR DESCRIPTION
## What does this PR do?

Replacing the incorrect "InvalidDescriptor" with the network descriptor "EmptyDescriptor".

## Why?

Because "InvalidDescriptor" become "EmptyDescriptor" here: https://github.com/PowerNukkitX/PowerNukkitX/blob/beta/src/main/java/org/powernukkitx/recipe/descriptor/InvalidDescriptor.java#L37

Closes #

## Type of change

<!-- Tick what applies. -->

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** git-c71abad
- **Bedrock client version:** 26.40
- **Plugins loaded:**

**Steps performed and results:**


- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [x] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes


N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|       |             |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
