### PR TITLE
fix: Command names overlapping

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -6963,21 +6963,25 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         synchronized (commands) {
             snapshot = new ArrayList<>(commands.values());
         }
+        final Set<Command> distinct = Collections.newSetFromMap(new IdentityHashMap<>());
         for (Command command : snapshot) {
             if (!command.testPermissionSilent(this.getPlayer()) || !command.isRegistered() || command.isServerSideOnly()) {
                 continue;
             }
+            if (!distinct.add(command)){
+                continue;
+            }
             ++count;
             CommandDataVersions data0 = command.generateCustomCommandData(this.getPlayer());
-            data.put(command.getName(), data0);
+            data.put(command.getLabel(), data0);
         }
         if (count > 0) {
             Map<String, CommandDataVersions> filtered = getStringCommandDataVersionsMap(data);
 
             if (!filtered.isEmpty()) {
                 final List<CommandData> commandData = new ObjectArrayList<>();
-                for (CommandDataVersions value : filtered.values()) {
-                    commandData.addAll(value.toNetwork());
+                for (Entry<String, CommandDataVersions> entry : filtered.entrySet()){
+                    commandData.addAll(entry.getValue().toNetwork(entry.getKey()));
                 }
 
                 pk.getCommands().addAll(commandData);

--- a/src/main/java/org/powernukkitx/command/Command.java
+++ b/src/main/java/org/powernukkitx/command/Command.java
@@ -188,7 +188,15 @@ public abstract class Command {
         NukkitCommandData customData = this.commandData.clone();
 
         if (getAliases().length > 0) {
-            List<String> aliases = new ArrayList<>(Arrays.asList(getAliases()));
+            final Map<String, Command> known = player.getServer().getCommandMap().getCommands();
+            List<String> aliases = new ArrayList<>();
+            for (String alias : getAliases()){
+                Command owner = known.get(alias.toLowerCase(Locale.ENGLISH));
+                if (owner != null && owner != this){
+                    continue;
+                }
+                aliases.add(alias);
+            }
             if (!aliases.contains(this.name)) {
                 aliases.add(this.name);
             }

--- a/src/main/java/org/powernukkitx/command/SimpleCommandMap.java
+++ b/src/main/java/org/powernukkitx/command/SimpleCommandMap.java
@@ -303,49 +303,16 @@ public class SimpleCommandMap implements CommandMap {
     private boolean registerAlias(Command command, boolean isAlias, String fallbackPrefix, String label) {
         this.knownCommands.put(fallbackPrefix + ":" + label, command);
 
-        //if you're registering a command alias that is already registered, then return false
-        boolean alreadyRegistered = this.knownCommands.containsKey(label);
         Command existingCommand = this.knownCommands.get(label);
-        boolean existingCommandIsNotVanilla = alreadyRegistered && !(existingCommand instanceof VanillaCommand);
-        //basically, if we're an alias, and it's already registered, or we're a vanilla command, then we can't override it
-        if ((command instanceof VanillaCommand || isAlias) && alreadyRegistered && existingCommandIsNotVanilla) {
+        if (existingCommand != null && existingCommand != command) {
             return false;
         }
-
-        //if you're registering a name (alias or label) which is identical to another command who's primary name is the same
-        //so basically we can't override the main name of a command, but we can override aliases if we're not an alias
-
-        //added the last statement which will allow us to override a VanillaCommand unconditionally
-        if (alreadyRegistered && existingCommand.getLabel() != null && existingCommand.getLabel().equals(label) && existingCommandIsNotVanilla) {
-            return false;
-        }
-
-        //you can now assume that the command is either uniquely named, or overriding another command's alias (and is not itself, an alias)
 
         if (!isAlias) {
             command.setLabel(label);
         }
 
-        // Then we need to check if there isn't any command conflicts with vanilla commands
-        ArrayList<String> toRemove = new ArrayList<>();
-
-        for (Entry<String, Command> entry : knownCommands.entrySet()) {
-            Command cmd = entry.getValue();
-            if (cmd.getLabel().equalsIgnoreCase(command.getLabel()) && !cmd.equals(command)) { // If the new command conflicts... (But if it isn't the same command)
-                if (cmd instanceof VanillaCommand) { // And if the old command is a vanilla command...
-                    // Remove it!
-                    toRemove.add(entry.getKey());
-                }
-            }
-        }
-
-        // Now we loop the toRemove list to remove the command conflicts from the knownCommands map
-        for (String cmd : toRemove) {
-            knownCommands.remove(cmd);
-        }
-
         this.knownCommands.put(label, command);
-
         return true;
     }
 

--- a/src/main/java/org/powernukkitx/command/data/CommandDataVersions.java
+++ b/src/main/java/org/powernukkitx/command/data/CommandDataVersions.java
@@ -41,9 +41,13 @@ public class CommandDataVersions {
     public List<NukkitCommandData> versions = new ArrayList<>();
 
     public List<CommandData> toNetwork() {
+       return toNetwork(null);
+    }
+
+    public List<CommandData> toNetwork(String nameOverride) {
         final List<CommandData> list = new ObjectArrayList<>();
         for (NukkitCommandData version : this.versions) {
-            list.add(version.toNetwork());
+            list.add(nameOverride == null ? version.toNetwork() : version.toNetwork(nameOverride));
         }
         return list;
     }

--- a/src/main/java/org/powernukkitx/command/data/NukkitCommandData.java
+++ b/src/main/java/org/powernukkitx/command/data/NukkitCommandData.java
@@ -195,6 +195,10 @@ public class NukkitCommandData implements Cloneable {
     }
 
     public CommandData toNetwork() {
+        return toNetwork(this.name);
+    }
+
+    public CommandData toNetwork(String name) {
         final Set<CommandData.Flag> flags = new ObjectOpenHashSet<>();
         for (Flag flag : this.flags) {
             flags.add(CommandData.Flag.valueOf(flag.name()));
@@ -220,7 +224,7 @@ public class NukkitCommandData implements Cloneable {
             }
         }
         return new CommandData(
-                this.name,
+                name,
                 this.description,
                 flags,
                 this.permission,


### PR DESCRIPTION
## What does this PR do?

Fix when you have 2 same command the plugin command is <pluginName:command>

## Why?

bug fix

## Type of change

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** b7e640b
- **Bedrock client version:** 26.45
- **Plugins loaded:** Custom Plugin

**Steps performed and results:**

1. join the server with a plugin that registers a command whose name collides with a vanilla command
2. look the client command list

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|       |             |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x]  This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
