### PR TITLE
fix: colored bed shows default color until relog

### DIFF
--- a/src/main/java/org/powernukkitx/block/BlockBed.java
+++ b/src/main/java/org/powernukkitx/block/BlockBed.java
@@ -209,14 +209,14 @@ public class BlockBed extends BlockTransparent implements Faceable, BlockEntityH
 
         setBlockFace(direction);
 
-        level.setBlock(block, this, false, true);
+        level.setBlock(block, this, true, true);
         if (next instanceof BlockLiquid && ((BlockLiquid) next).usesWaterLogging()) {
             level.setBlock(next, 1, next, false, false);
         }
 
         BlockBed head = (BlockBed) clone();
         head.setHeadPiece(true);
-        level.setBlock(next, head, false, true);
+        level.setBlock(next, head, true, true);
 
         BlockEntityBed thisBed = null;
         try {


### PR DESCRIPTION
## What does this PR do?

Sends the bed blocks to the client directly on placement instead of batching them so the block exists client-side before the block entity sends its color

## Why?

because when you place a colored bed its red no matter what color the bed is

## Type of change

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 9b6254429
- **Bedrock client version:** 26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. place a colored bed

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|       |             |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
