### PR TITLE
feat: Dispense behavior of Tipped Arrows

### DIFF
--- a/src/main/java/org/powernukkitx/block/dispenser/ArrowDispenseBehavior.java
+++ b/src/main/java/org/powernukkitx/block/dispenser/ArrowDispenseBehavior.java
@@ -6,9 +6,9 @@ import org.powernukkitx.entity.projectile.EntityArrow;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemArrow;
 
-public class ArrowDispenserBehavior extends ProjectileDispenseBehavior {
+public class ArrowDispenseBehavior extends ProjectileDispenseBehavior {
 
-    public ArrowDispenserBehavior() {
+    public ArrowDispenseBehavior() {
         super(EntityID.ARROW);
     }
 

--- a/src/main/java/org/powernukkitx/block/dispenser/ArrowDispenserBehavior.java
+++ b/src/main/java/org/powernukkitx/block/dispenser/ArrowDispenserBehavior.java
@@ -1,0 +1,28 @@
+package org.powernukkitx.block.dispenser;
+
+import org.powernukkitx.entity.Entity;
+import org.powernukkitx.entity.EntityID;
+import org.powernukkitx.entity.projectile.EntityArrow;
+import org.powernukkitx.item.Item;
+import org.powernukkitx.item.ItemArrow;
+
+public class ArrowDispenserBehavior extends ProjectileDispenseBehavior {
+
+    public ArrowDispenserBehavior() {
+        super(EntityID.ARROW);
+    }
+
+    @Override
+    protected double getMotion() {
+        return super.getMotion() * 1.5;
+    }
+
+    @Override
+    protected void configureProjectile(Entity projectile, Item item) {
+        if (projectile instanceof EntityArrow arrow && item instanceof ItemArrow arrowItem) {
+            ItemArrow carried = (ItemArrow) arrowItem.clone();
+            carried.setCount(1);
+            arrow.setItem(carried);
+        }
+    }
+}

--- a/src/main/java/org/powernukkitx/block/dispenser/DispenseBehaviorRegister.java
+++ b/src/main/java/org/powernukkitx/block/dispenser/DispenseBehaviorRegister.java
@@ -87,13 +87,7 @@ public final class DispenseBehaviorRegister {
         });
 
         registerBehavior(BlockID.TNT, new TNTDispenseBehavior());
-        registerBehavior(ItemID.ARROW, new ProjectileDispenseBehavior(EntityID.ARROW) {
-            @Override
-            protected double getMotion() {
-                return super.getMotion() * 1.5;
-            }
-        });
-        //TODO: tipped arrow
+        registerBehavior(ItemID.ARROW, new ArrowDispenserBehavior());
         //TODO: spectral arrow
         registerBehavior(ItemID.EGG, new ProjectileDispenseBehavior(EntityID.EGG));
         registerBehavior(ItemID.SNOWBALL, new ProjectileDispenseBehavior(EntityID.SNOWBALL));

--- a/src/main/java/org/powernukkitx/block/dispenser/DispenseBehaviorRegister.java
+++ b/src/main/java/org/powernukkitx/block/dispenser/DispenseBehaviorRegister.java
@@ -87,7 +87,7 @@ public final class DispenseBehaviorRegister {
         });
 
         registerBehavior(BlockID.TNT, new TNTDispenseBehavior());
-        registerBehavior(ItemID.ARROW, new ArrowDispenserBehavior());
+        registerBehavior(ItemID.ARROW, new ArrowDispenseBehavior());
         //TODO: spectral arrow
         registerBehavior(ItemID.EGG, new ProjectileDispenseBehavior(EntityID.EGG));
         registerBehavior(ItemID.SNOWBALL, new ProjectileDispenseBehavior(EntityID.SNOWBALL));

--- a/src/main/java/org/powernukkitx/block/dispenser/ProjectileDispenseBehavior.java
+++ b/src/main/java/org/powernukkitx/block/dispenser/ProjectileDispenseBehavior.java
@@ -34,6 +34,8 @@ public class ProjectileDispenseBehavior extends DefaultDispenseBehavior {
             return super.dispense(source, face, item);
         }
 
+        configureProjectile(projectile, item);
+
         Vector3 motion = initMotion(face);
 
         projectile.setMotion(motion);
@@ -68,6 +70,9 @@ public class ProjectileDispenseBehavior extends DefaultDispenseBehavior {
 
     protected String getEntityType() {
         return this.entityType;
+    }
+
+    protected void configureProjectile(Entity projectile, Item item) {
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?

Add tipped arrow

## Why?

match vanilla behavior

## Type of change

- [ ] Bug Fix
- [X] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 80f09c499
- **Bedrock client version:** 26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. get a dispenser place a poison arrow or any effect
2. and get a lever, turn on and off dispenser and you have effect ; same color arrow

- [X] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

| Model | What it did |
|-------|-------------|
|       |             |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
