### PR TITLE
fix: register sessions and record packets for botnet detectio

### DIFF
--- a/src/main/java/org/powernukkitx/network/Network.java
+++ b/src/main/java/org/powernukkitx/network/Network.java
@@ -181,13 +181,20 @@ public class Network implements NetworkInterface {
                             new PlayerSessionHolder(
                                 session,
                                 Network.this.server.getSettings().networkSettings().rateLimitSettings()
-                            )
+                            ),
+                            Network.this.botnetDetector
                         ));
+                        if (Network.this.botnetDetector != null) {
+                            Network.this.botnetDetector.registerSession(address);
+                        }
                         final Channel sessionChannel = session.getPeer().getChannel();
                         Network.this.sessionMap.put(address, session);
                         sessionChannel.closeFuture().addListener(future -> {
                             if (!Network.this.sessionMap.remove(address, session)) {
                                 Network.this.sessionMap.values().remove(session);
+                            }
+                            if (Network.this.botnetDetector != null) {
+                                Network.this.botnetDetector.unregisterSession(address);
                             }
                         });
                     }

--- a/src/main/java/org/powernukkitx/network/process/NetworkPacketHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/NetworkPacketHandler.java
@@ -10,6 +10,9 @@ import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacketHandler;
 import org.cloudburstmc.protocol.common.PacketSignal;
 import org.jetbrains.annotations.Nullable;
+import org.powernukkitx.network.security.BotnetDetector;
+
+import java.net.InetSocketAddress;
 
 /**
  * @author Kaooot
@@ -20,9 +23,15 @@ public class NetworkPacketHandler implements BedrockPacketHandler {
 
     private final Server server;
     private final PlayerSessionHolder session;
+    private final @Nullable BotnetDetector botnetDetector;
 
     @Override
     public PacketSignal handlePacket(BedrockPacket packet) {
+        if (this.botnetDetector != null
+            && this.session.getSession().getSocketAddress() instanceof InetSocketAddress address) {
+            this.botnetDetector.recordPacket(address, packet.getPacketType().ordinal());
+        }
+
         if (!this.session.checkRateLimits()) {
             return PacketSignal.HANDLED;
         }

--- a/src/test/java/org/powernukkitx/network/security/BotnetDetectorTest.java
+++ b/src/test/java/org/powernukkitx/network/security/BotnetDetectorTest.java
@@ -1,13 +1,20 @@
 package org.powernukkitx.network.security;
 
+import org.cloudburstmc.protocol.bedrock.BedrockServerSession;
+import org.cloudburstmc.protocol.bedrock.packet.TextPacket;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.powernukkitx.Server;
+import org.powernukkitx.network.process.NetworkPacketHandler;
+import org.powernukkitx.network.process.PlayerSessionHolder;
 
 import java.net.InetSocketAddress;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link BotnetDetector}.
@@ -228,6 +235,18 @@ class BotnetDetectorTest {
     }
 
     @Test
+    void networkPacketHandlerFeedsDetector() {
+        InetSocketAddress a = addr("10.0.0.1", 1000);
+        InetSocketAddress b = addr("10.0.0.2", 1001);
+        InetSocketAddress c = addr("10.0.0.3", 1002);
+
+        floodViaHandler(a, b, c);
+
+        BotnetReport report = detector.tick().orElseThrow();
+        assertEquals(3, report.getFloodingSessions().size());
+    }
+
+    @Test
     void scoreReflectsNumberOfSignalsFired() {
         long base = fakeTime.get();
         floodAtTime(addr("192.168.1.1", 1000), 0x10, base);
@@ -274,6 +293,37 @@ class BotnetDetectorTest {
 
     private InetSocketAddress addr(String ip, int port) {
         return new InetSocketAddress(ip, port);
+    }
+
+    private void floodViaHandler(InetSocketAddress... addrs) {
+        long start = fakeTime.get();
+        NetworkPacketHandler[] handlers = new NetworkPacketHandler[addrs.length];
+        for (int i = 0; i < addrs.length; i++) {
+            detector.registerSession(addrs[i]);
+            handlers[i] = handlerFor(addrs[i]);
+        }
+
+        for (int i = 0; i < THRESHOLD + 1; i++) {
+            for (var handler : handlers) handler.handlePacket(new TextPacket());
+            fakeTime.addAndGet(1L);
+        }
+
+        fakeTime.set(start + 1_100L);
+        for (var handler : handlers) {
+            handler.handlePacket(new TextPacket());
+            fakeTime.addAndGet(1L);
+        }
+    }
+
+    private NetworkPacketHandler handlerFor(InetSocketAddress address) {
+        BedrockServerSession session = mock(BedrockServerSession.class);
+        when(session.getSocketAddress()).thenReturn(address);
+
+        PlayerSessionHolder holder = mock(PlayerSessionHolder.class);
+        when(holder.getSession()).thenReturn(session);
+        when(holder.checkRateLimits()).thenReturn(false);
+
+        return new NetworkPacketHandler(mock(Server.class), holder, detector);
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?

wire BotnetDetector into the network packet pipeline

## Why?

 The BotnetDetector was never receiving any packets, so the multi-IP flood detection never triggered in production.

## Type of change

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 48031b37e
- **Bedrock client version:** 26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. join the server

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|       |             |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
