### PR TITLE
fix: allow critical hits while sprinting

### DIFF
--- a/src/main/java/org/powernukkitx/entity/Entity.java
+++ b/src/main/java/org/powernukkitx/entity/Entity.java
@@ -1551,7 +1551,6 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
     protected boolean canCriticalHit(Player player) {
         return player.fallDistance < 0
                 && !player.isOnGround()
-                && !player.isSprinting()
                 && !player.isSwimming()
                 && !player.isGliding()
                 && !player.isTouchingWater()


### PR DESCRIPTION
## What does this PR do?

It allow critical hits while sprinting.

## Why?

It match vanilla behaviour.

`canCriticalHit` in `Entity.java` was denying the critical when the player is sprinting. That is the Java Edition rule, where sprinting cancels the crit. Bedrock does not have that rule, the sprint-jump crit is a normal thing to do.

Nukkit's original canCriticalHit did not check for sprinting. The check was introduced in #2636, which rewrote the condition. Bedrock does not have the sprinting rule (it comes from Java Edition), so this brings the check back in line with the client.

So right now, on a PNX server, jumping and hitting while sprinting gives no bonus damage.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:**
- **Bedrock client version:** 26.44
- **Plugins loaded:** none

**Steps performed and results:**

Diamond sword (7 damage) on a cow (10 health), so a critical (7 * 1.5 = 10) kills it in one hit and a normal hit needs two.

1. joined
2. summoned a cow
3. jumped and hit it while falling, not sprinting, it died in 1 hit
4. did the same but sprinting, before the fix it took 2 hits, after the fix it dies in 1

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|       |             |

- [ ] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled