### PR TITLE
fix: craft banner shield

### DIFF
--- a/src/main/java/org/powernukkitx/inventory/request/CraftRecipeActionProcessor.java
+++ b/src/main/java/org/powernukkitx/inventory/request/CraftRecipeActionProcessor.java
@@ -10,6 +10,8 @@ import org.powernukkitx.inventory.InputInventory;
 import org.powernukkitx.inventory.Inventory;
 import org.powernukkitx.inventory.SmithingInventory;
 import org.powernukkitx.item.Item;
+import org.powernukkitx.item.ItemBanner;
+import org.powernukkitx.item.ItemShield;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.item.enchantment.EnchantmentHelper;
 import org.powernukkitx.nbt.tag.CompoundTag;
@@ -51,6 +53,33 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
     public static final String RECIPE_DATA_KEY = "recipe";
     public static final String ENCH_RECIPE_KEY = "ench_recipe";
     public static final String GRID_CONSUMED_KEY = "grid_consumed";
+    public static final String MULTI_RESULT_KEY = "multi_result";
+
+    private Item computeMultiRecipeResult(Item[][] data) {
+        ItemShield shield = null;
+        ItemBanner banner = null;
+        for (Item[] row : data) {
+            for (Item ingredient : row) {
+                if (ingredient == null || ingredient.isNull()) continue;
+                if (ingredient instanceof ItemShield s) {
+                    if (shield != null) return null;
+                    shield = s;
+                } else if (ingredient instanceof ItemBanner b) {
+                    if (banner != null) return null;
+                    banner = b;
+                } else {
+                    return null;
+                }
+            }
+        }
+        if (shield != null && banner != null && !shield.hasBannerPattern()) {
+            ItemShield result = (ItemShield) shield.clone();
+            result.setCount(1);
+            result.setBannerPattern(banner);
+            return result;
+        }
+        return null;
+    }
 
     public boolean checkTrade(CompoundTag recipeInput, Item input, int subtract) {
         String id = input.getId();
@@ -229,6 +258,10 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
             return context.error();
         } else {
             Inventory craftInventory = (Inventory) craft;
+            Item multiResult = null;
+            if (recipe instanceof MultiRecipe && recipe.getResults().isEmpty()) {
+                multiResult = computeMultiRecipeResult(data);
+            }
             if (recipe instanceof ShapelessRecipe shapelessRecipe) {
                 if (!consumeShapelessRecipe(shapelessRecipe, craftInventory, numberOfRequestedCrafts)) {
                     return context.error();
@@ -246,6 +279,9 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
             player.getRecipeBook().unlock(recipe);
             if (recipe instanceof MultiRecipe && recipe.getResults().isEmpty()) {
                 context.put(RECIPE_DATA_KEY, recipe);
+                if (multiResult != null && !multiResult.isNull()) {
+                    context.put(MULTI_RESULT_KEY, multiResult);
+                }
             } else if (recipe.getResults().size() == 1) {
                 // If the recipe has a single output item, the client will not send a CreateAction; in this case, we will output the item directly to CREATED_OUTPUT in CraftRecipeAction
                 // If the recipe has multiple output items, the client will send a CreateAction; in this case, we will output the items to CREATED_OUTPUT within the CreateActionProcessor

--- a/src/main/java/org/powernukkitx/inventory/request/CraftResultDeprecatedActionProcessor.java
+++ b/src/main/java/org/powernukkitx/inventory/request/CraftResultDeprecatedActionProcessor.java
@@ -12,6 +12,7 @@ import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.recipe.Recipe;
 import org.powernukkitx.recipe.RecipeType;
 
+import static org.powernukkitx.inventory.request.CraftRecipeActionProcessor.MULTI_RESULT_KEY;
 import static org.powernukkitx.inventory.request.CraftRecipeActionProcessor.RECIPE_DATA_KEY;
 
 /**
@@ -31,9 +32,16 @@ public class CraftResultDeprecatedActionProcessor implements ItemStackRequestAct
     @Override
     public ActionResponse handle(CraftResultsDeprecatedAction action, Player player, ItemStackRequestContext context) {
         if (context.has(RECIPE_DATA_KEY) && ((Recipe) context.get(RECIPE_DATA_KEY)).getType() == RecipeType.MULTI) {
-            if (action.getResultItemsDeprecated().length == 0) {
-                log.warn("Multi recipe result is missing!");
-                return context.error();
+            if (action.getResultItemsDeprecated() == null || action.getResultItemsDeprecated().length == 0) {
+                Item computed = context.has(MULTI_RESULT_KEY) ? ((Item) context.get(MULTI_RESULT_KEY)) : null;
+                if (computed == null || computed.isNull()) {
+                    log.warn("Multi recipe result is missing!");
+                    return context.error();
+                }
+                var createdOutput = player.getCreativeOutputInventory();
+                computed.autoAssignStackNetworkId();
+                createdOutput.setItem(0, computed, false);
+                return null;
             }
             Item resultItem = Item.fromNetwork(action.getResultItemsDeprecated()[0]);
             if (resultItem.isNull() || resultItem.getCount() <= 0 || resultItem.getCount() > resultItem.getMaxStackSize()) {

--- a/src/main/java/org/powernukkitx/item/ItemShield.java
+++ b/src/main/java/org/powernukkitx/item/ItemShield.java
@@ -62,8 +62,11 @@ public class ItemShield extends ItemTool {
         } else {
             tag = this.getNbt();
         }
-        for (var e : banner.getNbt().getEntrySet()) {
-            tag.put(e.getKey(), e.getValue());
+        CompoundTag bannerNbt = banner.getNbt();
+        if (bannerNbt != null) {
+            for (var e : bannerNbt.getEntrySet()) {
+                tag.put(e.getKey(), e.getValue());
+            }
         }
         tag.putInt("Base", banner.getBaseColor());
         this.setNbt(tag);


### PR DESCRIPTION
## What does this PR do?

Fix when you craft a banner + shield

## Why?

bugfix

## Type of change

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 5e8fbb2f2
- **Bedrock client version:** 26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. join the server
2. craft shield + banner

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|       |             |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
