### PR TITLE
refact: move jukebox sound stop to Level API

### DIFF
--- a/src/main/java/org/powernukkitx/blockentity/BlockEntityJukebox.java
+++ b/src/main/java/org/powernukkitx/blockentity/BlockEntityJukebox.java
@@ -6,9 +6,6 @@ import org.powernukkitx.item.ItemMusicDisc;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.utils.ItemHelper;
-import org.cloudburstmc.math.vector.Vector3f;
-import org.cloudburstmc.protocol.bedrock.packet.PlaySoundPacket;
-import org.cloudburstmc.protocol.bedrock.packet.StopSoundPacket;
 
 import java.util.Objects;
 
@@ -50,21 +47,13 @@ public class BlockEntityJukebox extends BlockEntitySpawnable {
 
     public void play() {
         if (this.recordItem instanceof ItemMusicDisc itemRecord) {
-            final PlaySoundPacket packet = new PlaySoundPacket();
-            packet.setName(itemRecord.getSoundId());
-            packet.setPosition(Vector3f.from(this.getFloorX(), this.getFloorY(), this.getFloorZ()));
-            packet.setVolume(1f);
-            packet.setPitch(1f);
-            this.getLevel().addChunkPacket(this.getFloorX() >> 4, this.getFloorZ() >> 4, packet);
+            this.getLevel().addSound(this, itemRecord.getSoundId());
         }
     }
 
-    //TODO: Transfer the stop sound to the new sound method
     public void stop() {
         if (this.recordItem instanceof ItemMusicDisc itemRecord) {
-            final StopSoundPacket packet = new StopSoundPacket();
-            packet.setSoundName(itemRecord.getSoundId());
-            this.getLevel().addChunkPacket(this.getFloorX() >> 4, this.getFloorZ() >> 4, packet);
+            this.getLevel().stopSound(this, itemRecord.getSoundId());
         }
     }
 

--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -834,6 +834,28 @@ public class Level implements Metadatable {
         }
     }
 
+    public void stopSound(Vector3 pos, String soundName) {
+        this.stopSound(pos, soundName, (Player[]) null);
+    }
+
+    public void stopSound(Vector3 pos, String soundName, Collection<Player> players) {
+        this.stopSound(pos, soundName, players != null ? players.toArray(Player.EMPTY_ARRAY) : null);
+    }
+
+    public void stopSound(Vector3 pos, String soundName, Player... players) {
+        final StopSoundPacket packet = new StopSoundPacket();
+        packet.setSoundName(soundName);
+        if (soundName == null || soundName.isEmpty()) {
+            packet.setStopAllSounds(true);
+        }
+
+        if (players == null || players.length == 0) {
+            addChunkPacket(pos.getFloorX() >> 4, pos.getFloorZ() >> 4, packet);
+        } else {
+            Server.broadcastPacket(players, packet);
+        }
+    }
+
     public void playMusic(String trackName) {
         this.playMusic(trackName, 1, 0, MusicRepeatMode.PLAY_ONCE, (Player[]) null);
     }


### PR DESCRIPTION
## What does this PR do?

add a stopSound() helper on Level and makes the jukebox use it (and addSound) instead of building the sound packets

## Why?

the jukebox was crafting Play/Stop-SoundPacket manually while the rest of the code goes through level there was no stopSound equivalent so this adds it and cleans up the jukebox

## Type of change

<!-- Tick what applies. -->

- [ ] Bug Fix
- [ ] New Feature
- [ ] Performance
- [X] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** ed3e5d488
- **Bedrock client version:** 26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. with jukebox put a music disk and stop jukebox

- [X] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

# add stopSound() on Level

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|       |             |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
