### PR TITLE
fix: implement mycelium light levels and fix spread coord bug

### DIFF
--- a/src/main/java/org/powernukkitx/block/BlockMycelium.java
+++ b/src/main/java/org/powernukkitx/block/BlockMycelium.java
@@ -2,6 +2,7 @@ package org.powernukkitx.block;
 
 import org.powernukkitx.Player;
 import org.powernukkitx.Server;
+import org.powernukkitx.event.block.BlockFadeEvent;
 import org.powernukkitx.event.block.BlockSpreadEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemBlock;
@@ -12,6 +13,8 @@ import org.powernukkitx.math.BlockFace;
 import org.powernukkitx.math.Vector3;
 import org.powernukkitx.utils.random.NukkitRandom;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * @author Pub4Game
@@ -63,23 +66,30 @@ public class BlockMycelium extends BlockDirt {
     @Override
     public int onUpdate(int type) {
         if (type == Level.BLOCK_UPDATE_RANDOM) {
+            if (up().getLightFilter() > 1) {
+                BlockFadeEvent ev = new BlockFadeEvent(this, Block.get(BlockID.DIRT));
+                Server.getInstance().getPluginManager().callEvent(ev);
+                if (!ev.isCancelled()) {
+                    this.getLevel().setBlock(this, ev.getNewState());
+                    return type;
+                }
+            }
+
             if (getLevel().getFullLight(add(0, 1, 0)) >= BlockCrops.MINIMUM_LIGHT_LEVEL) {
-                //TODO: light levels
-                NukkitRandom random = new NukkitRandom();
-                x = random.nextInt((int) x - 1, (int) x + 1);
-                y = random.nextInt((int) y - 1, (int) y + 1);
-                z = random.nextInt((int) z - 1, (int) z + 1);
+                ThreadLocalRandom random = ThreadLocalRandom.current();
+                int x = random.nextInt((int) this.x - 1, (int) this.x + 1 + 1);
+                int y = random.nextInt((int) this.y - 3, (int) this.y + 1 + 1);
+                int z = random.nextInt((int) this.z - 1, (int) this.z + 1 + 1);
                 Block block = this.getLevel().getBlock(new Vector3(x, y, z));
-                if (block.getId().equals(Block.DIRT)) {
-                    if (block.up().isTransparent()) {
-                        BlockSpreadEvent ev = new BlockSpreadEvent(block, this, Block.get(BlockID.MYCELIUM));
-                        Server.getInstance().getPluginManager().callEvent(ev);
-                        if (!ev.isCancelled()) {
-                            this.getLevel().setBlock(block, ev.getNewState());
-                        }
+                if (block.getId().equals(Block.DIRT) && getLevel().getFullLight(block.up()) >= 4 && block.up().getLightFilter() < 2) {
+                    BlockSpreadEvent ev = new BlockSpreadEvent(block, this, Block.get(BlockID.MYCELIUM));
+                    Server.getInstance().getPluginManager().callEvent(ev);
+                    if (!ev.isCancelled()) {
+                        this.getLevel().setBlock(block, ev.getNewState());
                     }
                 }
             }
+            return type;
         }
         return 0;
     }

--- a/src/main/java/org/powernukkitx/block/BlockMycelium.java
+++ b/src/main/java/org/powernukkitx/block/BlockMycelium.java
@@ -23,6 +23,9 @@ import java.util.concurrent.ThreadLocalRandom;
 public class BlockMycelium extends BlockDirt {
     public static final BlockProperties PROPERTIES = new BlockProperties(MYCELIUM);
 
+    public static final int MINIMUM_SPREAD_LIGHT_LEVEL = 4;
+    public static final int MAXIMUM_SPREAD_LIGHT_FILTER = 2;
+
     @Override
     @NotNull public BlockProperties getProperties() {
         return PROPERTIES;
@@ -81,7 +84,7 @@ public class BlockMycelium extends BlockDirt {
                 int y = random.nextInt((int) this.y - 3, (int) this.y + 1 + 1);
                 int z = random.nextInt((int) this.z - 1, (int) this.z + 1 + 1);
                 Block block = this.getLevel().getBlock(new Vector3(x, y, z));
-                if (block.getId().equals(Block.DIRT) && getLevel().getFullLight(block.up()) >= 4 && block.up().getLightFilter() < 2) {
+                if (block.getId().equals(BlockID.DIRT) && getLevel().getFullLight(block.up()) >= MINIMUM_SPREAD_LIGHT_LEVEL && block.up().getLightFilter() < MAXIMUM_SPREAD_LIGHT_FILTER) {
                     BlockSpreadEvent ev = new BlockSpreadEvent(block, this, Block.get(BlockID.MYCELIUM));
                     Server.getInstance().getPluginManager().callEvent(ev);
                     if (!ev.isCancelled()) {


### PR DESCRIPTION
## What does this PR do?

the mycelium turns back into soil beneath an opaque block and spreads toward the light like grass

## Why?

match vanilla behavior

## Type of change

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 0e56a01a9
- **Bedrock client version:** 26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. /gamerule randomTickSpeed 600 place mycelium with a stone block on top -> mycelium turns to dirt 
2. place mycelium next to dirt blocks in a lit area -> mycelium spreads to the nearby dirt 

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|       |             |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
