### PR TITLE
fix: Fix block to item

### DIFF
--- a/src/main/java/org/powernukkitx/block/BlockChest.java
+++ b/src/main/java/org/powernukkitx/block/BlockChest.java
@@ -257,7 +257,7 @@ public class BlockChest extends BlockTransparent implements Faceable, BlockEntit
 
     @Override
     public Item toItem() {
-        return new ItemBlock(this, 0);
+        return new ItemBlock(new BlockChest(), 0);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/block/BlockComposter.java
+++ b/src/main/java/org/powernukkitx/block/BlockComposter.java
@@ -84,7 +84,7 @@ public class BlockComposter extends BlockSolid {
 
     @Override
     public Item toItem() {
-        return new ItemBlock(this, 0);
+        return new ItemBlock(new BlockComposter(), 0);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/block/BlockDaylightDetector.java
+++ b/src/main/java/org/powernukkitx/block/BlockDaylightDetector.java
@@ -67,7 +67,7 @@ public class BlockDaylightDetector extends BlockTransparent implements RedstoneC
 
     @Override
     public Item toItem() {
-        return new ItemBlock(this, 0);
+        return new ItemBlock(new BlockDaylightDetector(), 0);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/block/BlockEndPortalFrame.java
+++ b/src/main/java/org/powernukkitx/block/BlockEndPortalFrame.java
@@ -194,7 +194,7 @@ public class BlockEndPortalFrame extends BlockTransparent implements Faceable {
 
     @Override
     public Item toItem() {
-        return new ItemBlock(this, 0);
+        return new ItemBlock(new BlockEndPortalFrame(), 0);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/block/BlockEndRod.java
+++ b/src/main/java/org/powernukkitx/block/BlockEndRod.java
@@ -99,7 +99,7 @@ public class BlockEndRod extends BlockTransparent implements Faceable {
 
     @Override
     public Item toItem() {
-        return new ItemBlock(this, 0);
+        return new ItemBlock(new BlockEndPortalFrame(), 0);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/block/BlockEnderChest.java
+++ b/src/main/java/org/powernukkitx/block/BlockEnderChest.java
@@ -184,7 +184,7 @@ public class BlockEnderChest extends BlockTransparent implements Faceable, Block
 
     @Override
     public Item toItem() {
-        return new ItemBlock(this, 0);
+        return new ItemBlock(new BlockEnderChest(), 0);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/block/BlockIronBars.java
+++ b/src/main/java/org/powernukkitx/block/BlockIronBars.java
@@ -53,7 +53,7 @@ public class BlockIronBars extends BlockThin {
 
     @Override
     public Item toItem() {
-        return new ItemBlock(this, 0);
+        return new ItemBlock(new BlockIronBars(), 0);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/block/BlockJukebox.java
+++ b/src/main/java/org/powernukkitx/block/BlockJukebox.java
@@ -53,7 +53,7 @@ public class BlockJukebox extends BlockSolid implements BlockEntityHolder<BlockE
 
     @Override
     public Item toItem() {
-        return new ItemBlock(this, 0);
+        return new ItemBlock(new BlockJukebox(), 0);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/block/BlockLever.java
+++ b/src/main/java/org/powernukkitx/block/BlockLever.java
@@ -62,7 +62,7 @@ public class BlockLever extends BlockFlowable implements RedstoneComponent, Face
 
     @Override
     public Item toItem() {
-        return new ItemBlock(this, 0);
+        return new ItemBlock(new BlockLever(), 0);
     }
 
     public boolean isPowerOn() {

--- a/src/main/java/org/powernukkitx/block/BlockPumpkin.java
+++ b/src/main/java/org/powernukkitx/block/BlockPumpkin.java
@@ -53,7 +53,7 @@ public class BlockPumpkin extends BlockSolid implements Faceable, Natural {
 
     @Override
     public Item toItem() {
-        return new ItemBlock(this, 0);
+        return new ItemBlock(new BlockPumpkin(), 0);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/block/BlockRail.java
+++ b/src/main/java/org/powernukkitx/block/BlockRail.java
@@ -364,7 +364,7 @@ public class BlockRail extends BlockFlowable implements Faceable {
 
     @Override
     public Item toItem() {
-        return new ItemBlock(this, 0);
+        return new ItemBlock(new BlockRail(), 0);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/block/BlockTripwireHook.java
+++ b/src/main/java/org/powernukkitx/block/BlockTripwireHook.java
@@ -289,7 +289,7 @@ public class BlockTripwireHook extends BlockTransparent implements RedstoneCompo
 
     @Override
     public Item toItem() {
-        return new ItemBlock(this, 0);
+        return new ItemBlock(new BlockTripwireHook(), 0);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/block/BlockVine.java
+++ b/src/main/java/org/powernukkitx/block/BlockVine.java
@@ -179,7 +179,7 @@ public class BlockVine extends BlockTransparent {
 
     @Override
     public Item toItem() {
-        return new ItemBlock(this, 0);
+        return new ItemBlock(new BlockVine(), 0);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/block/BlockWaterlily.java
+++ b/src/main/java/org/powernukkitx/block/BlockWaterlily.java
@@ -90,7 +90,7 @@ public class BlockWaterlily extends BlockFlowable {
 
     @Override
     public Item toItem() {
-        return new ItemBlock(this, 0);
+        return new ItemBlock(new BlockWaterlily(), 0);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/block/copper/bars/BlockCopperBars.java
+++ b/src/main/java/org/powernukkitx/block/copper/bars/BlockCopperBars.java
@@ -60,7 +60,7 @@ public class BlockCopperBars extends BlockCopperBarBase implements BlockConnecta
 
     @Override
     public Item toItem() {
-        return new ItemBlock(this, 0);
+        return new ItemBlock(new BlockCopperBars(), 0);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/block/copper/chain/BlockCopperChain.java
+++ b/src/main/java/org/powernukkitx/block/copper/chain/BlockCopperChain.java
@@ -56,7 +56,7 @@ public class BlockCopperChain extends AbstractBlockCopperChain {
 
     @Override
     public Item toItem() {
-        return new ItemBlock(this, 0);
+        return new ItemBlock(new BlockCopperChain(), 0);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/block/copper/golem/BlockCopperGolemStatue.java
+++ b/src/main/java/org/powernukkitx/block/copper/golem/BlockCopperGolemStatue.java
@@ -41,7 +41,7 @@ public class BlockCopperGolemStatue extends AbstractBlockCopperGolemStatue {
 
     @Override
     public Item toItem() {
-        return new ItemBlock(this, 0);
+        return new ItemBlock(new BlockCopperGolemStatue(), 0);
     }
 
     public @NotNull OxidizationLevel getOxidizationLevel() {

--- a/src/main/java/org/powernukkitx/block/copper/lantern/BlockCopperLantern.java
+++ b/src/main/java/org/powernukkitx/block/copper/lantern/BlockCopperLantern.java
@@ -35,7 +35,7 @@ public class BlockCopperLantern extends AbstractBlockCopperLantern {
 
     @Override
     public Item toItem() {
-        return new ItemBlock(this, 0);
+        return new ItemBlock(new BlockCopperLantern(), 0);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/block/dispenser/BlockDispenser.java
+++ b/src/main/java/org/powernukkitx/block/dispenser/BlockDispenser.java
@@ -93,7 +93,7 @@ public class BlockDispenser extends BlockSolid implements RedstoneComponent, Fac
 
     @Override
     public Item toItem() {
-        return new ItemBlock(this, 0);
+        return new ItemBlock(new BlockDispenser(), 0);
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?

Fix block to item.

## Why?

When picking up or dropping item it was generating the block with the current definitions such as cardinal direction and other meta, making the item impossible to stack with others.

Closes #

## Type of change

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** <!-- commit hash -->
- **Bedrock client version:** <!-- e.g. 1.21.x -->
- **Plugins loaded:** <!-- none / list them -->

**Steps performed and results:**

1.
2.

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [X] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
|       |             |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [ ] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
