### PR TITLE
fix(player): align movement exhaustion with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -973,9 +973,9 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         if (this.firstMove) this.firstMove = false;
         boolean invalidMotion = false;
         var revertPos = this.getLocation().clone();
-        double distance = clientPos.distanceSquared(this);
+        double distanceSquared = clientPos.distanceSquared(this);
         //before check
-        if (isCheckingMovement() && distance > 128) {
+        if (isCheckingMovement() && distanceSquared > 128) {
             invalidMotion = true;
         } else if (this.chunk == null || !chunk.getChunkState().canSend()) {
             IChunk chunk = this.level.getChunk(clientPos.getChunkX(), clientPos.getChunkZ(), false);
@@ -1077,7 +1077,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
             this.speed.setComponents(last.x - now.x, last.y - now.y, last.z - now.z);
         }
 
-        handleLogicInMove(invalidMotion, distance);
+        handleLogicInMove(invalidMotion, now.x - last.x, now.y - last.y, now.z - last.z);
 
         //if plugin cancels move
         if (invalidMotion) {
@@ -1085,7 +1085,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
             this.revertClientMotion(revertPos);
             this.resetClientMovement();
         } else {
-            if (distance != 0 && this.nextChunkOrderRun > 20) {
+            if (distanceSquared != 0 && this.nextChunkOrderRun > 20) {
                 this.nextChunkOrderRun = 20;
             }
         }
@@ -1228,30 +1228,31 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
     }
 
 
-    protected void handleLogicInMove(boolean invalidMotion, double distance) {
+    /**
+     * @deprecated Use the overload that receives each movement component so liquid movement can use its proper axis.
+     */
+    @Deprecated
+    protected void handleLogicInMove(boolean invalidMotion, double squaredDistance) {
+        handleLogicInMove(invalidMotion, Math.sqrt(Math.max(0.0, squaredDistance)), 0.0, 0.0);
+    }
+
+    protected void handleLogicInMove(boolean invalidMotion, double deltaX, double deltaY, double deltaZ) {
         if (!invalidMotion) {
             boolean recentlyTeleported = lastTeleportMessage != null
                     && System.currentTimeMillis() - lastTeleportMessage.right() < POST_TELEPORT_GRACE_MS;
             //Handling saturation updates
             if (this.getFoodData().isEnabled() && this.getServer().getDifficulty() > 0 && !recentlyTeleported) {
-                //UpdateFoodExpLevel
-                if (distance >= 0.05) {
-                    double jump = 0;
-                    double swimming = this.isInsideOfWater() ? 0.01 * distance : 0;
-                    double distance2 = distance;
-                    if (swimming != 0) distance2 = 0;
-                    if (this.isSprinting()) {  //Running
-                        if (this.inAirTicks == 3 && swimming == 0) {
-                            jump = 0.2;
-                        }
-                        this.getFoodData().exhaust(0.1 * distance2 + jump + swimming);
-                    } else {
-                        if (this.inAirTicks == 3 && swimming == 0) {
-                            jump = 0.05;
-                        }
-                        this.getFoodData().exhaust(jump + swimming);
-                    }
+                boolean underWater = this.isInsideOfWater();
+                boolean inWater = this.isTouchingWater();
+                double movement = calculateMovementExhaustion(
+                        deltaX, deltaY, deltaZ,
+                        underWater, inWater, this.isOnGround(), this.isSprinting(), this.riding != null
+                );
+                double jump = 0.0;
+                if (this.inAirTicks == 3 && !underWater) {
+                    jump = this.isSprinting() ? 0.2 : 0.05;
                 }
+                this.getFoodData().exhaust(movement + jump);
             }
 
             if (this.isOnGround()) {
@@ -1294,6 +1295,31 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
             }
 
         }
+    }
+
+    static double calculateMovementExhaustion(double deltaX, double deltaY, double deltaZ,
+                                              boolean underWater, boolean inWater, boolean onGround,
+                                              boolean sprinting, boolean riding) {
+        if (riding) {
+            return 0.0;
+        }
+
+        float x = (float) deltaX;
+        float y = (float) deltaY;
+        float z = (float) deltaZ;
+        int distance3Dcm = Math.round((float) Math.sqrt(x * x + y * y + z * z) * 100.0f);
+        int distanceXZcm = Math.round((float) Math.sqrt(x * x + z * z) * 100.0f);
+
+        if (underWater) {
+            return distance3Dcm > 0 ? distance3Dcm * 0.00015f : 0.0;
+        }
+        if (inWater) {
+            return distanceXZcm > 0 ? distanceXZcm * 0.00015f : 0.0;
+        }
+        if (onGround && distanceXZcm > 0) {
+            return distanceXZcm * (sprinting ? 0.001f : 0.0001f);
+        }
+        return 0.0;
     }
 
     protected void resetClientMovement() {

--- a/src/main/java/org/powernukkitx/PlayerHandle.java
+++ b/src/main/java/org/powernukkitx/PlayerHandle.java
@@ -323,6 +323,10 @@ public final class PlayerHandle {
         player.handleLogicInMove(invalidMotion, distance);
     }
 
+    public void handleLogicInMove(boolean invalidMotion, double deltaX, double deltaY, double deltaZ) {
+        player.handleLogicInMove(invalidMotion, deltaX, deltaY, deltaZ);
+    }
+
     public void resetClientMovement() {
         player.resetClientMovement();
     }

--- a/src/test/java/org/powernukkitx/PlayerMovementExhaustionTest.java
+++ b/src/test/java/org/powernukkitx/PlayerMovementExhaustionTest.java
@@ -1,0 +1,44 @@
+package org.powernukkitx;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PlayerMovementExhaustionTest {
+
+    private static final double EPSILON = 1.0e-7;
+
+    @Test
+    void usesLinearHorizontalDistanceOnGround() {
+        assertEquals(0.2, exhaustion(2.0, 0.0, 0.0, false, false, true, true, false), EPSILON);
+        assertEquals(0.05, exhaustion(0.5, 0.0, 0.0, false, false, true, true, false), EPSILON);
+        assertEquals(0.02, exhaustion(2.0, 0.0, 0.0, false, false, true, false, false), EPSILON);
+    }
+
+    @Test
+    void usesThreeDimensionalDistanceOnlyWhenSubmerged() {
+        assertEquals(0.03, exhaustion(0.0, 2.0, 0.0, true, true, false, false, false), EPSILON);
+        assertEquals(0.0, exhaustion(0.0, 2.0, 0.0, false, true, false, false, false), EPSILON);
+        assertEquals(0.03, exhaustion(2.0, 0.0, 0.0, false, true, false, false, false), EPSILON);
+    }
+
+    @Test
+    void roundsDistanceToCentimetresBeforeApplyingExhaustion() {
+        assertEquals(0.005, exhaustion(0.03, 0.0, 0.04, false, false, true, true, false), EPSILON);
+        assertEquals(0.0, exhaustion(0.004, 0.0, 0.0, false, false, true, true, false), EPSILON);
+    }
+
+    @Test
+    void ignoresAirborneAndVehicleMovement() {
+        assertEquals(0.0, exhaustion(2.0, 0.0, 0.0, false, false, false, true, false), EPSILON);
+        assertEquals(0.0, exhaustion(2.0, 0.0, 0.0, true, true, true, true, true), EPSILON);
+    }
+
+    private static double exhaustion(double deltaX, double deltaY, double deltaZ,
+                                     boolean underWater, boolean inWater, boolean onGround,
+                                     boolean sprinting, boolean riding) {
+        return Player.calculateMovementExhaustion(
+                deltaX, deltaY, deltaZ, underWater, inWater, onGround, sprinting, riding
+        );
+    }
+}


### PR DESCRIPTION


## What does this PR do?

It  align movement exhaustion with vanilla

## Why?

To match vanilla behavior.
Closes #

## Type of change

<!-- Tick what applies. -->

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?


- **Server build tested:** 895c3aba0
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

1.joined server
2. moved

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [x] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes


N/A

## AI usage disclosure



- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [ x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
