### PR TITLE
feat: pull hooked entities toward the owner when reeling in

### DIFF
--- a/src/main/java/org/powernukkitx/entity/item/EntityFishingHook.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityFishingHook.java
@@ -272,13 +272,28 @@ public class EntityFishingHook extends SlenderProjectile {
                 }
             }
         } else if (this.shootingEntity != null) {
-            var eid = this.getDataProperty(ActorDataTypes.TARGET, 0L);
-            var targetEntity = this.getLevel().getEntity(eid);
-            if (eid != 0L && targetEntity != null && targetEntity.isAlive()) {
-                targetEntity.setMotion(this.shootingEntity.subtract(targetEntity).divide(8).add(0, 0.3, 0));
+            long eid = this.getDataProperty(ActorDataTypes.TARGET, 0L);
+            if (eid != 0L) {
+                Entity targetEntity = this.getLevel().getEntity(eid);
+                if (targetEntity != null && targetEntity.isAlive()) {
+                    this.pullEntity(targetEntity);
+                }
             }
         }
         this.close();
+    }
+
+    private void pullEntity(Entity target) {
+        double dx = this.shootingEntity.x - target.x;
+        double dy = (this.shootingEntity.y + 1.0) - target.y;
+        double dz = this.shootingEntity.z - target.z;
+        double distSq = dx * dx + dy * dy + dz * dz;
+
+        target.setMotion(new Vector3(
+                dx * 0.1,
+                Math.sqrt(Math.sqrt(distSq * 0.01) * 0.08) + dy * 0.1,
+                dz * 0.1
+        ));
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?

It pull the hooked entity toward the owner when the line is reeled in.

## Why?

It match vanilla behaviour.

Since #3094 the hook correctly attach to the entity it hit (`setTarget` was writing to `OWNER` instead of `TARGET`, so the pull branch in `reelLine()` was never reached).
Now that the target is actually set, the pull itself was still wrong: the old code was `shootingEntity.subtract(target).divide(8).add(0, 0.3, 0)`, which is a made up formula, the vertical part is a flat 0.3 no matter the distance.

Vanilla does:

dx = owner.x - entity.x
dy = (owner.y + 1.0) - entity.y
dz = owner.z - entity.z

motion.x = dx * 0.1
motion.y = sqrt(sqrt((dx² + dy² + dz²) * 0.01) * 0.08) + dy * 0.1
motion.z = dz * 0.1

So the pull is now horizontal * 0.1 and the vertical part scale with the distance, and it aim 1 block above the owner feet like vanilla do.

## Type of change

<!-- Tick what applies. -->

- [ ] Bug Fix
- [x] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 
- **Bedrock client version:** 26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. joined
2. hooked a cow with the fishing rod
3. right clicked again to reel in, the cow got pulled to me
4. did the same on a second player, he got pulled too
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|    claude fable 5.1   |   wrote that pr          |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled