### PR TITLE
refact: Refact/change Entity getId() to runtimeId()

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -1123,7 +1123,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         ));
         pk.setPositionMode(PositionMode.ONLY_HEAD_ROT);
         pk.setOnGround(this.onGround);
-        pk.setRidingRuntimeID(riding.getId());
+        pk.setRidingRuntimeID(riding.runtimeId());
         pk.setTick(this.getServer().getTick());
 
         Set<Player> viewers = new HashSet<>();
@@ -1755,7 +1755,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         experience.setValue(Math.max(0f, Math.min(1f, experienceProgress)));
 
         final UpdateAttributesPacket packet = new UpdateAttributesPacket();
-        packet.setRuntimeID(this.getId());
+        packet.setRuntimeID(this.runtimeId());
         packet.getAttributeList().add(health.toNetwork());
         packet.getAttributeList().add(hunger.toNetwork());
         packet.getAttributeList().add(exhaustion.toNetwork());
@@ -2078,7 +2078,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
 
         final SetActorDataPacket packet = new SetActorDataPacket();
         packet.setActorData(this.getActorDataMap());
-        packet.setTargetRuntimeID(this.getId());
+        packet.setTargetRuntimeID(this.runtimeId());
         packet.setSyncedProperties(data);
 
         Player[] targets = (viewers == null || viewers.length == 0)
@@ -2384,7 +2384,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
         if (this.spawned) {
-            this.server.updatePlayerListData(this.getUniqueId(), this.getId(), this.getDisplayName(), this.getSkin(), this.getXUID(), this.getLocatorBarColor());
+            this.server.updatePlayerListData(this.getUniqueId(), this.runtimeId(), this.getDisplayName(), this.getSkin(), this.getXUID(), this.getLocatorBarColor());
         }
     }
 
@@ -2771,7 +2771,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
      */
     private void sendInitialAttributes(boolean includeLoginOnlyAttributes) {
         final UpdateAttributesPacket packet = new UpdateAttributesPacket();
-        packet.setRuntimeID(this.getId());
+        packet.setRuntimeID(this.runtimeId());
 
         final float health = Math.max(
             0.0f,
@@ -2954,7 +2954,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         if (this.needDimensionChangeACK) {
             this.needDimensionChangeACK = false;
             final PlayerActionPacket playerActionPacket = new PlayerActionPacket();
-            playerActionPacket.setPlayerRuntimeID(this.getId());
+            playerActionPacket.setPlayerRuntimeID(this.runtimeId());
             playerActionPacket.setAction(PlayerActionType.CHANGE_DIMENSION_ACK);
             playerActionPacket.setBlockPosition(this.toNetwork().toInt());
             playerActionPacket.setResultPos(this.toNetwork().toInt());
@@ -3103,7 +3103,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         }
 
         final AnimatePacket pk = new AnimatePacket();
-        pk.setTargetRuntimeID(this.getId());
+        pk.setTargetRuntimeID(this.runtimeId());
         pk.setAction(AnimatePacket.Action.WAKE_UP);
         this.sendPacket(pk);
     }
@@ -3355,7 +3355,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
             if (this.chunk != null) {
                 this.addMotion(this.motionX, this.motionY, this.motionZ);  // Send it to others
                 final SetActorMotionPacket packet = new SetActorMotionPacket();
-                packet.setTargetRuntimeID(this.getId());
+                packet.setTargetRuntimeID(this.runtimeId());
                 packet.setMotion(Vector3f.from(this.motionX, this.motionY, this.motionZ));
                 this.sendPacket(packet);  // Send it to self
             }
@@ -3375,7 +3375,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
      */
     public void sendAttributes() {
         UpdateAttributesPacket pk = new UpdateAttributesPacket();
-        pk.setRuntimeID(this.getId());
+        pk.setRuntimeID(this.runtimeId());
         pk.getAttributeList().addAll(
             Arrays.asList(
                 Attribute.getAttribute(Attribute.HEALTH).setMaxValue(this.getHealthMax()).setValue(health > 0 ? (health < getHealthMax() ? health : getHealthMax()) : 0).toNetwork(),
@@ -4834,7 +4834,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
 
         if (this.spawned && this.isAlive()) {
             UpdateAttributesPacket pk = new UpdateAttributesPacket();
-            pk.setRuntimeID(this.getId());
+            pk.setRuntimeID(this.runtimeId());
             pk.getAttributeList().add(attribute.toNetwork());
             this.sendPacket(pk);
         }
@@ -5017,7 +5017,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
      */
     public void syncAttribute(Attribute attribute) {
         final UpdateAttributesPacket pk = new UpdateAttributesPacket();
-        pk.setRuntimeID(this.getId());
+        pk.setRuntimeID(this.runtimeId());
         pk.getAttributeList().add(attribute.toNetwork());
         this.sendPacket(pk);
     }
@@ -5040,7 +5040,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
 
     protected void syncAttributes(boolean immediately) {
         final UpdateAttributesPacket pk = new UpdateAttributesPacket();
-        pk.setRuntimeID(this.getId());
+        pk.setRuntimeID(this.runtimeId());
 
         for (final Attribute attribute : this.attributes.values()) {
             if (attribute != null && attribute.isSyncable()) {
@@ -5160,7 +5160,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
                     this.lastBeAttackEntity = entityDamageByEntityEvent.getDamager();
                 }
                 final ActorEventPacket pk = new ActorEventPacket();
-                pk.setTargetRuntimeID(this.getId());
+                pk.setTargetRuntimeID(this.runtimeId());
                 pk.setType(ActorEvent.HURT);
                 this.sendPacket(pk);
             }
@@ -5257,13 +5257,13 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
      */
     public void sendPosition(Vector3 pos, double yaw, double pitch, PositionMode mode, Player[] targets) {
         final MovePlayerPacket pk = new MovePlayerPacket();
-        pk.setPlayerRuntimeID(this.getId());
+        pk.setPlayerRuntimeID(this.runtimeId());
         pk.setPosition(Vector3f.from(pos.x, pos.y + this.getEyeHeight(), pos.z));
         pk.setRotation(Vector3f.from(pitch, yaw, yaw));
         pk.setPositionMode(mode);
         pk.setOnGround(this.onGround);
         if (this.riding != null) {
-            pk.setRidingRuntimeID(this.riding.getId());
+            pk.setRidingRuntimeID(this.riding.runtimeId());
             pk.setPositionMode(PositionMode.ONLY_HEAD_ROT);
         }
 
@@ -5979,7 +5979,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         }
 
         final PlayerActionPacket dimensionAckPacket = new PlayerActionPacket();
-        dimensionAckPacket.setPlayerRuntimeID(this.getId());
+        dimensionAckPacket.setPlayerRuntimeID(this.runtimeId());
         dimensionAckPacket.setAction(PlayerActionType.CHANGE_DIMENSION_ACK);
         dimensionAckPacket.setBlockPosition(Vector3i.ZERO);
         dimensionAckPacket.setResultPos(Vector3i.ZERO);
@@ -6136,8 +6136,8 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
                 }
 
                 final TakeItemActorPacket pk = new TakeItemActorPacket();
-                pk.setActorRuntimeID(this.getId());
-                pk.setItemRuntimeID(entity.getId());
+                pk.setActorRuntimeID(this.runtimeId());
+                pk.setItemRuntimeID(entity.runtimeId());
                 Server.broadcastPacket(entity.getViewers().values(), pk);
                 this.sendPacket(pk);
 
@@ -6180,8 +6180,8 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
                 }
 
                 final TakeItemActorPacket pk = new TakeItemActorPacket();
-                pk.setActorRuntimeID(this.getId());
-                pk.setItemRuntimeID(entity.getId());
+                pk.setActorRuntimeID(this.runtimeId());
+                pk.setItemRuntimeID(entity.runtimeId());
                 Server.broadcastPacket(entity.getViewers().values(), pk);
                 this.sendPacket(pk);
 
@@ -6214,8 +6214,8 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
                         }
 
                         final TakeItemActorPacket pk = new TakeItemActorPacket();
-                        pk.setActorRuntimeID(this.getId());
-                        pk.setItemRuntimeID(entity.getId());
+                        pk.setActorRuntimeID(this.runtimeId());
+                        pk.setItemRuntimeID(entity.runtimeId());
                         Server.broadcastPacket(entity.getViewers().values(), pk);
                         this.sendPacket(pk);
 
@@ -6284,7 +6284,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         if (!(obj instanceof Player other)) {
             return false;
         }
-        return Objects.equals(this.getUniqueId(), other.getUniqueId()) && this.getId() == other.getId();
+        return Objects.equals(this.getUniqueId(), other.getUniqueId()) && this.runtimeId() == other.runtimeId();
     }
 
     /**
@@ -6481,7 +6481,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         this.showingCredits = showingCredits;
         if (showingCredits) {
             final ShowCreditsPacket pk = new ShowCreditsPacket();
-            pk.setPlayerRuntimeID(this.getId());
+            pk.setPlayerRuntimeID(this.runtimeId());
             pk.setCreditsState(
                 showingCredits ? ShowCreditsPacket.CreditsState.START_CREDITS : ShowCreditsPacket.CreditsState.END_CREDITS
             );
@@ -6672,7 +6672,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
             BlockEntity blockEntity = this.getLevel().getBlockEntity(position);
             if (blockEntity instanceof BlockEntitySign blockEntitySign) {
                 if (blockEntitySign.getEditorEntityRuntimeId() == -1) {
-                    blockEntitySign.setEditorEntityRuntimeId(this.getId());
+                    blockEntitySign.setEditorEntityRuntimeId(this.runtimeId());
                     final OpenSignPacket openSignPacket = new OpenSignPacket();
                     openSignPacket.setPos(position.asBlockVector3().toNetwork());
                     openSignPacket.setFrontSide(frontSide);
@@ -6721,7 +6721,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
     public void setLocatorBarColor(Color color) {
         this.locatorBarColor = color;
         if (this.spawned) {
-            this.server.updatePlayerListData(this.getUniqueId(), this.getId(), this.getDisplayName(), this.getSkin(), this.getXUID(), this.getLocatorBarColor());
+            this.server.updatePlayerListData(this.getUniqueId(), this.runtimeId(), this.getDisplayName(), this.getSkin(), this.getXUID(), this.getLocatorBarColor());
         }
     }
 

--- a/src/main/java/org/powernukkitx/block/BlockBamboo.java
+++ b/src/main/java/org/powernukkitx/block/BlockBamboo.java
@@ -121,7 +121,7 @@ public class BlockBamboo extends BlockTransparent implements BlockFlowerPot.Flow
             if (player != null) {
                 final AnimatePacket animatePacket = new AnimatePacket();
                 animatePacket.setAction(AnimatePacket.Action.SWING);
-                animatePacket.setTargetRuntimeID(player.getId());
+                animatePacket.setTargetRuntimeID(player.runtimeId());
                 this.getLevel().addChunkPacket(player.getChunkX(), player.getChunkZ(), animatePacket);
             }
             setBambooLeafSize(BambooLeafSize.SMALL_LEAVES);

--- a/src/main/java/org/powernukkitx/blockentity/BlockEntityConduit.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntityConduit.java
@@ -64,7 +64,7 @@ public class BlockEntityConduit extends BlockEntitySpawnable {
     public void saveNBT() {
         super.saveNBT();
         Entity targetEntity = this.targetEntity;
-        nbt.putLong("Target", targetEntity != null ? targetEntity.getId() : -1)
+        nbt.putLong("Target", targetEntity != null ? targetEntity.runtimeId() : -1)
                 .putBoolean("Active", active);
     }
 
@@ -361,7 +361,7 @@ public class BlockEntityConduit extends BlockEntitySpawnable {
                 .putBoolean("isMovable", this.isMovable())
                 .putBoolean("Active", this.active);
         Entity targetEntity = this.targetEntity;
-        tag.putLong("Target", targetEntity != null ? targetEntity.getId() : -1);
+        tag.putLong("Target", targetEntity != null ? targetEntity.runtimeId() : -1);
         return tag;
     }
 }

--- a/src/main/java/org/powernukkitx/blockentity/BlockEntityPistonArm.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntityPistonArm.java
@@ -90,7 +90,7 @@ public class BlockEntityPistonArm extends BlockEntitySpawnable {
         // Player clients automatically handle movement
         if (diff == 0 || !entity.canBePushedByPiston() || entity instanceof Player)
             return false;
-        if (!this.markEntityAffected(entity) || this.movedEntitiesThisTick.contains(entity.getId()))
+        if (!this.markEntityAffected(entity) || this.movedEntitiesThisTick.contains(entity.runtimeId()))
             return false;
         EntityMoveByPistonEvent event = new EntityMoveByPistonEvent(entity, entity.getPosition());
         this.level.getServer().getPluginManager().callEvent(event);
@@ -99,7 +99,7 @@ public class BlockEntityPistonArm extends BlockEntitySpawnable {
         entity.onPushByPiston(this);
         if (entity.closed)
             return false;
-        this.movedEntitiesThisTick.add(entity.getId());
+        this.movedEntitiesThisTick.add(entity.runtimeId());
         // Need to counteract gravity
         entity.move(
                 diff * moveDirection.getXOffset(),
@@ -114,7 +114,7 @@ public class BlockEntityPistonArm extends BlockEntitySpawnable {
         if (diff == 0 || !entity.canBePushedByPiston()) {
             return false;
         }
-        return this.affectedEntitiesThisTick.add(entity.getId());
+        return this.affectedEntitiesThisTick.add(entity.runtimeId());
     }
 
     /**

--- a/src/main/java/org/powernukkitx/dialog/window/FormWindowDialog.java
+++ b/src/main/java/org/powernukkitx/dialog/window/FormWindowDialog.java
@@ -94,7 +94,7 @@ public class FormWindowDialog implements Dialog {
     }
 
     public long getEntityId() {
-        return bindEntity.getId();
+        return bindEntity.runtimeId();
     }
 
     public Entity getBindEntity() {

--- a/src/main/java/org/powernukkitx/entity/Entity.java
+++ b/src/main/java/org/powernukkitx/entity/Entity.java
@@ -223,8 +223,16 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
      */
     protected UUID entityUniqueId;
     /**
-     * runtime id (changed after you restart the server)
+     * Runtime entity ID used by the current server process.
      */
+    protected volatile long runtimeId;
+
+    /**
+     * Legacy alias for {@link #runtimeId}.
+     *
+     * @deprecated Use {@link #runtimeId} internally or {@link #runtimeId()} through the API.
+     */
+    @Deprecated(since = "3.1.0", forRemoval = true)
     protected volatile long id;
     protected EntityDamageEvent lastDamageCause = null;
     protected int age = 0;
@@ -289,6 +297,39 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         if (!(this instanceof Player)) {
             this.init(chunk, nbt);
         }
+    }
+
+    /**
+     * Returns the runtime entity ID.
+     * <p>
+     * This ID is valid only for the current server runtime and may
+     * change after a server restart.
+     *
+     * @return runtime entity ID
+     */
+    public long runtimeId() {
+        return this.runtimeId;
+    }
+
+    /**
+     * Gets unique id(UUID)
+     */
+    public UUID getUniqueId() {
+        return this.entityUniqueId;
+    }
+
+    /**
+     * Returns the runtime entity ID.
+     * <p>
+     * This ID is valid only for the current server runtime and may
+     * change after a server restart.
+     *
+     * @return runtime entity ID
+     * @deprecated Use {@link #runtimeId()} instead.
+     */
+    @Deprecated(since = "3.1.0", forRemoval = true)
+    public long getId() {
+        return this.runtimeId;
     }
 
     /**
@@ -421,7 +462,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
      */
     public static void playAnimationOnEntities(EntityAnimation animation, Collection<Entity> entities, Collection<Player> players) {
         var pk = animation.toNetwork();
-        entities.forEach(entity -> pk.getRuntimeIds().add(entity.getId()));
+        entities.forEach(entity -> pk.getRuntimeIds().add(entity.runtimeId()));
         Server.broadcastPacket(players, pk);
     }
 
@@ -665,7 +706,8 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         if ((chunk == null || chunk.getProvider() == null)) {
             throw new ChunkException("Invalid garbage Chunk given to Entity");
         }
-        this.id = Entity.entityCount.getAndIncrement();
+        this.runtimeId = Entity.entityCount.getAndIncrement();
+        this.id = this.runtimeId;
         this.isPlayer = this instanceof Player;
         this.temporalVector = new Vector3();
         this.justCreated = true;
@@ -954,7 +996,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
 
             if (this instanceof Player player && effect.getId() != null) {
                 final MobEffectPacket packet = new MobEffectPacket();
-                packet.setTargetRuntimeID(player.getId());
+                packet.setTargetRuntimeID(player.runtimeId());
                 packet.setEffectID(effect.getId());
                 packet.setEvent(MobEffectPacket.Event.REMOVE);
                 player.sendPacket(packet);
@@ -1001,7 +1043,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
 
         if (this instanceof Player player && effect.getId() != null) {
             final MobEffectPacket packet = new MobEffectPacket();
-            packet.setTargetRuntimeID(player.getId());
+            packet.setTargetRuntimeID(player.runtimeId());
             packet.setEffectID(effect.getId());
             packet.setEffectAmplifier(effect.getAmplifier());
             packet.setShowParticles(effect.isVisible());
@@ -1312,7 +1354,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
             addActorPacket.getActorLinks().add(actorLink);
         }
         addActorPacket.setTargetActorID(this.getId());
-        addActorPacket.setTargetRuntimeID(this.getId());
+        addActorPacket.setTargetRuntimeID(this.runtimeId());
         addActorPacket.setActorType(this.getIdentifier());
         addActorPacket.setPosition(this.getPosition().toNetwork());
         addActorPacket.setVelocity(org.cloudburstmc.math.vector.Vector3f.from(this.motionX, this.motionY, this.motionZ));
@@ -1333,7 +1375,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         for (Effect effect : effects.values()) {
             if (effect.getId() != null) {
                 final MobEffectPacket packet = new MobEffectPacket();
-                packet.setTargetRuntimeID(this.getId());
+                packet.setTargetRuntimeID(this.runtimeId());
                 packet.setEffectID(effect.getId());
                 packet.setEffectAmplifier(effect.getAmplifier());
                 packet.setShowParticles(effect.isVisible());
@@ -1351,7 +1393,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
     public void sendData(Player player, ActorDataMap data) {
         final SetActorDataPacket packet = new SetActorDataPacket();
         packet.setActorData(data == null ? this.actorDataMap : data);
-        packet.setTargetRuntimeID(this.getId());
+        packet.setTargetRuntimeID(this.runtimeId());
         PropertySyncData syncData = this.propertySyncData();
         packet.getSyncedProperties().getFloatProperties().addAll(syncData.getFloatProperties());
         packet.getSyncedProperties().getIntProperties().addAll(syncData.getIntProperties());
@@ -1366,7 +1408,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
     public void sendData(Player[] players, ActorDataMap data) {
         final SetActorDataPacket packet = new SetActorDataPacket();
         packet.setActorData(data == null ? this.actorDataMap : data);
-        packet.setTargetRuntimeID(this.getId());
+        packet.setTargetRuntimeID(this.runtimeId());
         PropertySyncData syncData = this.propertySyncData();
         packet.getSyncedProperties().getFloatProperties().addAll(syncData.getFloatProperties());
         packet.getSyncedProperties().getIntProperties().addAll(syncData.getIntProperties());
@@ -1475,7 +1517,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
                     this.addEffect(Effect.get(EffectType.ABSORPTION).setDuration(100).setAmplifier(1));
 
                     final ActorEventPacket actorEventPacket = new ActorEventPacket();
-                    actorEventPacket.setTargetRuntimeID(this.getId());
+                    actorEventPacket.setTargetRuntimeID(this.runtimeId());
                     actorEventPacket.setType(ActorEvent.TALISMAN_ACTIVATE);
                     player.sendPacket(actorEventPacket);
 
@@ -1937,7 +1979,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
      */
     public void addMotion(double motionX, double motionY, double motionZ) {
         final SetActorMotionPacket packet = new SetActorMotionPacket();
-        packet.setTargetRuntimeID(this.getId());
+        packet.setTargetRuntimeID(this.runtimeId());
         packet.setMotion(org.cloudburstmc.math.vector.Vector3f.from(motionX, motionY, motionZ));
 
         Server.broadcastPacket(this.hasSpawned.values(), packet);
@@ -1946,7 +1988,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
 
     protected void broadcastMovement(boolean tp) {
         final MoveActorAbsoluteData moveData = new MoveActorAbsoluteData();
-        moveData.setActorRuntimeID(this.getId());
+        moveData.setActorRuntimeID(this.runtimeId());
         moveData.setOnGround(this.onGround);
         moveData.setTeleported(tp);
         moveData.setPos(this.getPosition().toNetwork().add(0f, this.getBaseOffset(), 0f));
@@ -4525,7 +4567,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         this.setTamed(true);
 
         final ActorEventPacket packet = new ActorEventPacket();
-        packet.setTargetRuntimeID(this.getId());
+        packet.setTargetRuntimeID(this.runtimeId());
         packet.setType(ActorEvent.TAMING_SUCCEEDED);
 
         player.sendPacket(packet);
@@ -4535,7 +4577,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
 
     public void onTameFail(Player player) {
         final ActorEventPacket packet = new ActorEventPacket();
-        packet.setTargetRuntimeID(this.getId());
+        packet.setTargetRuntimeID(this.runtimeId());
         packet.setType(ActorEvent.TAMING_FAILED);
 
         player.sendPacket(packet);
@@ -4580,7 +4622,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
     }
 
     public final void scheduleUpdate() {
-        this.level.updateEntities.put(this.getId(), this);
+        this.level.updateEntities.put(this.runtimeId(), this);
     }
 
     public boolean isOnFire() {
@@ -4631,7 +4673,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
 
     public void syncAttribute(Attribute attribute) {
         final UpdateAttributesPacket packet = new UpdateAttributesPacket();
-        packet.setRuntimeID(this.getId());
+        packet.setRuntimeID(this.runtimeId());
         packet.getAttributeList().add(attribute.toNetwork());
 
         Server.broadcastPacket(this.getViewers().values(), packet);
@@ -4639,7 +4681,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
 
     public void syncAttributes() {
         final UpdateAttributesPacket packet = new UpdateAttributesPacket();
-        packet.setRuntimeID(this.getId());
+        packet.setRuntimeID(this.runtimeId());
         var attributeList = packet.getAttributeList();
         for (Attribute attribute : this.attributes.values()) {
             if (attribute.isSyncable()) {
@@ -5767,21 +5809,6 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         return false;
     }
 
-    /**
-     * return runtime id (changed after restart the server),the id is incremental number
-     */
-    public long getId() {
-        return this.id;
-    }
-
-
-    /**
-     * Gets unique id(UUID)
-     */
-    public UUID getUniqueId() {
-        return this.entityUniqueId;
-    }
-
     public void respawnToAll() {
         Player[] players = this.hasSpawned.values().toArray(Player.EMPTY_ARRAY);
         this.hasSpawned.clear();
@@ -6001,13 +6028,13 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
             return false;
         }
         Entity other = (Entity) obj;
-        return this.getId() == other.getId();
+        return this.runtimeId() == other.runtimeId();
     }
 
     @Override
     public int hashCode() {
         int hash = 7;
-        hash = (int) (29 * hash + this.getId());
+        hash = (int) (29 * hash + this.runtimeId());
         return hash;
     }
 
@@ -6135,7 +6162,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
      */
     public void playAnimation(EntityAnimation animation, Collection<Player> players) {
         var pk = animation.toNetwork();
-        pk.getRuntimeIds().add(this.getId());
+        pk.getRuntimeIds().add(this.runtimeId());
         Server.broadcastPacket(players, pk);
     }
 
@@ -6155,7 +6182,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
     public void playActionAnimation(AnimatePacket.Action action, ActorSwingSource swingSource, Collection<Player> players) {
         var pk = new AnimatePacket();
         pk.setAction(action);
-        pk.setTargetRuntimeID(this.getId());
+        pk.setTargetRuntimeID(this.runtimeId());
         pk.setSwingSource(swingSource);
         Server.broadcastPacket(players, pk);
     }

--- a/src/main/java/org/powernukkitx/entity/EntityHuman.java
+++ b/src/main/java/org/powernukkitx/entity/EntityHuman.java
@@ -252,7 +252,7 @@ public class EntityHuman extends EntityHumanType {
             addPlayerPacket.setUuid(this.getUniqueId());
             addPlayerPacket.setPlayerName(this.getName());
             addPlayerPacket.setTargetActorID(this.getId());
-            addPlayerPacket.setTargetRuntimeID(this.getId());
+            addPlayerPacket.setTargetRuntimeID(this.runtimeId());
             addPlayerPacket.setPosition(this.getPosition().toNetwork());
             addPlayerPacket.setVelocity(this.getMotionVector());
             addPlayerPacket.setRotation(this.getRotationVector());

--- a/src/main/java/org/powernukkitx/entity/EntityLiving.java
+++ b/src/main/java/org/powernukkitx/entity/EntityLiving.java
@@ -332,7 +332,7 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
         super.setHealthCurrent(health);
         if (this.isAlive() && !wasAlive) {
             final ActorEventPacket pk = new ActorEventPacket();
-            pk.setTargetRuntimeID(this.getId());
+            pk.setTargetRuntimeID(this.runtimeId());
             pk.setType(ActorEvent.SPAWN_ALIVE);
             Server.broadcastPacket(this.hasSpawned.values(), pk);
         }
@@ -469,7 +469,7 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
                 }
                 if (event.isCriticalHit()) {
                     final AnimatePacket animatePacket = new AnimatePacket();
-                    animatePacket.setTargetRuntimeID(this.getId());
+                    animatePacket.setTargetRuntimeID(this.runtimeId());
                     animatePacket.setAction(AnimatePacket.Action.CRITICAL_HIT);
                     animatePacket.setData(55f);
 
@@ -485,7 +485,7 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
                     }
                     if (enchantmentBonus > 0) {
                         final AnimatePacket magicCritPacket = new AnimatePacket();
-                        magicCritPacket.setTargetRuntimeID(this.getId());
+                        magicCritPacket.setTargetRuntimeID(this.runtimeId());
                         magicCritPacket.setAction(AnimatePacket.Action.MAGIC_CRITICAL_HIT);
                         magicCritPacket.setData(55f);
 
@@ -503,7 +503,7 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
             }
 
             final ActorEventPacket actorEventPacket = new ActorEventPacket();
-            actorEventPacket.setTargetRuntimeID(this.getId());
+            actorEventPacket.setTargetRuntimeID(this.runtimeId());
             actorEventPacket.setType(this.getHealthCurrent() <= 0 ? ActorEvent.DEATH : ActorEvent.HURT);
             Server.broadcastPacket(this.hasSpawned.values(), actorEventPacket);
 
@@ -1305,7 +1305,7 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
 
     public void sendBreedingAnimation(Item item) {
         final ActorEventPacket pk = new ActorEventPacket();
-        pk.setTargetRuntimeID(this.getId());
+        pk.setTargetRuntimeID(this.runtimeId());
         pk.setType(ActorEvent.FEED);
         pk.setData(item.getFullId());
         Server.broadcastPacket(this.getViewers().values(), pk);
@@ -1313,7 +1313,7 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
 
     public void sendLoveParticles() {
         final ActorEventPacket pk = new ActorEventPacket();
-        pk.setTargetRuntimeID(this.getId());
+        pk.setTargetRuntimeID(this.runtimeId());
         pk.setType(ActorEvent.LOVE_HEARTS);
         Server.broadcastPacket(this.getViewers().values(), pk);
     }

--- a/src/main/java/org/powernukkitx/entity/EntityPhysical.java
+++ b/src/main/java/org/powernukkitx/entity/EntityPhysical.java
@@ -499,7 +499,7 @@ public abstract class EntityPhysical extends EntityCreature implements EntityAsy
 
         RideableComponent.InputType type = getInputControlType();
         if (type == null) {
-            log.warn("Entity {} ({}) received rider input but has no RideableComponent.InputType defined.", this.getId(), this.getIdentifier());
+            log.warn("Entity {} ({}) received rider input but has no RideableComponent.InputType defined.", this.runtimeId(), this.getIdentifier());
             return false;
         }
 

--- a/src/main/java/org/powernukkitx/entity/IHuman.java
+++ b/src/main/java/org/powernukkitx/entity/IHuman.java
@@ -167,7 +167,7 @@ public interface IHuman extends InventoryHolder {
             if (this.getSkin() == null) {
                 this.setSkin(new Skin(org.cloudburstmc.protocol.bedrock.data.skin.Skin.builder().skinData(ImageData.EMPTY).build()));
             }
-            this.setUniqueId(Utils.dataToUUID(String.valueOf(human.getId()).getBytes(StandardCharsets.UTF_8),
+            this.setUniqueId(Utils.dataToUUID(String.valueOf(human.runtimeId()).getBytes(StandardCharsets.UTF_8),
                 this.getSkin().getSkin().getSkinData().getImage(), human.getNameTag().getBytes(StandardCharsets.UTF_8)));
         }
 

--- a/src/main/java/org/powernukkitx/entity/ai/executor/BreedingExecutor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/executor/BreedingExecutor.java
@@ -757,7 +757,7 @@ public class BreedingExecutor implements IBehaviorExecutor {
     }
 
     protected boolean isBreedingLeader(EntityIntelligent entity, EntityIntelligent spouse) {
-        return entity.getId() < spouse.getId();
+        return entity.runtimeId() < spouse.runtimeId();
     }
 
     protected void clearBreedingState(EntityIntelligent entity) {

--- a/src/main/java/org/powernukkitx/entity/ai/executor/BreezeJumpExecutor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/executor/BreezeJumpExecutor.java
@@ -57,7 +57,7 @@ public class BreezeJumpExecutor implements EntityControl, IBehaviorExecutor {
         entity.setMotion(motion);
         entity.setDataFlag(ActorFlags.JUMP_GOAL_JUMP, false);
         final ActorEventPacket pk = new ActorEventPacket();
-        pk.setTargetRuntimeID(entity.getId());
+        pk.setTargetRuntimeID(entity.runtimeId());
         pk.setType(ActorEvent.GROUND_DUST);
         Server.broadcastPacket(entity.getViewers().values(), pk);
     }

--- a/src/main/java/org/powernukkitx/entity/ai/executor/EatGrassExecutor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/executor/EatGrassExecutor.java
@@ -55,7 +55,7 @@ public class EatGrassExecutor implements IBehaviorExecutor {
 
     protected void playEatGrassAnimation(EntityIntelligent entity) {
         final ActorEventPacket pk = new ActorEventPacket();
-        pk.setTargetRuntimeID(entity.getId());
+        pk.setTargetRuntimeID(entity.runtimeId());
         pk.setType(ActorEvent.EAT_GRASS);
         Server.broadcastPacket(entity.getViewers().values(), pk);
     }

--- a/src/main/java/org/powernukkitx/entity/ai/executor/GuardianAttackExecutor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/executor/GuardianAttackExecutor.java
@@ -130,7 +130,7 @@ public class GuardianAttackExecutor implements EntityControl, IBehaviorExecutor 
     private void endSequence(Entity entity) {
         entity.setDataProperty(ActorDataTypes.TARGET, 0L);
         final ActorEventPacket pk = new ActorEventPacket();
-        pk.setTargetRuntimeID(entity.getId());
+        pk.setTargetRuntimeID(entity.runtimeId());
         pk.setType(ActorEvent.GUARDIAN_ATTACK_SOUND);
         Server.broadcastPacket(entity.getViewers().values(), pk);
     }

--- a/src/main/java/org/powernukkitx/entity/ai/executor/InLoveExecutor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/executor/InLoveExecutor.java
@@ -42,7 +42,7 @@ public class InLoveExecutor implements IBehaviorExecutor {
 
     protected void sendLoveParticle(EntityIntelligent entity) {
         final ActorEventPacket pk = new ActorEventPacket();
-        pk.setTargetRuntimeID(entity.getId());
+        pk.setTargetRuntimeID(entity.runtimeId());
         pk.setType(ActorEvent.LOVE_HEARTS);
         Server.broadcastPacket(entity.getViewers().values(), pk);
     }

--- a/src/main/java/org/powernukkitx/entity/ai/executor/LoveTimeoutExecutor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/executor/LoveTimeoutExecutor.java
@@ -70,7 +70,7 @@ public class LoveTimeoutExecutor implements IBehaviorExecutor {
 
     protected void sendLoveParticle(EntityIntelligent entity) {
         final ActorEventPacket pk = new ActorEventPacket();
-        pk.setTargetRuntimeID(entity.getId());
+        pk.setTargetRuntimeID(entity.runtimeId());
         pk.setType(ActorEvent.LOVE_HEARTS);
         Server.broadcastPacket(entity.getViewers().values(), pk);
     }

--- a/src/main/java/org/powernukkitx/entity/ai/executor/MeleeAttackExecutor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/executor/MeleeAttackExecutor.java
@@ -186,7 +186,7 @@ public class MeleeAttackExecutor implements EntityControl, IBehaviorExecutor {
 
     protected void playAttackAnimation(EntityIntelligent entity) {
         final ActorEventPacket pk = new ActorEventPacket();
-        pk.setTargetRuntimeID(entity.getId());
+        pk.setTargetRuntimeID(entity.runtimeId());
         pk.setType(ActorEvent.START_ATTACKING);
         Server.broadcastPacket(entity.getViewers().values(), pk);
     }

--- a/src/main/java/org/powernukkitx/entity/ai/executor/RideableTameExecutor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/executor/RideableTameExecutor.java
@@ -86,7 +86,7 @@ public class RideableTameExecutor extends FlatRandomRoamExecutor {
 
             if (Utils.rand(0, 100) <= tameProbability) {
                 final ActorEventPacket packet = new ActorEventPacket();
-                packet.setTargetRuntimeID(animal.getId());
+                packet.setTargetRuntimeID(animal.runtimeId());
                 packet.setType(ActorEvent.TAMING_SUCCEEDED);
 
                 animal.setOwnerName(animal.getMemoryStorage().get(CoreMemoryTypes.RIDER_NAME));
@@ -99,7 +99,7 @@ public class RideableTameExecutor extends FlatRandomRoamExecutor {
 
             } else {
                 final ActorEventPacket packet = new ActorEventPacket();
-                packet.setTargetRuntimeID(animal.getId());
+                packet.setTargetRuntimeID(animal.runtimeId());
                 packet.setType(ActorEvent.TAMING_FAILED);
                 Player player = (Player) animal.getRider();
                 if (player == null) return false;

--- a/src/main/java/org/powernukkitx/entity/ai/executor/TameHorseExecutor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/executor/TameHorseExecutor.java
@@ -94,7 +94,7 @@ public class TameHorseExecutor extends FlatRandomRoamExecutor {
                 var horse = (EntityHorse) entity;
                 horse.setOwnerName(horse.getMemoryStorage().get(CoreMemoryTypes.RIDER_NAME));
                 final ActorEventPacket packet = new ActorEventPacket();
-                packet.setTargetRuntimeID(horse.getId());
+                packet.setTargetRuntimeID(horse.runtimeId());
                 packet.setType(ActorEvent.TAMING_SUCCEEDED);
                 Player player = (Player) horse.getRider();
                 if (player == null) {
@@ -104,7 +104,7 @@ public class TameHorseExecutor extends FlatRandomRoamExecutor {
             } else {
                 var horse = (EntityHorse) entity;
                 final ActorEventPacket packet = new ActorEventPacket();
-                packet.setTargetRuntimeID(horse.getId());
+                packet.setTargetRuntimeID(horse.runtimeId());
                 packet.setType(ActorEvent.TAMING_FAILED);
                 Player player = (Player) horse.getRider();
                 if (player == null) {

--- a/src/main/java/org/powernukkitx/entity/ai/executor/WardenMeleeAttackExecutor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/executor/WardenMeleeAttackExecutor.java
@@ -105,7 +105,7 @@ public class WardenMeleeAttackExecutor implements EntityControl, IBehaviorExecut
 
     protected void playAttackAnimation(EntityIntelligent entity) {
         final ActorEventPacket pk = new ActorEventPacket();
-        pk.setTargetRuntimeID(entity.getId());
+        pk.setTargetRuntimeID(entity.runtimeId());
         pk.setType(ActorEvent.START_ATTACKING);
         Server.broadcastPacket(entity.getViewers().values(), pk);
     }

--- a/src/main/java/org/powernukkitx/entity/ai/executor/villager/VillagerBreedingExecutor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/executor/villager/VillagerBreedingExecutor.java
@@ -86,8 +86,8 @@ public class VillagerBreedingExecutor extends BreedingExecutor {
     @Override
     protected void breed(EntityIntelligent parent1, EntityIntelligent parent2) {
         var villageManager = parent1.getLevel().getVillageManager();
-        Village village = villageManager.getVillageForDweller(parent1.getId()).orElse(null);
-        if (village == null || villageManager.getVillageForDweller(parent2.getId())
+        Village village = villageManager.getVillageForDweller(parent1.runtimeId()).orElse(null);
+        if (village == null || villageManager.getVillageForDweller(parent2.runtimeId())
                 .filter(other -> other.uuid().equals(village.uuid())).isEmpty()) {
             sendAngryParticles(parent1);
             sendAngryParticles(parent2);
@@ -139,14 +139,14 @@ public class VillagerBreedingExecutor extends BreedingExecutor {
 
     protected void sendInLoveParticles(EntityIntelligent entity) {
         final ActorEventPacket pk = new ActorEventPacket();
-        pk.setTargetRuntimeID(entity.getId());
+        pk.setTargetRuntimeID(entity.runtimeId());
         pk.setType(ActorEvent.LOVE_HEARTS);
         Server.broadcastPacket(entity.getViewers().values(), pk);
     }
 
     protected void sendAngryParticles(EntityIntelligent entity) {
         final ActorEventPacket pk = new ActorEventPacket();
-        pk.setTargetRuntimeID(entity.getId());
+        pk.setTargetRuntimeID(entity.runtimeId());
         pk.setType(ActorEvent.VILLAGER_ANGRY);
         Server.broadcastPacket(entity.getViewers().values(), pk);
     }

--- a/src/main/java/org/powernukkitx/entity/ai/memory/CoreMemoryTypes.java
+++ b/src/main/java/org/powernukkitx/entity/ai/memory/CoreMemoryTypes.java
@@ -292,7 +292,7 @@ public interface CoreMemoryTypes {
                             entity.setDataFlag(ActorFlags.TAMED, true);
                             var owner = entity.getServer().getPlayerExact(data);
                             if (owner != null && owner.isOnline()) {
-                                entity.setDataProperty(ActorDataTypes.OWNER, owner.getId());
+                                entity.setDataProperty(ActorDataTypes.OWNER, owner.runtimeId());
                             }
                         }
                     })

--- a/src/main/java/org/powernukkitx/entity/item/EntityArmorStand.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityArmorStand.java
@@ -323,7 +323,7 @@ public class EntityArmorStand extends Entity implements EntityInventoryHolder, E
     private void setPose(int pose) {
         this.actorDataMap.put(ActorDataTypes.POSE_INDEX, pose);
         final SetActorDataPacket packet = new SetActorDataPacket();
-        packet.setTargetRuntimeID(this.getId());
+        packet.setTargetRuntimeID(this.runtimeId());
         packet.setActorData(this.getActorDataMap());
         Server.getInstance().getOnlinePlayers().values().forEach(all -> all.sendPacket(packet));
     }

--- a/src/main/java/org/powernukkitx/entity/item/EntityBoat.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityBoat.java
@@ -151,7 +151,7 @@ public class EntityBoat extends EntityVehicle {
     protected BedrockPacket createAddEntityPacket() {
         final AddActorPacket packet = new AddActorPacket();
         packet.setTargetActorID(this.getId());
-        packet.setTargetRuntimeID(this.getId());
+        packet.setTargetRuntimeID(this.runtimeId());
         packet.setActorType("minecraft:boat");
         packet.setPosition(org.cloudburstmc.math.vector.Vector3f.from(this.x, this.y + this.getBaseOffset(), this.z));
         packet.setVelocity(org.cloudburstmc.math.vector.Vector3f.from(this.motionX, this.motionY, this.motionZ));

--- a/src/main/java/org/powernukkitx/entity/item/EntityChestBoat.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityChestBoat.java
@@ -76,7 +76,7 @@ public class EntityChestBoat extends EntityBoat implements InventoryHolder {
     protected BedrockPacket createAddEntityPacket() {
         final AddActorPacket packet = new AddActorPacket();
         packet.setTargetActorID(this.getId());
-        packet.setTargetRuntimeID(this.getId());
+        packet.setTargetRuntimeID(this.runtimeId());
         packet.setActorType("minecraft:chest_boat");
         packet.setPosition(Vector3f.from(this.x, this.y + this.getBaseOffset(), this.z));
         packet.setVelocity(Vector3f.from(this.motionX, this.motionY, this.motionZ));

--- a/src/main/java/org/powernukkitx/entity/item/EntityCrossbowFirework.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityCrossbowFirework.java
@@ -45,7 +45,7 @@ public class EntityCrossbowFirework extends EntityFireworksRocket {
                     hasUpdate = true;
                     if (this.fireworkAge >= this.lifetime) {
                         ActorEventPacket pk = new ActorEventPacket();
-                        pk.setTargetRuntimeID(this.getId());
+                        pk.setTargetRuntimeID(this.runtimeId());
                         pk.setType(ActorEvent.FIREWORKS_EXPLODE);
                         this.level.addLevelSoundEvent(this, SoundEvent.LARGE_BLAST, -1, 72);
                         Server.broadcastPacket(this.getViewers().values(), pk);

--- a/src/main/java/org/powernukkitx/entity/item/EntityElytraFirework.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityElytraFirework.java
@@ -53,7 +53,7 @@ public class EntityElytraFirework extends EntityFireworksRocket {
                     hasUpdate = true;
                     if (this.fireworkAge >= this.lifetime) {
                         ActorEventPacket pk = new ActorEventPacket();
-                        pk.setTargetRuntimeID(this.getId());
+                        pk.setTargetRuntimeID(this.runtimeId());
                         pk.setType(ActorEvent.FIREWORKS_EXPLODE);
                         this.level.addLevelSoundEvent(this, SoundEvent.LARGE_BLAST, -1, 72);
                         Server.broadcastPacket(this.getViewers().values(), pk);

--- a/src/main/java/org/powernukkitx/entity/item/EntityFireworksRocket.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityFireworksRocket.java
@@ -148,7 +148,7 @@ public class EntityFireworksRocket extends Entity {
             if (this.fireworkAge >= this.lifetime) {
                 final ActorEventPacket pk = new ActorEventPacket();
                 pk.setData(0);
-                pk.setTargetRuntimeID(this.getId());
+                pk.setTargetRuntimeID(this.runtimeId());
                 pk.setType(ActorEvent.FIREWORKS_EXPLODE);
 
                 level.addLevelSoundEvent(this, SoundEvent.LARGE_BLAST, -1, getNetworkId());

--- a/src/main/java/org/powernukkitx/entity/item/EntityFishingHook.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityFishingHook.java
@@ -195,15 +195,15 @@ public class EntityFishingHook extends SlenderProjectile {
         Collection<Player> viewers = this.getViewers().values();
 
         final ActorEventPacket pk = new ActorEventPacket();
-        pk.setTargetRuntimeID(this.getId());
+        pk.setTargetRuntimeID(this.runtimeId());
         pk.setType(ActorEvent.FISHHOOK_HOOKTIME);
 
         final ActorEventPacket bubblePk = new ActorEventPacket();
-        bubblePk.setTargetRuntimeID(this.getId());
+        bubblePk.setTargetRuntimeID(this.runtimeId());
         bubblePk.setType(ActorEvent.FISHHOOK_BUBBLE);
 
         final ActorEventPacket teasePk = new ActorEventPacket();
-        teasePk.setTargetRuntimeID(this.getId());
+        teasePk.setTargetRuntimeID(this.runtimeId());
         teasePk.setType(ActorEvent.FISHHOOK_TEASE);
 
         Server.broadcastPacket(viewers, pk);
@@ -285,7 +285,7 @@ public class EntityFishingHook extends SlenderProjectile {
     protected BedrockPacket createAddEntityPacket() {
         final AddActorPacket pk = new AddActorPacket();
         pk.setTargetActorID(this.getId());
-        pk.setTargetRuntimeID(this.getId());
+        pk.setTargetRuntimeID(this.runtimeId());
         pk.setActorType("minecraft:fishing_hook");
         pk.setPosition(org.cloudburstmc.math.vector.Vector3f.from(this.x, this.y, this.z));
         pk.setVelocity(org.cloudburstmc.math.vector.Vector3f.from(this.motionX, this.motionY, this.motionZ));

--- a/src/main/java/org/powernukkitx/entity/item/EntityItem.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityItem.java
@@ -203,7 +203,7 @@ public class EntityItem extends Entity {
                         entity.close();
                         this.getItem().setCount(newAmount);
                         final ActorEventPacket packet = new ActorEventPacket();
-                        packet.setTargetRuntimeID(this.getId());
+                        packet.setTargetRuntimeID(this.runtimeId());
                         packet.setType(ActorEvent.UPDATE_STACK_SIZE);
                         packet.setData(newAmount);
                         Server.broadcastPacket(this.getViewers().values(), packet);
@@ -406,7 +406,7 @@ public class EntityItem extends Entity {
         final AddItemActorPacket addItemActorPacket = new AddItemActorPacket();
         addItemActorPacket.setEntityData(this.actorDataMap);
         addItemActorPacket.setTargetActorID(this.getId());
-        addItemActorPacket.setTargetRuntimeID(this.getId());
+        addItemActorPacket.setTargetRuntimeID(this.runtimeId());
         addItemActorPacket.setItem(this.getItem().toNetwork());
         addItemActorPacket.setPosition(Vector3f.from(this.x, this.y + this.getBaseOffset(), this.z));
         addItemActorPacket.setVelocity(Vector3f.from(this.motionX, this.motionY, this.motionZ));

--- a/src/main/java/org/powernukkitx/entity/item/EntityPainting.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityPainting.java
@@ -193,7 +193,7 @@ public class EntityPainting extends EntityHanging {
     public BedrockPacket createAddEntityPacket() {
         final AddPaintingPacket packet = new AddPaintingPacket();
         packet.setTargetActorID(this.getId());
-        packet.setTargetRuntimeID(this.getId());
+        packet.setTargetRuntimeID(this.runtimeId());
         packet.setPosition(Vector3f.from(this.x, this.y, this.z));
         packet.setDirection(this.getDirection().getHorizontalIndex());
         packet.setMotif(this.getNbt().getString("Motive"));

--- a/src/main/java/org/powernukkitx/entity/mob/EntityEnderDragon.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityEnderDragon.java
@@ -117,7 +117,7 @@ public class EntityEnderDragon extends EntityBoss implements EntityFlyable {
         );
         pk.setActorData(this.getActorDataMap());
         pk.setTargetActorID(this.getId());
-        pk.setTargetRuntimeID(this.getId());
+        pk.setTargetRuntimeID(this.runtimeId());
         pk.setActorType("minecraft:ender_dragon");
         pk.setPosition(org.cloudburstmc.math.vector.Vector3f.from(this.x, this.y, this.z));
         pk.setVelocity(org.cloudburstmc.math.vector.Vector3f.from(this.motionX, this.motionY, this.motionZ));
@@ -173,7 +173,7 @@ public class EntityEnderDragon extends EntityBoss implements EntityFlyable {
             deathTicks = 190;
             getLevel().addLevelSoundEvent(this, SoundEvent.DEATH, -1, getIdentifier(), false, false);
             final ActorEventPacket packet = new ActorEventPacket();
-            packet.setTargetRuntimeID(this.getId());
+            packet.setTargetRuntimeID(this.runtimeId());
             packet.setType(ActorEvent.DRAGON_START_DEATH_ANIM);
             Server.broadcastPacket(getViewers().values(), packet);
             setImmobile(true);

--- a/src/main/java/org/powernukkitx/entity/mob/EntityEvocationFang.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityEvocationFang.java
@@ -53,7 +53,7 @@ public class EntityEvocationFang extends EntityMob implements EntityWalkable {
     public void spawnTo(Player player) {
         super.spawnTo(player);
         final ActorEventPacket pk = new ActorEventPacket();
-        pk.setTargetRuntimeID(this.getId());
+        pk.setTargetRuntimeID(this.runtimeId());
         pk.setType(ActorEvent.START_ATTACKING);
         player.sendPacket(pk);
     }

--- a/src/main/java/org/powernukkitx/entity/mob/EntityPiglin.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityPiglin.java
@@ -301,8 +301,8 @@ public class EntityPiglin extends EntityMob implements EntityWalkable {
                     }
                     if (pickup) {
                         final TakeItemActorPacket pk = new TakeItemActorPacket();
-                        pk.setActorRuntimeID(entity.getId());
-                        pk.setItemRuntimeID(i.getId());
+                        pk.setActorRuntimeID(entity.runtimeId());
+                        pk.setItemRuntimeID(i.runtimeId());
                         Server.broadcastPacket(entity.getViewers().values(), pk);
                         i.close();
                     }

--- a/src/main/java/org/powernukkitx/entity/mob/EntityWarden.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityWarden.java
@@ -231,7 +231,7 @@ public class EntityWarden extends EntityMob implements EntityWalkable, Vibration
         this.waitForVibration = false;
         this.lastDetectTime = getLevel().getTick();
         final ActorEventPacket pk = new ActorEventPacket();
-        pk.setTargetRuntimeID(this.getId());
+        pk.setTargetRuntimeID(this.runtimeId());
         pk.setType(ActorEvent.VIBRATION_DETECTED);
         Server.broadcastPacket(this.getViewers().values(), pk);
 

--- a/src/main/java/org/powernukkitx/entity/mob/EntityWither.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityWither.java
@@ -162,7 +162,7 @@ public class EntityWither extends EntityBoss implements EntityFlyable, EntitySmi
             deathTicks = 190;
             getLevel().addLevelSoundEvent(this, SoundEvent.DEATH, -1, Entity.WITHER, false, false);
             final ActorEventPacket packet = new ActorEventPacket();
-            packet.setTargetRuntimeID(this.getId());
+            packet.setTargetRuntimeID(this.runtimeId());
             packet.setType(ActorEvent.DEATH);
             Server.broadcastPacket(getViewers().values(), packet);
             setImmobile(true);
@@ -234,7 +234,7 @@ public class EntityWither extends EntityBoss implements EntityFlyable, EntitySmi
         );
         packet.setActorData(this.getActorDataMap());
         packet.setTargetActorID(this.getId());
-        packet.setTargetRuntimeID(this.getId());
+        packet.setTargetRuntimeID(this.runtimeId());
         packet.setActorType("minecraft:wither");
         packet.setPosition(org.cloudburstmc.math.vector.Vector3f.from(this.x, this.y, this.z));
         packet.setVelocity(org.cloudburstmc.math.vector.Vector3f.from(this.motionX, this.motionY, this.motionZ));

--- a/src/main/java/org/powernukkitx/entity/mob/EntityZombie.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityZombie.java
@@ -208,8 +208,8 @@ public class EntityZombie extends EntityMob implements EntityWalkable, EntitySmi
                         }
                         if (holder.equip(item)) {
                             final TakeItemActorPacket pk = new TakeItemActorPacket();
-                            pk.setActorRuntimeID(entity.getId());
-                            pk.setItemRuntimeID(i.getId());
+                            pk.setActorRuntimeID(entity.runtimeId());
+                            pk.setItemRuntimeID(i.runtimeId());
                             Server.broadcastPacket(entity.getViewers().values(), pk);
                             i.close();
                         }

--- a/src/main/java/org/powernukkitx/entity/passive/EntityPanda.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityPanda.java
@@ -222,8 +222,8 @@ public class EntityPanda extends EntityAnimal implements EntityWalkable, EntityC
                         }
                         getInventory().addItem(item);
                         final TakeItemActorPacket pk = new TakeItemActorPacket();
-                        pk.setActorRuntimeID(this.getId());
-                        pk.setItemRuntimeID(entity.getId());
+                        pk.setActorRuntimeID(this.runtimeId());
+                        pk.setItemRuntimeID(entity.runtimeId());
                         Server.broadcastPacket(getViewers().values(), pk);
                         entityItem.close();
                     }

--- a/src/main/java/org/powernukkitx/entity/passive/EntitySulfurCube.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntitySulfurCube.java
@@ -291,7 +291,7 @@ public class EntitySulfurCube extends EntityAnimal implements EntityWalkable, En
         String absorbed = getSwallowedBlock();
 
         MobEquipmentPacket packet = new MobEquipmentPacket();
-        packet.setTargetRuntimeID(getId());
+        packet.setTargetRuntimeID(runtimeId());
         packet.setItem((absorbed == null ? Item.AIR : Item.get(absorbed)).toNetwork());
         packet.setSlot(0);
         packet.setSelectedSlot(0);

--- a/src/main/java/org/powernukkitx/entity/passive/EntityVillagerV2.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityVillagerV2.java
@@ -251,7 +251,7 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
                                     this.nbt.remove("bed");
                                     getMemoryStorage().clear(CoreMemoryTypes.OCCUPIED_BED);
                                 } else {
-                                    getLevel().getVillageManager().ensureTicket(getMemoryStorage().get(CoreMemoryTypes.OCCUPIED_BED).asBlockVector3(), getId());
+                                    getLevel().getVillageManager().ensureTicket(getMemoryStorage().get(CoreMemoryTypes.OCCUPIED_BED).asBlockVector3(), runtimeId());
                                 }
                             }
                         },
@@ -293,7 +293,7 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
                                         setTradeSeed(new NukkitRandom().nextInt(Integer.MAX_VALUE - 1));
                                     }
                                 } else if (siteBlock != null) {
-                                    getLevel().getVillageManager().ensureTicket(siteBlock.asBlockVector3(), getId());
+                                    getLevel().getVillageManager().ensureTicket(siteBlock.asBlockVector3(), runtimeId());
                                 }
 
                                 if (getMemoryStorage().isEmpty(CoreMemoryTypes.SITE_BLOCK)) {
@@ -377,11 +377,11 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
     }
 
     public void setBed(BlockBed bed) {
-        if (bed.isBedValid() && getLevel().getVillageManager().takeAt(bed.getFootPart().asBlockVector3(), getId())) {
+        if (bed.isBedValid() && getLevel().getVillageManager().takeAt(bed.getFootPart().asBlockVector3(), runtimeId())) {
             getMemoryStorage().put(CoreMemoryTypes.OCCUPIED_BED, bed);
             getLevel().getVillageManager().getVillageAt(bed.asBlockVector3()).ifPresent(village -> {
                 setVillageUuid(village.uuid());
-                getLevel().getVillageManager().addDweller(village.uuid(), new VillageDwellers.Actor(getId(), asBlockVector3(), getLevel().getCurrentTick(), null));
+                getLevel().getVillageManager().addDweller(village.uuid(), new VillageDwellers.Actor(runtimeId(), asBlockVector3(), getLevel().getCurrentTick(), null));
             });
             for (int i = 0; i < 5; i++) {
                 float randX = Utils.rand(0f, 0.5f);
@@ -430,7 +430,7 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
     private void restoreBed(BlockBed bed) {
         BlockBed foot = bed.getFootPart();
         if (foot != null && foot.isBedValid()
-                && getLevel().getVillageManager().ensureTicket(foot.asBlockVector3(), getId())) {
+                && getLevel().getVillageManager().ensureTicket(foot.asBlockVector3(), runtimeId())) {
             getMemoryStorage().put(CoreMemoryTypes.OCCUPIED_BED, foot);
         }
     }
@@ -562,7 +562,7 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
             setProfession(nbtMap.getInt("profession"), false);
         }
         if (!nbtMap.containsString("villageUuid")) {
-            getLevel().getVillageManager().getVillageForDweller(getId())
+            getLevel().getVillageManager().getVillageForDweller(runtimeId())
                     .ifPresent(village -> setVillageUuid(village.uuid()));
         }
         if (nbtMap.contains("clothing")) {
@@ -634,7 +634,7 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
                 && event.getDamager() instanceof Player player) {
             addGossip(player.getXUID(), Gossip.MINOR_NEGATIVE, 25);
             final ActorEventPacket pk = new ActorEventPacket();
-            pk.setTargetRuntimeID(this.getId());
+            pk.setTargetRuntimeID(this.runtimeId());
             pk.setType(ActorEvent.VILLAGER_ANGRY);
             Server.broadcastPacket(getViewers().values(), pk);
             for (Entity e : getLevel().getCollidingEntities(getBoundingBox().grow(48, 8, 48))) {
@@ -802,7 +802,7 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
         for (Profession profession : Profession.getProfessions().values()) {
             if (getTradeExp() != 0 && profession.getIndex() != getProfession()) continue;
             if (block.getId().equals(profession.getBlockID())) {
-                if (!getLevel().getVillageManager().takeAt(block.asBlockVector3(), getId())) return false;
+                if (!getLevel().getVillageManager().takeAt(block.asBlockVector3(), runtimeId())) return false;
                 getMemoryStorage().put(CoreMemoryTypes.SITE_BLOCK, block);
                 getLevel().getVillageManager().getVillageAt(block.asBlockVector3())
                         .ifPresent(village -> setVillageUuid(village.uuid()));
@@ -841,7 +841,7 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
     private void restoreProfessionBlock(Block block) {
         Profession profession = Profession.getProfession(getProfession());
         if (profession != null && block.getId().equals(profession.getBlockID())
-                && getLevel().getVillageManager().ensureTicket(block.asBlockVector3(), getId())) {
+                && getLevel().getVillageManager().ensureTicket(block.asBlockVector3(), runtimeId())) {
             getMemoryStorage().put(CoreMemoryTypes.SITE_BLOCK, block);
         }
     }
@@ -1059,8 +1059,8 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
                                 continue;
                             }
                             final TakeItemActorPacket pk = new TakeItemActorPacket();
-                            pk.setActorRuntimeID(this.getId());
-                            pk.setItemRuntimeID(i.getId());
+                            pk.setActorRuntimeID(this.runtimeId());
+                            pk.setItemRuntimeID(i.getRuntimeId());
                             Server.broadcastPacket(getViewers().values(), pk);
                             slice.addItem(item);
                             i.close();

--- a/src/main/java/org/powernukkitx/entity/passive/EntityVillagerV2.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityVillagerV2.java
@@ -1060,7 +1060,7 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
                             }
                             final TakeItemActorPacket pk = new TakeItemActorPacket();
                             pk.setActorRuntimeID(this.runtimeId());
-                            pk.setItemRuntimeID(i.getRuntimeId());
+                            pk.setItemRuntimeID(i.runtimeId());
                             Server.broadcastPacket(getViewers().values(), pk);
                             slice.addItem(item);
                             i.close();

--- a/src/main/java/org/powernukkitx/entity/projectile/EntityArrow.java
+++ b/src/main/java/org/powernukkitx/entity/projectile/EntityArrow.java
@@ -160,7 +160,7 @@ public class EntityArrow extends SlenderProjectile {
     protected void addHitEffect() {
         this.level.addSound(this, Sound.RANDOM_BOWHIT);
         final ActorEventPacket packet = new ActorEventPacket();
-        packet.setTargetRuntimeID(this.getId());
+        packet.setTargetRuntimeID(this.runtimeId());
         packet.setType(ActorEvent.SHAKE);
         packet.setData(7); // TODO Magic value. I have no idea why we have to set it to 7 here...
         Server.broadcastPacket(this.hasSpawned.values(), packet);

--- a/src/main/java/org/powernukkitx/entity/weather/EntityLightningBolt.java
+++ b/src/main/java/org/powernukkitx/entity/weather/EntityLightningBolt.java
@@ -218,7 +218,7 @@ public class EntityLightningBolt extends Entity implements EntityLightningStrike
                 bb.setMaxX(bb.getMaxX() + 6);
 
                 for (Entity entity : this.level.getCollidingEntities(bb, this)) {
-                    if (struckEntities.add(entity.getId())) {
+                    if (struckEntities.add(entity.runtimeId())) {
                         entity.onStruckByLightning(this);
                     }
                 }

--- a/src/main/java/org/powernukkitx/inventory/EntityArmorInventory.java
+++ b/src/main/java/org/powernukkitx/inventory/EntityArmorInventory.java
@@ -113,7 +113,7 @@ public class EntityArmorInventory extends BaseInventory {
             player.sendPacket(inventorySlotPacket);
         } else {
             final MobArmorEquipmentPacket mobArmorEquipmentPacket = new MobArmorEquipmentPacket();
-            mobArmorEquipmentPacket.setTargetRuntimeID(this.entity.getId());
+            mobArmorEquipmentPacket.setTargetRuntimeID(this.entity.runtimeId());
             mobArmorEquipmentPacket.setHead(this.getHelmet().toNetwork());
             mobArmorEquipmentPacket.setTorso(this.getChestplate().toNetwork());
             mobArmorEquipmentPacket.setLegs(this.getLeggings().toNetwork());
@@ -149,7 +149,7 @@ public class EntityArmorInventory extends BaseInventory {
             player.sendPacket(inventoryContentPacket);
         } else {
             final MobArmorEquipmentPacket mobArmorEquipmentPacket = new MobArmorEquipmentPacket();
-            mobArmorEquipmentPacket.setTargetRuntimeID(this.entity.getId());
+            mobArmorEquipmentPacket.setTargetRuntimeID(this.entity.runtimeId());
             mobArmorEquipmentPacket.setHead(this.getHelmet().toNetwork());
             mobArmorEquipmentPacket.setTorso(this.getChestplate().toNetwork());
             mobArmorEquipmentPacket.setLegs(this.getLeggings().toNetwork());

--- a/src/main/java/org/powernukkitx/inventory/EntityEquipmentInventory.java
+++ b/src/main/java/org/powernukkitx/inventory/EntityEquipmentInventory.java
@@ -44,7 +44,7 @@ public class EntityEquipmentInventory extends BaseInventory {
     @Override
     public void sendSlot(int index, Player player) {
         final MobEquipmentPacket packet = new MobEquipmentPacket();
-        packet.setTargetRuntimeID(this.entity.getId());
+        packet.setTargetRuntimeID(this.entity.runtimeId());
         packet.setSlot(index);
         packet.setSelectedSlot(index);
         packet.setItem(this.getItem(index).toNetwork());

--- a/src/main/java/org/powernukkitx/inventory/HorseInventory.java
+++ b/src/main/java/org/powernukkitx/inventory/HorseInventory.java
@@ -183,7 +183,7 @@ public class HorseInventory<T extends EntityCreature & InventoryHolder> extends 
             if (!armor.isNull()) getHolder().getLevel().addSound(getHolder(), Sound.MOB_HORSE_ARMOR);
 
             final MobArmorEquipmentPacket mobArmorEquipmentPacket = new MobArmorEquipmentPacket();
-            mobArmorEquipmentPacket.setTargetRuntimeID(this.getHolder().getId());
+            mobArmorEquipmentPacket.setTargetRuntimeID(this.getHolder().runtimeId());
             mobArmorEquipmentPacket.setHead(ItemData.AIR);
             mobArmorEquipmentPacket.setTorso(ItemData.AIR);
             mobArmorEquipmentPacket.setLegs(ItemData.AIR);
@@ -200,7 +200,7 @@ public class HorseInventory<T extends EntityCreature & InventoryHolder> extends 
             // TODO: Do Nautilus play a sound on equip armor?
 
             final MobArmorEquipmentPacket mobArmorEquipmentPacket = new MobArmorEquipmentPacket();
-            mobArmorEquipmentPacket.setTargetRuntimeID(this.getHolder().getId());
+            mobArmorEquipmentPacket.setTargetRuntimeID(this.getHolder().runtimeId());
             mobArmorEquipmentPacket.setHead(ItemData.AIR);
             mobArmorEquipmentPacket.setTorso(ItemData.AIR);
             mobArmorEquipmentPacket.setLegs(ItemData.AIR);
@@ -301,7 +301,7 @@ public class HorseInventory<T extends EntityCreature & InventoryHolder> extends 
         if (armor.isNull()) armor = Item.AIR;
 
         final MobArmorEquipmentPacket pk = new MobArmorEquipmentPacket();
-        pk.setTargetRuntimeID(this.getHolder().getId());
+        pk.setTargetRuntimeID(this.getHolder().runtimeId());
         pk.setHead(ItemData.AIR);
         pk.setTorso(ItemData.AIR);
         pk.setLegs(ItemData.AIR);

--- a/src/main/java/org/powernukkitx/inventory/HumanInventory.java
+++ b/src/main/java/org/powernukkitx/inventory/HumanInventory.java
@@ -267,9 +267,9 @@ public class HumanInventory extends BaseInventory {
         pk.setSelectedSlot(this.getHeldItemIndex());
 
         for (Player player : players) {
-            pk.setTargetRuntimeID(this.getHolder().getEntity().getId());
+            pk.setTargetRuntimeID(this.getHolder().getEntity().runtimeId());
             if (player.equals(this.getHolder())) {
-                pk.setTargetRuntimeID(player.getId());
+                pk.setTargetRuntimeID(player.runtimeId());
                 this.sendSlot(this.getHeldItemIndex(), player);
             }
 
@@ -600,7 +600,7 @@ public class HumanInventory extends BaseInventory {
         Item[] armor = this.getArmorContents();
 
         final MobArmorEquipmentPacket pk = new MobArmorEquipmentPacket();
-        pk.setTargetRuntimeID(this.getHolder().getEntity().getId());
+        pk.setTargetRuntimeID(this.getHolder().getEntity().runtimeId());
         pk.setHead(this.getArmorContents()[0].toNetwork());
         pk.setTorso(this.getArmorContents()[1].toNetwork());
         pk.setLegs(this.getArmorContents()[2].toNetwork());
@@ -690,7 +690,7 @@ public class HumanInventory extends BaseInventory {
         Item[] armor = this.getArmorContents();
 
         final MobArmorEquipmentPacket mobArmorEquipmentPacket = new MobArmorEquipmentPacket();
-        mobArmorEquipmentPacket.setTargetRuntimeID(this.getHolder().getEntity().getId());
+        mobArmorEquipmentPacket.setTargetRuntimeID(this.getHolder().getEntity().runtimeId());
         mobArmorEquipmentPacket.setHead(armor[0].toNetwork());
         mobArmorEquipmentPacket.setTorso(armor[1].toNetwork());
         mobArmorEquipmentPacket.setLegs(armor[2].toNetwork());

--- a/src/main/java/org/powernukkitx/inventory/HumanOffHandInventory.java
+++ b/src/main/java/org/powernukkitx/inventory/HumanOffHandInventory.java
@@ -89,7 +89,7 @@ public class HumanOffHandInventory extends BaseInventory {
     private MobEquipmentPacket createMobEquipmentPacket(Item item) {
         final int slot = 1;
         final MobEquipmentPacket packet = new MobEquipmentPacket();
-        packet.setTargetRuntimeID(this.getHolder().getEntity().getId());
+        packet.setTargetRuntimeID(this.getHolder().getEntity().runtimeId());
         packet.setItem(item.toNetwork());
         packet.setSlot(slot);
         packet.setSelectedSlot(slot);

--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -4858,14 +4858,14 @@ public class Level implements Metadatable {
         }
 
         if (entity instanceof Player p) {
-            this.players.remove(entity.getId());
+            this.players.remove(entity.runtimeId());
             this.checkSleep();
         } else {
             entity.close();
         }
 
-        this.entities.remove(entity.getId());
-        this.updateEntities.remove(entity.getId());
+        this.entities.remove(entity.runtimeId());
+        this.updateEntities.remove(entity.runtimeId());
     }
 
     public void addEntity(Entity entity) {
@@ -4874,10 +4874,10 @@ public class Level implements Metadatable {
         }
 
         if (entity instanceof Player p) {
-            this.players.put(entity.getId(), p);
+            this.players.put(entity.runtimeId(), p);
             p.setShownWeather(WeatherDisplay.NONE);
         }
-        this.entities.put(entity.getId(), entity);
+        this.entities.put(entity.runtimeId(), entity);
     }
 
     public void addBlockEntity(BlockEntity blockEntity) {
@@ -5730,11 +5730,11 @@ public class Level implements Metadatable {
 
     public void addPlayerMovement(Entity entity, double x, double y, double z, double yaw, double pitch, double headYaw) {
         final MovePlayerPacket packet = new MovePlayerPacket();
-        packet.setPlayerRuntimeID(entity.getId());
+        packet.setPlayerRuntimeID(entity.runtimeId());
         packet.setPosition(org.cloudburstmc.math.vector.Vector3f.from(x, y, z));
         packet.setRotation(org.cloudburstmc.math.vector.Vector3f.from(pitch, yaw, headYaw));
         if (entity.riding != null) {
-            packet.setRidingRuntimeID(entity.riding.getId());
+            packet.setRidingRuntimeID(entity.riding.runtimeId());
             packet.setPositionMode(PositionMode.ONLY_HEAD_ROT);
         } else {
             packet.setPositionMode(PositionMode.NORMAL);
@@ -5746,7 +5746,7 @@ public class Level implements Metadatable {
     public void addEntityMovement(Entity entity, double x, double y, double z, double yaw, double pitch, double headYaw) {
         final MoveActorDeltaPacket packet = new MoveActorDeltaPacket();
         final MoveActorDeltaData data = new MoveActorDeltaData();
-        data.setActorRuntimeID(entity.getId());
+        data.setActorRuntimeID(entity.runtimeId());
 
         if (entity.lastX != x) {
             data.setNewPositionX((float) x);

--- a/src/main/java/org/powernukkitx/level/format/Chunk.java
+++ b/src/main/java/org/powernukkitx/level/format/Chunk.java
@@ -522,7 +522,7 @@ public class Chunk implements IChunk {
 
     @Override
     public void addEntity(Entity entity) {
-        if (this.entities.put(entity.getId(), entity) == null) {
+        if (this.entities.put(entity.runtimeId(), entity) == null) {
             this.entityCount.incrementAndGet();
         }
         if (!(entity instanceof Player) && this.isInit) {
@@ -532,10 +532,10 @@ public class Chunk implements IChunk {
 
     @Override
     public void removeEntity(Entity entity) {
-        if (entity.getId() < 0) return;
+        if (entity.runtimeId() < 0) return;
         if (this.entities != null) {
             synchronized (this.entities) {
-                if (this.entities.remove(entity.getId()) != null) {
+                if (this.entities.remove(entity.runtimeId()) != null) {
                     this.entityCount.decrementAndGet();
                 }
                 if (!(entity instanceof Player) && this.isInit) {

--- a/src/main/java/org/powernukkitx/level/vibration/SimpleVibrationManager.java
+++ b/src/main/java/org/powernukkitx/level/vibration/SimpleVibrationManager.java
@@ -76,7 +76,7 @@ public class SimpleVibrationManager implements VibrationManager {
         LevelEventGenericPacket packet = new LevelEventGenericPacket();
         packet.setType(LevelEvent.PARTICLE_VIBRATION_SIGNAL);
         packet.setTag(tag);
-        //todo: Packets are only sent to players within the player's field of view.
+        // TODO: Packets are only sent to players within the player's field of view.
         Server.broadcastPacket(level.getPlayers().values(), packet);
     }
 
@@ -92,8 +92,8 @@ public class SimpleVibrationManager implements VibrationManager {
     protected NbtMap createEntityTargetTag(Entity entity) {
         return NbtMap.builder()
                 .putString("type", "actor")
-                .putLong("uniqueID", entity.getId())
-                .putInt("attachPos", 3) //todo: check the use of this value :)
+                .putLong("uniqueID", entity.runtimeId())
+                .putInt("attachPos", 3) // TODO: check the use of this value.
                 .build();
     }
 

--- a/src/main/java/org/powernukkitx/level/village/VillageManager.java
+++ b/src/main/java/org/powernukkitx/level/village/VillageManager.java
@@ -142,7 +142,7 @@ public final class VillageManager {
                     if (entity instanceof EntityVillagerV2 villager) {
                         BlockVector3 pos = villager.asBlockVector3();
                         if (isInside(min, max, pos)) {
-                            actors.add(new VillageDwellers.Actor(villager.getId(), pos, tick, null));
+                            actors.add(new VillageDwellers.Actor(villager.runtimeId(), pos, tick, null));
                         }
                     }
                 }

--- a/src/main/java/org/powernukkitx/metadata/EntityMetadataStore.java
+++ b/src/main/java/org/powernukkitx/metadata/EntityMetadataStore.java
@@ -12,6 +12,6 @@ public class EntityMetadataStore extends MetadataStore {
         if (!(entity instanceof Entity)) {
             throw new IllegalArgumentException("Argument must be an Entity instance");
         }
-        return ((Entity) entity).getId() + ":" + metadataKey;
+        return ((Entity) entity).runtimeId() + ":" + metadataKey;
     }
 }

--- a/src/main/java/org/powernukkitx/network/primitiveshape/PrimitiveShape.java
+++ b/src/main/java/org/powernukkitx/network/primitiveshape/PrimitiveShape.java
@@ -85,7 +85,7 @@ public abstract class PrimitiveShape<T extends PrimitiveShape<T>> {
     }
 
     public T attachTo(Entity entity) {
-        this.attachedToEntityId = entity.getId();
+        this.attachedToEntityId = entity.runtimeId();
         return self();
     }
 

--- a/src/main/java/org/powernukkitx/network/process/PlayerSessionHolder.java
+++ b/src/main/java/org/powernukkitx/network/process/PlayerSessionHolder.java
@@ -325,7 +325,7 @@ public class PlayerSessionHolder {
     private void sendStartGame(Server server) {
         final StartGamePacket packet = new StartGamePacket();
         packet.setEntityID(this.player.getId());
-        packet.setRuntimeID(this.player.getId());
+        packet.setRuntimeID(this.player.runtimeId());
         packet.setGameType(GameType.from(Player.toNetworkGamemode(this.player.getGamemode())));
         packet.setPosition(this.player.getInitialSpawnPosition());
         packet.setRotation(Vector2f.from(this.player.getYaw(), this.player.getPitch()));

--- a/src/main/java/org/powernukkitx/network/process/handler/ActorEventHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/ActorEventHandler.java
@@ -24,7 +24,7 @@ public class ActorEventHandler implements PacketHandler<ActorEventPacket> {
 
 
         if (packet.getType().equals(ActorEvent.FEED) || packet.getType().equals(ActorEvent.DRINK_MILK)) {
-            if (packet.getTargetRuntimeID() != player.getId()) {
+            if (packet.getTargetRuntimeID() != player.runtimeId()) {
                 return;
             }
 
@@ -42,7 +42,7 @@ public class ActorEventHandler implements PacketHandler<ActorEventPacket> {
                 return;
             }
 
-            packet.setTargetRuntimeID(player.getId());
+            packet.setTargetRuntimeID(player.runtimeId());
             if (packet.getType().equals(ActorEvent.FEED)) {
                 packet.setData(predictedData);
             }

--- a/src/main/java/org/powernukkitx/network/process/handler/AnimateHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/AnimateHandler.java
@@ -44,7 +44,7 @@ public class AnimateHandler implements PacketHandler<AnimatePacket> {
 
         final AnimatePacket pk = new AnimatePacket();
         pk.setAction(animationEvent.getAnimationType());
-        pk.setTargetRuntimeID(player.getId());
+        pk.setTargetRuntimeID(player.runtimeId());
         pk.setData(animationEvent.getData());
         pk.setSwingSource(animationEvent.getSwingSource());
         Server.broadcastPacket(player.getViewers().values(), pk);

--- a/src/main/java/org/powernukkitx/network/process/handler/EmoteHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/EmoteHandler.java
@@ -22,8 +22,8 @@ public class EmoteHandler implements PacketHandler<EmotePacket> {
         if (!playerHandle.player.spawned) {
             return;
         }
-        if (packet.getActorRuntimeId() != playerHandle.player.getId()) {
-            log.warn("{} sent EmotePacket with invalid entity id: {} != {}", playerHandle.getUsername(), packet.getActorRuntimeId(), playerHandle.player.getId());
+        if (packet.getActorRuntimeId() != playerHandle.player.runtimeId()) {
+            log.warn("{} sent EmotePacket with invalid entity id: {} != {}", playerHandle.getUsername(), packet.getActorRuntimeId(), playerHandle.player.runtimeId());
             return;
         }
         if (!UUIDValidator.isValidUUID(packet.getEmoteId())) {

--- a/src/main/java/org/powernukkitx/network/process/handler/InteractHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/InteractHandler.java
@@ -72,7 +72,7 @@ public class InteractHandler implements PacketHandler<InteractPacket> {
                         boolean restricted = targetEntity.getComponentInventory().isRestrictedToOwner();
                         if (restricted && !player.getName().equals(targetEntity.getOwnerName())) return;
                     }
-                } else if (targetEntity.getId() != player.getId()) {
+                } else if (targetEntity.runtimeId() != player.runtimeId()) {
                     return;
                 }
                 if (!player.isInventoryOpen()) {

--- a/src/main/java/org/powernukkitx/network/process/handler/InventoryTransactionHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/InventoryTransactionHandler.java
@@ -206,7 +206,7 @@ public class InventoryTransactionHandler implements PacketHandler<InventoryTrans
             if (target instanceof Player && !player.getAdventureSettings().get(AdventureSettings.Type.ATTACK_PLAYERS)
                     || !(target instanceof Player) && !player.getAdventureSettings().get(AdventureSettings.Type.ATTACK_MOBS))
                 return;
-            if (target.getId() == player.getId()) {
+            if (target.runtimeId() == player.runtimeId()) {
                 PlayerHackDetectedEvent event = new PlayerHackDetectedEvent(player, PlayerHackDetectedEvent.HackType.INVALID_PVP);
                 player.getServer().getPluginManager().callEvent(event);
 

--- a/src/main/java/org/powernukkitx/network/process/handler/PlayerActionHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/PlayerActionHandler.java
@@ -35,7 +35,7 @@ public class PlayerActionHandler implements PacketHandler<PlayerActionPacket> {
             return;
         }
 
-        packet.setPlayerRuntimeID(player.getId());
+        packet.setPlayerRuntimeID(player.runtimeId());
         Vector3 pos = Vector3.fromNetwork(packet.getBlockPosition().toFloat());
         BlockFace face = BlockFace.fromIndex(packet.getFace());
 

--- a/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
@@ -297,7 +297,7 @@ public class PlayerAuthInputHandler implements PacketHandler<PlayerAuthInputPack
 
         Long clientPredictedVehicle = pk.getClientPredictedVehicle();
         if (clientPredictedVehicle == null || clientPredictedVehicle == 0L) return;
-        if (clientPredictedVehicle.longValue() != vehicle.getId()) return;
+        if (clientPredictedVehicle.longValue() != vehicle.runtimeId()) return;
 
         Vector3f pos = Vector3f.fromNetwork(pk.getPosition());
 

--- a/src/test/java/org/powernukkitx/dialog/DialogSmokeTest.java
+++ b/src/test/java/org/powernukkitx/dialog/DialogSmokeTest.java
@@ -63,7 +63,7 @@ public class DialogSmokeTest {
         Assertions.assertEquals("Title", dialog.getTitle());
         Assertions.assertEquals("Content", dialog.getContent());
         Assertions.assertSame(player, dialog.getBindEntity());
-        Assertions.assertEquals(player.getId(), dialog.getEntityId());
+        Assertions.assertEquals(player.runtimeId(), dialog.getEntityId());
         Assertions.assertNotNull(dialog.getSceneName());
         Assertions.assertNotNull(dialog.getSkinData());
         Assertions.assertTrue(dialog.getButtons().isEmpty());

--- a/src/test/java/org/powernukkitx/level/LevelDeepSmokeTest.java
+++ b/src/test/java/org/powernukkitx/level/LevelDeepSmokeTest.java
@@ -64,7 +64,7 @@ public class LevelDeepSmokeTest {
         safe(() -> level.getNearbyEntities(bb, entity));
         safe(() -> level.getNearbyEntitiesSafe(bb));
         if (entity != null) {
-            safe(() -> level.getEntity(entity.getId()));
+            safe(() -> level.getEntity(entity.runtimeId()));
             safe(() -> level.getChunkEntities(entity.getChunkX(), entity.getChunkZ()));
             safe(() -> level.removeEntity(entity));
             safe(() -> level.addEntity(entity));

--- a/src/test/java/org/powernukkitx/network/process/handler/PacketHandlerSmokeTest.java
+++ b/src/test/java/org/powernukkitx/network/process/handler/PacketHandlerSmokeTest.java
@@ -92,7 +92,7 @@ class PacketHandlerSmokeTest {
 
         safe(() -> {
             EmotePacket p = new EmotePacket();
-            p.setActorRuntimeId(player.getId());
+            p.setActorRuntimeId(player.runtimeId());
             p.setEmoteId(UUID.randomUUID().toString());
             dispatch(p);
         });
@@ -123,7 +123,7 @@ class PacketHandlerSmokeTest {
         safe(() -> {
             RespawnPacket p = new RespawnPacket();
             p.setState(PlayerRespawnState.CLIENT_READY_TO_SPAWN);
-            p.setPlayerRuntimeId(player.getId());
+            p.setPlayerRuntimeId(player.runtimeId());
             dispatch(p);
         });
 
@@ -145,7 +145,7 @@ class PacketHandlerSmokeTest {
         safe(() -> {
             ShowCreditsPacket p = new ShowCreditsPacket();
             p.setCreditsState(ShowCreditsPacket.CreditsState.END_CREDITS);
-            p.setPlayerRuntimeID(player.getId());
+            p.setPlayerRuntimeID(player.runtimeId());
             dispatch(p);
         });
 


### PR DESCRIPTION
## What does this PR do?

Refactor the Entity getId() to runtime().
Some of the usage of getId() was not migrated intentionally, as they are meant to be uniqueId, that will be implemented in the levelDBParity PR (coming next).

## Why?

Better naming aligned with the actual runtime Id, and getting the repo prepared for the implementation of the Entity uniqueId.

Closes #

## Type of change

<!-- Tick what applies. -->

- [ ] Bug Fix
- [ ] New Feature
- [ ] Performance
- [X] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** <!-- commit hash -->
- **Bedrock client version:** <!-- e.g. 1.21.x -->
- **Plugins loaded:** <!-- none / list them -->

**Steps performed and results:**

1.
2.

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [X] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
|       |             |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [ ] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
