### PR TITLE
feat: Allow custom groups during onLoad and auto-register after plugin loading

### DIFF
--- a/src/main/java/org/powernukkitx/Server.java
+++ b/src/main/java/org/powernukkitx/Server.java
@@ -104,6 +104,7 @@ import org.powernukkitx.plugin.service.NKServiceManager;
 import org.powernukkitx.plugin.service.ServiceManager;
 import org.powernukkitx.network.positiontracking.PositionTrackingService;
 import org.powernukkitx.recipe.Recipe;
+import org.powernukkitx.registry.CreativeGroupsRegistry;
 import org.powernukkitx.registry.RecipeRegistry;
 import org.powernukkitx.registry.Registries;
 import org.powernukkitx.registry.RegistryCache;
@@ -672,6 +673,8 @@ public class Server {
 
         if (settings.gameplaySettings().enableEducation()) Education.registerCreative();
 
+        CreativeGroupsRegistry.register();
+
         if (settings.miscSettings().installSpark()) {
             SparkInstaller.initSpark(this);
         }
@@ -857,6 +860,7 @@ public class Server {
             Registries.RECIPE.trim();
         }
         this.enablePlugins(PluginLoadOrder.POSTWORLD);
+        CreativeGroupsRegistry.register();
         this.network.setState(NetworkState.STARTED);
     }
 

