### PR TITLE
fix: fast craft on a recipe

### DIFF
--- a/src/main/java/org/powernukkitx/inventory/request/CraftRecipeAutoProcessor.java
+++ b/src/main/java/org/powernukkitx/inventory/request/CraftRecipeAutoProcessor.java
@@ -2,6 +2,7 @@ package org.powernukkitx.inventory.request;
 
 import lombok.extern.slf4j.Slf4j;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
+import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.EmptyDescriptor;
 import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.ItemDescriptor;
 import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.ItemTagDescriptor;
 import org.cloudburstmc.protocol.bedrock.data.inventory.descriptor.NameDescriptor;
@@ -16,7 +17,6 @@ import org.powernukkitx.event.inventory.CraftItemEvent;
 import org.powernukkitx.inventory.CreativeOutputInventory;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.recipe.UserDataShapelessRecipe;
-import org.powernukkitx.recipe.descriptor.InvalidDescriptor;
 import org.powernukkitx.registry.Registries;
 import org.powernukkitx.tags.ItemTags;
 
@@ -58,7 +58,7 @@ public class CraftRecipeAutoProcessor implements ItemStackRequestActionProcessor
                     match = this.match(serverExpect, tagDescriptor, clientInputItem);
                 } else if (serverExpect.getDescriptor() instanceof NameDescriptor descriptor) {
                     match = this.match(serverExpect, descriptor, clientInputItem);
-                } else if (serverExpect.getDescriptor() instanceof InvalidDescriptor) {
+                } else if (serverExpect.getDescriptor() instanceof EmptyDescriptor) {
                     match = clientInputItem.equals(Item.AIR);
                 }
                 if (match) {
@@ -126,6 +126,7 @@ public class CraftRecipeAutoProcessor implements ItemStackRequestActionProcessor
             final ItemData itemData = ItemData.builder()
                 .definition(defaultDescriptor.getItemId())
                 .damage(defaultDescriptor.getAuxValue())
+                .count(Math.max(descriptorWithCount.getStackSize(), 1))
                 .build();
             return Item.fromNetwork(itemData).equals(item, true, false);
         }


### PR DESCRIPTION
## What does this PR do?

fix an issue where shift-clicking on a recipe to the left of a crafting table

## Why?

bugfix

## Type of change

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 90d5fbc
- **Bedrock client version:** Latest
- **Plugins loaded:** none

**Steps performed and results:**

1. join a server
2. and fast craft an item

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|       |             |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
