### PR TITLE
fix: Align entity fall damage with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/Entity.java
+++ b/src/main/java/org/powernukkitx/entity/Entity.java
@@ -4779,7 +4779,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         return this.boundingBox;
     }
 
-    public void fall(float fallDistance) { //todo: check why @param fallDistance always less than the real distance
+    public void fall(float fallDistance) {
         if (this.hasEffect(EffectType.SLOW_FALLING)) {
             return;
         }
@@ -4799,7 +4799,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
             boolean rideable = this.isRideable();
             boolean isRideJumping = rideable && (this instanceof EntityPhysical ef) && ef.isRideJumping();
             float jumpReduction = this.canPowerJump() ? this.getRideJumpStrength() : 0f;
-            float damage = fallDistance - 3.255f - jumpBoost - jumpReduction;
+            float damage = (float) Math.ceil(fallDistance - 3f - jumpBoost - jumpReduction);
 
             if (damage > 0) {
                 if (!this.isSneaking()) {


### PR DESCRIPTION


## What does this PR do?

It: align fall damage with vanilla

## Why?

match vanilla behaviour

Closes #

## Type of change

<!-- Tick what applies. -->

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?


- **Server build tested:** 0370a9d85
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. joined
2. falled

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [x] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure


- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