--- a/src/main/java/org/powernukkitx/registry/CreativeGroupsRegistry.java
+++ b/src/main/java/org/powernukkitx/registry/CreativeGroupsRegistry.java
@@ -20,21 +20,19 @@ import java.util.Map;
  */
 @Slf4j
 public class CreativeGroupsRegistry {
-    private static final ObjectLinkedOpenHashSet<CreativeGroupInfoPayload> INJECTED_GROUPS = new ObjectLinkedOpenHashSet<>();
+    private static final ObjectLinkedOpenHashSet<CreativeCustomGroups.CustomGroupDefinition> PENDING_DEFINITIONS = new ObjectLinkedOpenHashSet<>();
 
     /**
-     * Registers a new custom creative group. If this is the first group being registered,
-     * triggers the injection process into the existing creative registry.
+     * Stages a custom creative group for later registration.
+     * This only records the definition (group name, category and icon ID); nothing is injected
+     * into the creative registry and the icon is <b>not</b> resolved yet. The actual finalization
+     * happens in {@link #register()}, which PNX invokes automatically after all plugins (and their
+     * custom items/blocks) have been loaded. Plugins should therefore not call {@link #register()}
+     * manually.
      */
     public static void load(CreativeCustomGroups.CustomGroupDefinition def) {
         if (!isValid(def)) return;
-
-        Item icon = resolveIcon(def);
-        CreativeGroupInfoPayload group = new CreativeGroupInfoPayload();
-        group.setCreativeCategory(def.getCategory());
-        group.setName(def.getName());
-        group.setGroupIconItem(icon.toNetwork());
-        INJECTED_GROUPS.add(group);
+        PENDING_DEFINITIONS.add(def);
     }
 
     private static boolean isValid(CreativeCustomGroups.CustomGroupDefinition def) {
@@ -54,16 +52,21 @@ public class CreativeGroupsRegistry {
     }
 
     /**
-     * Injects all registered custom groups into the group index map and runtime list.
+     * Finalizes all staged custom groups and injects them into the group index map and runtime list.
+     * Icons are resolved here (not when the group is staged in {@link #load(CreativeCustomGroups.CustomGroupDefinition)}),
+     * so an icon referencing a custom item is resolved correctly once every custom item/block is loaded.
+     * PNX calls this automatically after plugin loading; plugins should not call it manually.
      */
     public static void register() {
-        if (INJECTED_GROUPS.isEmpty()) return;
+        if (PENDING_DEFINITIONS.isEmpty()) return;
+
+        List<CreativeGroupInfoPayload> injected = buildStagedGroups();
 
         List<CreativeGroupInfoPayload> allOriginalGroups = new ArrayList<>(Registries.CREATIVE.getGroupList());
         Map<CreativeGroupInfoPayload, Integer> originalGroupIndices = extractOriginalGroupIndices(allOriginalGroups);
 
         Map<CreativeCategory, List<CreativeGroupInfoPayload>> groupedVanilla = groupByCategory(allOriginalGroups);
-        Map<CreativeCategory, List<CreativeGroupInfoPayload>> groupedCustom = groupByCategory(new ArrayList<>(INJECTED_GROUPS));
+        Map<CreativeCategory, List<CreativeGroupInfoPayload>> groupedCustom = groupByCategory(injected);
 
         Map<Integer, Integer> groupIndexMap = new HashMap<>();
         List<CreativeGroupInfoPayload> rebuilt = rebuildGroupsAndRemap(groupedVanilla, groupedCustom, originalGroupIndices, groupIndexMap);
@@ -72,7 +75,24 @@ public class CreativeGroupsRegistry {
         Registries.CREATIVE.getGroupList().addAll(rebuilt);
 
         remapCreativeItemGroups(groupIndexMap);
-        INJECTED_GROUPS.clear();
+        PENDING_DEFINITIONS.clear();
+    }
+
+    /**
+     * Builds the {@link CreativeGroupInfoPayload} for every staged definition, resolving each icon now
+     * that all custom items/blocks are loaded.
+     */
+    private static List<CreativeGroupInfoPayload> buildStagedGroups() {
+        List<CreativeGroupInfoPayload> injected = new ArrayList<>();
+        for (CreativeCustomGroups.CustomGroupDefinition def : PENDING_DEFINITIONS) {
+            Item icon = resolveIcon(def);
+            CreativeGroupInfoPayload group = new CreativeGroupInfoPayload();
+            group.setCreativeCategory(def.getCategory());
+            group.setName(def.getName());
+            group.setGroupIconItem(icon.toNetwork());
+            injected.add(group);
+        }
+        return injected;
     }
 
     private static Map<CreativeGroupInfoPayload, Integer> extractOriginalGroupIndices(List<CreativeGroupInfoPayload> allGroups) {

--- a/src/main/java/org/powernukkitx/registry/CreativeGroupsRegistry.java
+++ b/src/main/java/org/powernukkitx/registry/CreativeGroupsRegistry.java
@@ -57,6 +57,8 @@ public class CreativeGroupsRegistry {
      * Injects all registered custom groups into the group index map and runtime list.
      */
     public static void register() {
+        if (INJECTED_GROUPS.isEmpty()) return;
+
         List<CreativeGroupInfoPayload> allOriginalGroups = new ArrayList<>(Registries.CREATIVE.getGroupList());
         Map<CreativeGroupInfoPayload, Integer> originalGroupIndices = extractOriginalGroupIndices(allOriginalGroups);
 
@@ -70,6 +72,7 @@ public class CreativeGroupsRegistry {
         Registries.CREATIVE.getGroupList().addAll(rebuilt);
 
         remapCreativeItemGroups(groupIndexMap);
+        INJECTED_GROUPS.clear();
     }
 
     private static Map<CreativeGroupInfoPayload, Integer> extractOriginalGroupIndices(List<CreativeGroupInfoPayload> allGroups) {
@@ -151,17 +154,13 @@ public class CreativeGroupsRegistry {
         for (CreativeItemEntryPayload data : current) {
             Item item = Item.fromNetwork(data.getItemInstance());
             int originalGroupId = data.getGroupIndex();
-            int newGroupId = CreativeItemRegistry.LAST_ITEMS_INDEX;
+            int newGroupId;
 
             String originalId = data.getItemInstance().getDefinition().getIdentifier();
-            String rebuiltId = item.getItemDefinition().getIdentifier();
 
-            // Vanilla item: remap based on old group index
-            if (!isCategoryFallbackIndex(originalGroupId)) {
+            if (!CreativeItemRegistry.CUSTOM_ITEM_IDENTIFIERS.contains(originalId)){
                 Integer mapped = groupIndexMap.get(originalGroupId);
-                if (mapped != null) {
-                    newGroupId = mapped;
-                }
+                newGroupId = (mapped != null) ? mapped : originalGroupId;
             } else {
                 // Custom item: use mapped group names from ITEM_GROUP_MAP saved on item/block registry
                 String key = originalId;
@@ -221,13 +220,6 @@ public class CreativeGroupsRegistry {
         current.clear();
         current.addAll(rebuilt);
         CreativeItemRegistry.ITEM_GROUP_MAP.clear();
-    }
-
-    private static boolean isCategoryFallbackIndex(int groupId) {
-        return groupId == CreativeItemRegistry.LAST_CONSTRUCTION_INDEX
-            || groupId == CreativeItemRegistry.LAST_EQUIPMENTS_INDEX
-            || groupId == CreativeItemRegistry.LAST_ITEMS_INDEX
-            || groupId == CreativeItemRegistry.LAST_NATURE_INDEX;
     }
 
     public static CreativeCategory getCategoryFromFallbackIndex(int groupId) {

--- a/src/main/java/org/powernukkitx/registry/CreativeItemRegistry.java
+++ b/src/main/java/org/powernukkitx/registry/CreativeItemRegistry.java
@@ -31,8 +31,10 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
@@ -51,6 +53,7 @@ public class CreativeItemRegistry implements ItemID, IRegistry<Integer, Item, It
     static final ObjectLinkedOpenHashSet<CreativeGroupInfoPayload> GROUPS = new ObjectLinkedOpenHashSet<>();
     public static final ObjectLinkedOpenHashSet<CreativeItemEntryPayload> ITEM_DATA = new ObjectLinkedOpenHashSet<>();
     public static final Map<String, String> ITEM_GROUP_MAP = new HashMap<>();
+    public static final Set<String> CUSTOM_ITEM_IDENTIFIERS = new HashSet<>();
     static final Map<CreativeCategory, Map<String, Integer>> CATEGORY_GROUP_INDEX_MAP = new HashMap<>();
     private static final Map<String, BlockState> ITEM_BLOCK_STATES = new HashMap<>();
 
@@ -196,6 +199,7 @@ public class CreativeItemRegistry implements ItemID, IRegistry<Integer, Item, It
         if (!enabled) return;
         int i = MAP.lastIntKey();
         try {
+            CUSTOM_ITEM_IDENTIFIERS.add(item.getItemDefinition().getIdentifier());
             this.register(i + 1, item.clone());
         } catch (RegisterException e) {
             throw new RuntimeException(e);
@@ -209,6 +213,7 @@ public class CreativeItemRegistry implements ItemID, IRegistry<Integer, Item, It
         if (!enabled) return;
         int i = MAP.isEmpty() ? 0 : MAP.lastIntKey() + 1;
         try {
+            CUSTOM_ITEM_IDENTIFIERS.add(item.getItemDefinition().getIdentifier());
             this.register(i, item.clone(), groupIndex);
         } catch (RegisterException e) {
             throw new RuntimeException(e);
@@ -396,6 +401,7 @@ public class CreativeItemRegistry implements ItemID, IRegistry<Integer, Item, It
         MAP.clear();
         INTERNAL_DIFF_ITEM.clear();
         ITEM_BLOCK_STATES.clear();
+        CUSTOM_ITEM_IDENTIFIERS.clear();
         if (enabled) {
             init();
         } else {

--- a/src/test/java/org/powernukkitx/registry/CreativeGroupsRegistryTest.java
+++ b/src/test/java/org/powernukkitx/registry/CreativeGroupsRegistryTest.java
@@ -1,0 +1,203 @@
+package org.powernukkitx.registry;
+
+import org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition;
+import org.cloudburstmc.protocol.bedrock.data.definitions.SimpleItemDefinition;
+import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
+import org.cloudburstmc.protocol.bedrock.data.inventory.ItemVersion;
+import org.cloudburstmc.protocol.bedrock.data.payload.creative.CreativeGroupInfoPayload;
+import org.cloudburstmc.protocol.bedrock.data.payload.creative.CreativeItemCategory;
+import org.cloudburstmc.protocol.bedrock.data.payload.creative.CreativeItemEntryPayload;
+import org.cloudburstmc.protocol.bedrock.data.payload.creative.CreativeItemNetId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.powernukkitx.ServerMockFixture;
+import org.powernukkitx.item.customitem.data.CreativeCategory;
+import org.powernukkitx.network.protocol.types.inventory.creative.CreativeCustomGroups;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class CreativeGroupsRegistryTest {
+
+    private static final String GROUP_NAME = "itemGroup.name.test_backrooms_blocks";
+    private static final int CUSTOM_BLOCK_COUNT = 35;
+
+    private static List<CreativeGroupInfoPayload> groupsSnapshot;
+    private static List<CreativeItemEntryPayload> itemDataSnapshot;
+    private static Map<CreativeCategory, Map<String, Integer>> categoryIndexSnapshot;
+    private static Map<String, String> itemGroupSnapshot;
+    private static HashSet<String> customIdentifiersSnapshot;
+
+    @BeforeAll
+    static void boot() {
+        ServerMockFixture.boot();
+        Registries.ITEM.init();
+        Registries.CREATIVE.init();
+    }
+
+    @BeforeEach
+    void snapshot() {
+        groupsSnapshot = new ArrayList<>(CreativeItemRegistry.GROUPS);
+        itemDataSnapshot = new ArrayList<>(CreativeItemRegistry.ITEM_DATA);
+        categoryIndexSnapshot = new HashMap<>();
+        for (var e : CreativeItemRegistry.CATEGORY_GROUP_INDEX_MAP.entrySet()) {
+            categoryIndexSnapshot.put(e.getKey(), new HashMap<>(e.getValue()));
+        }
+        itemGroupSnapshot = new HashMap<>(CreativeItemRegistry.ITEM_GROUP_MAP);
+        customIdentifiersSnapshot = new HashSet<>(CreativeItemRegistry.CUSTOM_ITEM_IDENTIFIERS);
+    }
+
+    @AfterEach
+    void restore() {
+        CreativeItemRegistry.GROUPS.clear();
+        CreativeItemRegistry.GROUPS.addAll(groupsSnapshot);
+
+        CreativeItemRegistry.ITEM_DATA.clear();
+        CreativeItemRegistry.ITEM_DATA.addAll(itemDataSnapshot);
+
+        CreativeItemRegistry.CATEGORY_GROUP_INDEX_MAP.clear();
+        CreativeItemRegistry.CATEGORY_GROUP_INDEX_MAP.putAll(categoryIndexSnapshot);
+
+        CreativeItemRegistry.ITEM_GROUP_MAP.clear();
+        CreativeItemRegistry.ITEM_GROUP_MAP.putAll(itemGroupSnapshot);
+
+        CreativeItemRegistry.CUSTOM_ITEM_IDENTIFIERS.clear();
+        CreativeItemRegistry.CUSTOM_ITEM_IDENTIFIERS.addAll(customIdentifiersSnapshot);
+    }
+
+    private static void addCustomBlock(String id) {
+        CreativeItemRegistry.CUSTOM_ITEM_IDENTIFIERS.add(id);
+        CreativeItemRegistry.ITEM_GROUP_MAP.put(id, GROUP_NAME);
+
+        ItemDefinition def = new SimpleItemDefinition(id, 40000 + CreativeItemRegistry.ITEM_DATA.size(),
+            ItemVersion.NONE, false, null);
+        ItemData data = ItemData.builder().definition(def).damage(0).count(1).build();
+
+        CreativeItemEntryPayload payload = new CreativeItemEntryPayload();
+        payload.setCreativeNetId(new CreativeItemNetId(CreativeItemRegistry.ITEM_DATA.size()));
+        payload.setItemInstance(data);
+        payload.setGroupIndex(CreativeItemRegistry.LAST_CONSTRUCTION_INDEX);
+        CreativeItemRegistry.ITEM_DATA.add(payload);
+    }
+
+    private static int countAtGroup(int groupIndex) {
+        int n = 0;
+        for (CreativeItemEntryPayload data : CreativeItemRegistry.ITEM_DATA) {
+            if (data.getGroupIndex() == groupIndex) n++;
+        }
+        return n;
+    }
+
+    private static String iconId() {
+        return CreativeItemRegistry.ITEM_DATA.iterator().next()
+            .getItemInstance().getDefinition().getIdentifier();
+    }
+
+    @Test
+    void customGroupBuiltAndPopulatedWithoutManualRegister() {
+        int totalBefore = CreativeItemRegistry.ITEM_DATA.size();
+
+        List<String> vanillaTailIds = new ArrayList<>();
+        for (CreativeItemEntryPayload data : CreativeItemRegistry.ITEM_DATA) {
+            String id = data.getItemInstance().getDefinition().getIdentifier();
+            if (data.getGroupIndex() == CreativeItemRegistry.LAST_CONSTRUCTION_INDEX
+                && !CreativeItemRegistry.CUSTOM_ITEM_IDENTIFIERS.contains(id)) {
+                vanillaTailIds.add(id);
+            }
+        }
+
+        CreativeCustomGroups.define(CreativeItemCategory.CONSTRUCTION, GROUP_NAME, iconId());
+        List<String> customIds = new ArrayList<>();
+        for (int i = 0; i < CUSTOM_BLOCK_COUNT; i++) {
+            String id = "test:backrooms_" + i;
+            customIds.add(id);
+            addCustomBlock(id);
+        }
+
+        CreativeGroupsRegistry.register();
+
+        Integer customIdx = CreativeItemRegistry.CATEGORY_GROUP_INDEX_MAP
+            .getOrDefault(CreativeCategory.CONSTRUCTION, Map.of()).get(GROUP_NAME);
+        assertNotNull(customIdx, "custom group should be registered in the construction index map");
+
+        assertEquals(CUSTOM_BLOCK_COUNT, countAtGroup(customIdx),
+            "custom group must contain exactly the plugin's blocks");
+
+        Map<String, Integer> byId = new HashMap<>();
+        for (CreativeItemEntryPayload data : CreativeItemRegistry.ITEM_DATA) {
+            byId.put(data.getItemInstance().getDefinition().getIdentifier(), data.getGroupIndex());
+        }
+        for (String id : customIds) {
+            assertEquals(customIdx, byId.get(id), "custom block " + id + " should be in the custom group");
+        }
+
+        for (String id : vanillaTailIds) {
+            assertNotEquals(customIdx, byId.get(id),
+                "vanilla tail item " + id + " must not land in the injected custom group");
+        }
+
+        assertEquals(totalBefore + CUSTOM_BLOCK_COUNT, CreativeItemRegistry.ITEM_DATA.size());
+    }
+
+    @Test
+    void vanillaTailItemIgnoresStaleGroupName() {
+        String victim = null;
+        for (CreativeItemEntryPayload data : CreativeItemRegistry.ITEM_DATA) {
+            String id = data.getItemInstance().getDefinition().getIdentifier();
+            if (data.getGroupIndex() == CreativeItemRegistry.LAST_CONSTRUCTION_INDEX
+                && !CreativeItemRegistry.CUSTOM_ITEM_IDENTIFIERS.contains(id)) {
+                victim = id;
+                break;
+            }
+        }
+        assertNotNull(victim, "expected at least one vanilla construction-tail item in the dataset");
+
+        CreativeCustomGroups.define(CreativeItemCategory.CONSTRUCTION, GROUP_NAME, iconId());
+        addCustomBlock("test:backrooms_probe");
+        CreativeItemRegistry.ITEM_GROUP_MAP.put(victim, GROUP_NAME);
+
+        CreativeGroupsRegistry.register();
+
+        Integer customIdx = CreativeItemRegistry.CATEGORY_GROUP_INDEX_MAP
+            .getOrDefault(CreativeCategory.CONSTRUCTION, Map.of()).get(GROUP_NAME);
+        assertNotNull(customIdx);
+
+        Integer victimIdx = null;
+        for (CreativeItemEntryPayload data : CreativeItemRegistry.ITEM_DATA) {
+            if (victim.equals(data.getItemInstance().getDefinition().getIdentifier())) {
+                victimIdx = data.getGroupIndex();
+                break;
+            }
+        }
+        assertNotEquals(customIdx, victimIdx,
+            "vanilla tail item must not be pulled into the custom group by a stale group name");
+    }
+
+    @Test
+    void registerIsIdempotent() {
+        CreativeCustomGroups.define(CreativeItemCategory.CONSTRUCTION, GROUP_NAME, iconId());
+        addCustomBlock("test:backrooms_idem");
+
+        CreativeGroupsRegistry.register();
+        int groupsAfterFirst = CreativeItemRegistry.GROUPS.size();
+        int itemsAfterFirst = CreativeItemRegistry.ITEM_DATA.size();
+        Integer idxAfterFirst = CreativeItemRegistry.CATEGORY_GROUP_INDEX_MAP
+            .getOrDefault(CreativeCategory.CONSTRUCTION, Map.of()).get(GROUP_NAME);
+
+        CreativeGroupsRegistry.register();
+
+        assertEquals(groupsAfterFirst, CreativeItemRegistry.GROUPS.size(), "no duplicate group on re-register");
+        assertEquals(itemsAfterFirst, CreativeItemRegistry.ITEM_DATA.size(), "item count stable on re-register");
+        assertEquals(idxAfterFirst, CreativeItemRegistry.CATEGORY_GROUP_INDEX_MAP
+            .getOrDefault(CreativeCategory.CONSTRUCTION, Map.of()).get(GROUP_NAME), "custom group index stable");
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Custom creative groups defined by plugins are now built into the group index at the end of plugin load and vanilla items in a category's tail (wildcard) group are shifted correctly when a custom group is inserted

## Why?

Close #3113 

## Type of change

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** e474f10
- **Bedrock client version:** 26.45
- **Plugins loaded:** none

**Steps performed and results:**

1.
2.

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [X] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

CreativeGroupsRegistry.register() is now called automatically by PNX after all plugins are loaded (POSTWORLD). Plugins no longer need to call CreativeGroupsRegistry.register() manually doing so is no longer required.

Additionally, CreativeCustomGroups.define() / CreativeGroupsRegistry.load() now only stage a group definition (name, category, icon ID). The group icon is resolved later, during the final register(), once all custom items/blocks are loaded, so an icon pointing at a custom item now resolves correctly instead of falling back to minecraft:stone.

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|   Opus 4.8    |    for test file, javadoc  and somes messages      |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
