### PR TITLE
fix: remove nested keys in ConfigSection#remove

### DIFF
--- a/src/main/java/org/powernukkitx/level/generator/object/BlockManager.java
+++ b/src/main/java/org/powernukkitx/level/generator/object/BlockManager.java
@@ -21,6 +21,7 @@ import org.powernukkitx.utils.RuntimeBlockDefinition;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.protocol.bedrock.data.ActorBlockSyncMessageId;
 import org.cloudburstmc.protocol.bedrock.data.BlockChangeEntry;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateSubChunkBlocksPacket;
@@ -333,9 +334,7 @@ public class BlockManager {
                 }
                 UpdateSubChunkBlocksPacket batch = batchs.computeIfAbsent(new SubChunkEntry(b.getChunkX() << 4, (b.getFloorY() >> 4) << 4, b.getChunkZ() << 4), s -> {
                     final UpdateSubChunkBlocksPacket packet = new UpdateSubChunkBlocksPacket();
-                    packet.setChunkX(s.x);
-                    packet.setChunkY(s.y);
-                    packet.setChunkZ(s.z);
+                    packet.setSubChunkBlockPosition(Vector3i.from(s.x, s.y, s.z));
                     return packet;
                 });
                 if (b.layer == 1) {

--- a/src/main/java/org/powernukkitx/utils/ConfigSection.java
+++ b/src/main/java/org/powernukkitx/utils/ConfigSection.java
@@ -738,7 +738,7 @@ public class ConfigSection extends LinkedHashMap<String, Object> {
     public void remove(String key) {
         if (key == null || key.isEmpty()) return;
         if (super.containsKey(key)) super.remove(key);
-        else if (this.containsKey(".")) {
+        else if (key.contains(".")) {
             String[] keys = key.split("\\.", 2);
             if (super.get(keys[0]) instanceof ConfigSection) {
                 ConfigSection section = (ConfigSection) super.get(keys[0]);

--- a/src/test/java/org/powernukkitx/utils/ConfigTest.java
+++ b/src/test/java/org/powernukkitx/utils/ConfigTest.java
@@ -13,4 +13,15 @@ public class ConfigTest {
         config.load(resourceAsStream);
         Assertions.assertEquals(20, config.getSection("opSlots").getInt("slotsCount"));
     }
+
+    @Test
+    void test_removeNestedKey() {
+        Config config = new Config(Config.YAML);
+        config.set("first.second", "value");
+        Assertions.assertTrue(config.exists("first.second"));
+
+        config.remove("first.second");
+        Assertions.assertFalse(config.exists("first.second"));
+        Assertions.assertTrue(config.exists("first"));
+    }
 }


### PR DESCRIPTION
## What does this PR do?

Makes `ConfigSection#remove` work with dotted keys. `config.remove("first.second")` did nothing before, now it deletes the key.

Also carries a build fix for `BlockManager`, see below.

## Why?

The nested branch was guarded by `this.containsKey(".")`, which asks whether the section has a key literally named `.`. It never does, so the branch was dead and every dotted remove silently did nothing. No exception either, so you only notice when the key is still in the file after saving. The guard should be `key.contains(".")`, same as what `get` and `set` already do.

The second commit is unrelated and only here because `stable` does not compile right now. `bedrock-codec` `3.0.0.Beta7-Debug-SNAPSHOT` swapped `UpdateSubChunkBlocksPacket.setChunkX/Y/Z(int)` for `setSubChunkBlockPosition(Vector3i)` under the same version string, so `BlockManager` stopped building against a freshly resolved snapshot. Anyone with an older jar in their Gradle cache will not have seen it yet. Happy to split it out if you would rather have it on its own.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 1c16b50b6
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. Added `ConfigTest#test_removeNestedKey`, which sets `first.second`, removes it, and checks the parent section survives. Reverted the one line fix and ran it again: FAILED, `first.second` still present. Put the fix back: PASSED.
2. Ran the full suite with `gradlew test` against the current codec snapshot. BUILD SUCCESSFUL, 1035 tests, no failures. Before the `BlockManager` commit the same command died in `compileJava` with three `cannot find symbol` errors on lines 336 to 338.
3. Started the server, edited a nested value through a config, removed it with a dotted key and saved. The key is gone from the yml on disk and the sibling keys under `first` are untouched. Block updates still show up client side, which is what `BlockManager` feeds.

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [x] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None. `ConfigSection#remove` keeps its signature, and the only behaviour that changes is the case that used to be a silent no-op. Anything relying on a dotted remove doing nothing was already broken. `BlockManager` is internal and the packet now carries the same three coordinates in one `Vector3i`.

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| Claude Opus 5 | Wrote `ConfigTest#test_removeNestedKey` |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
