### PR TITLE
fix: add gamemode check to CREATIVE_DESTROY_BLOCK handler

### DIFF
--- a/src/main/java/org/powernukkitx/network/process/handler/PlayerActionHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/PlayerActionHandler.java
@@ -42,6 +42,7 @@ public class PlayerActionHandler implements PacketHandler<PlayerActionPacket> {
         switch (packet.getAction()) {
             case PlayerActionType.CREATIVE_DESTROY_BLOCK -> {
                 // Used by client to get book from lecterns and items from item frame in creative mode since 1.20.70
+                if (!player.isCreative()) return;
                 Block blockLectern = playerHandle.player.getLevel().getBlock(pos);
                 if (blockLectern instanceof BlockLectern blockLecternI && blockLectern.distance(playerHandle.player) <= 6) {
                     blockLecternI.dropBook(playerHandle.player);


### PR DESCRIPTION
## What does this PR do?

Adding a server-side gamemode check to a CREATIVE packet action..

## Why?

To prevent modified client to abuse.

Closes #

## Type of change

<!-- Tick what applies. -->

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** <!-- commit hash -->
- **Bedrock client version:** 26.44
- **Plugins loaded:** 

**Steps performed and results:**

1.
2.

- [ ] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

No AI used.

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
