### PR TITLE
fix(block): correct dirt hardness

### DIFF
--- a/src/main/java/org/powernukkitx/block/BlockDirt.java
+++ b/src/main/java/org/powernukkitx/block/BlockDirt.java
@@ -41,8 +41,7 @@ public class BlockDirt extends BlockSolid implements Natural {
 
     @Override
     public double getHardness() {
-        //Although the hardness on the wiki is 0.5, after testing, a hardness of 0.6 is more suitable for the vanilla
-        return 0.6;
+        return 0.5;
     }
 
     @Override


### PR DESCRIPTION

## What does this PR do?

It replace 0.6 dirt hardness to 0.5
## Why?
Matches vanilla behaviour.
(i don't know why it got bumped to 0.6)
After checking many different software + minecraft wiki the correct hardness is 0.5.
Even when i checked in minecraft windows executable it's 0.5.

Closes #

## Type of change

<!-- Tick what applies. -->

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?


- **Server build tested:** <!-- commit hash -->
- **Bedrock client version:** 26.45
- **Plugins loaded:** <!-- none / list them -->

**Steps performed and results:**

1. joined
2. breaked dirt

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [x] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
