### PR TITLE
fix: extinguish fire with a sword in creative mode

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -66,6 +66,7 @@ import org.powernukkitx.AdventureSettings.Type;
 import org.powernukkitx.api.UnintendedClientBehaviour;
 import org.powernukkitx.api.UsedByReflection;
 import org.powernukkitx.block.Block;
+import org.powernukkitx.block.BlockAir;
 import org.powernukkitx.block.BlockBed;
 import org.powernukkitx.block.BlockEndPortal;
 import org.powernukkitx.block.BlockID;
@@ -578,9 +579,9 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         target.onTouch(pos, this.getInventory().getItemInMainHand(), face, 0, 0, 0, this, playerInteractEvent.getAction());
 
         Block block = target.getSide(face);
-        if (block.getId().equals(Block.FIRE) || block.getId().equals(BlockID.SOUL_FIRE)) {
-            this.level.setBlock(block, Block.get(BlockID.AIR), true);
-            this.level.addLevelSoundEvent(block, SoundEvent.EXTINGUISH_FIRE);
+        Block fire = getFireAt(target, face);
+        if (fire != null) {
+            extinguishFire(fire);
             return;
         }
 
@@ -1316,6 +1317,42 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         } else {
             this.speed.setComponents(0, 0, 0);
         }
+    }
+
+    /**
+     * @param block the block to test
+     * @return true if the block is a fire block
+     */
+    public static boolean isFire(Block block) {
+        return block.getId().equals(BlockID.FIRE) || block.getId().equals(BlockID.SOUL_FIRE);
+    }
+
+    /**
+     * Resolves the fire block a hit refers to: either the hit block itself, or the one on the
+     * given face of it.
+     *
+     * @param target the block that was hit
+     * @param face   the face that was hit
+     * @return the fire block, or null if neither is fire
+     */
+    @Nullable
+    public static Block getFireAt(Block target, BlockFace face) {
+        if (isFire(target)) {
+            return target;
+        }
+        Block side = target.getSide(face);
+        return isFire(side) ? side : null;
+    }
+
+    /**
+     * Replaces the given fire block with air and plays the extinguish sound.
+     *
+     * @param fire the fire block to extinguish
+     */
+    public void extinguishFire(Block fire) {
+        Level fireLevel = fire.getLevel();
+        fireLevel.setBlock(fire, Block.get(BlockID.AIR), true);
+        fireLevel.addLevelSoundEvent(fire, SoundEvent.EXTINGUISH_FIRE);
     }
 
     /**

--- a/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
@@ -242,7 +242,7 @@ public class PlayerAuthInputHandler implements PacketHandler<PlayerAuthInputPack
                 if (player.getInventory().getItemInMainHand().isSword() && player.isCreative() && action.getPlayerActionType() == PlayerActionType.START_DESTROY_BLOCK) {
                     // fire only sends START_DESTROY_BLOCK, so extinguish it before filtering the action out
                     Block fireBlock = player.getLevel().getBlock(Vector3.fromNetwork(action.getBlockPosition().toFloat())).getSide(BlockFace.fromIndex(action.getFacing()));
-                    if (fireBlock.getId().equals(Block.FIRE) || fireBlock.getId().equals(BlockID.SOUL_FIRE)) {
+                    if (fireBlock.getId().equals(BlockID.FIRE) || fireBlock.getId().equals(BlockID.SOUL_FIRE)) {
                         player.getLevel().setBlock(fireBlock, Block.get(BlockID.AIR), true);
                         player.getLevel().addLevelSoundEvent(fireBlock, SoundEvent.EXTINGUISH_FIRE);
                     }

--- a/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
@@ -1,5 +1,6 @@
 package org.powernukkitx.network.process.handler;
 
+import org.cloudburstmc.protocol.bedrock.packet.UpdateBlockPacket;
 import org.powernukkitx.AdventureSettings;
 import org.powernukkitx.Player;
 import org.powernukkitx.PlayerHandle;
@@ -7,15 +8,8 @@ import org.powernukkitx.Server;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityPhysical;
 import org.powernukkitx.entity.item.EntityBoat;
-import org.powernukkitx.event.player.PlayerHackDetectedEvent;
-import org.powernukkitx.event.player.PlayerJumpEvent;
-import org.powernukkitx.event.player.PlayerKickEvent;
-import org.powernukkitx.event.player.PlayerToggleCrawlEvent;
-import org.powernukkitx.event.player.PlayerToggleFlightEvent;
-import org.powernukkitx.event.player.PlayerToggleGlideEvent;
-import org.powernukkitx.event.player.PlayerToggleSneakEvent;
-import org.powernukkitx.event.player.PlayerToggleSprintEvent;
-import org.powernukkitx.event.player.PlayerToggleSwimEvent;
+import org.powernukkitx.event.player.*;
+import org.powernukkitx.item.Item;
 import org.powernukkitx.level.Location;
 import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockID;
@@ -241,10 +235,23 @@ public class PlayerAuthInputHandler implements PacketHandler<PlayerAuthInputPack
                 //hack Since version 1.19.70, the Creative Mode Sword client no longer sends PREDITIC_DESTROY_BLOCK, but still sends START_DESTROY_BLOCK, filtering out
                 if (player.getInventory().getItemInMainHand().isSword() && player.isCreative() && action.getPlayerActionType() == PlayerActionType.START_DESTROY_BLOCK) {
                     // fire only sends START_DESTROY_BLOCK, so extinguish it before filtering the action out
-                    Block fireBlock = player.getLevel().getBlock(Vector3.fromNetwork(action.getBlockPosition().toFloat())).getSide(BlockFace.fromIndex(action.getFacing()));
-                    if (fireBlock.getId().equals(BlockID.FIRE) || fireBlock.getId().equals(BlockID.SOUL_FIRE)) {
-                        player.getLevel().setBlock(fireBlock, Block.get(BlockID.AIR), true);
-                        player.getLevel().addLevelSoundEvent(fireBlock, SoundEvent.EXTINGUISH_FIRE);
+                    Vector3 hitPos = Vector3.fromNetwork(action.getBlockPosition().toFloat());
+                    BlockFace hitFace = BlockFace.fromIndex(action.getFacing());
+                    Block target = player.getLevel().getBlock(hitPos);
+                    Block fire = Player.getFireAt(target, hitFace);
+
+                    if (fire != null) {
+                        Item hand = player.getInventory().getItemInMainHand();
+                        PlayerInteractEvent interactEvent = new PlayerInteractEvent(player, hand, fire, hitFace,
+                            PlayerInteractEvent.Action.LEFT_CLICK_BLOCK);
+                        server.getPluginManager().callEvent(interactEvent);
+                        new PlayerHandle(player).setInteract();
+
+                        if (interactEvent.isCancelled()) {
+                            player.getLevel().sendBlocks(new Player[]{player}, new Block[]{fire}, UpdateBlockPacket.FLAG_ALL_PRIORITY, 0);
+                        } else {
+                            player.extinguishFire(fire);
+                        }
                     }
                     continue;
                 }

--- a/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
@@ -241,11 +241,10 @@ public class PlayerAuthInputHandler implements PacketHandler<PlayerAuthInputPack
                 //hack Since version 1.19.70, the Creative Mode Sword client no longer sends PREDITIC_DESTROY_BLOCK, but still sends START_DESTROY_BLOCK, filtering out
                 if (player.getInventory().getItemInMainHand().isSword() && player.isCreative() && action.getPlayerActionType() == PlayerActionType.START_DESTROY_BLOCK) {
                     // fire only sends START_DESTROY_BLOCK, so extinguish it before filtering the action out
-                    Vector3 firePos = Vector3.fromNetwork(action.getBlockPosition().toFloat());
-                    BlockFace fireFace = BlockFace.fromIndex(action.getFacing());
-                    Block sideBlock = player.getLevel().getBlock(firePos).getSide(fireFace);
-                    if (sideBlock.getId().equals(Block.FIRE) || sideBlock.getId().equals(BlockID.SOUL_FIRE)) {
-                        player.onBlockBreakStart(firePos, fireFace);
+                    Block fireBlock = player.getLevel().getBlock(Vector3.fromNetwork(action.getBlockPosition().toFloat())).getSide(BlockFace.fromIndex(action.getFacing()));
+                    if (fireBlock.getId().equals(Block.FIRE) || fireBlock.getId().equals(BlockID.SOUL_FIRE)) {
+                        player.getLevel().setBlock(fireBlock, Block.get(BlockID.AIR), true);
+                        player.getLevel().addLevelSoundEvent(fireBlock, SoundEvent.EXTINGUISH_FIRE);
                     }
                     continue;
                 }

--- a/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/PlayerAuthInputHandler.java
@@ -17,6 +17,8 @@ import org.powernukkitx.event.player.PlayerToggleSneakEvent;
 import org.powernukkitx.event.player.PlayerToggleSprintEvent;
 import org.powernukkitx.event.player.PlayerToggleSwimEvent;
 import org.powernukkitx.level.Location;
+import org.powernukkitx.block.Block;
+import org.powernukkitx.block.BlockID;
 import org.powernukkitx.math.BlockFace;
 import org.powernukkitx.math.BlockVector3;
 import org.powernukkitx.math.Vector2f;
@@ -238,6 +240,13 @@ public class PlayerAuthInputHandler implements PacketHandler<PlayerAuthInputPack
             for (PlayerBlockActionData action : packet.getPlayerBlockActions()) {
                 //hack Since version 1.19.70, the Creative Mode Sword client no longer sends PREDITIC_DESTROY_BLOCK, but still sends START_DESTROY_BLOCK, filtering out
                 if (player.getInventory().getItemInMainHand().isSword() && player.isCreative() && action.getPlayerActionType() == PlayerActionType.START_DESTROY_BLOCK) {
+                    // fire only sends START_DESTROY_BLOCK, so extinguish it before filtering the action out
+                    Vector3 firePos = Vector3.fromNetwork(action.getBlockPosition().toFloat());
+                    BlockFace fireFace = BlockFace.fromIndex(action.getFacing());
+                    Block sideBlock = player.getLevel().getBlock(firePos).getSide(fireFace);
+                    if (sideBlock.getId().equals(Block.FIRE) || sideBlock.getId().equals(BlockID.SOUL_FIRE)) {
+                        player.onBlockBreakStart(firePos, fireFace);
+                    }
                     continue;
                 }
                 Vector3i blockPos = action.getBlockPosition();


### PR DESCRIPTION
## What does this PR do?

lets you extinguish fire with a sword in creative mode again

## Why?

in creative a sword only sends START_DESTROY_BLOCK, which the handler dropped so the fire was never removed server-side and re-synced back after a moment

## Type of change

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** ff5025616
- **Bedrock client version:** 26.45
- **Plugins loaded:** none

**Steps performed and results:**

1.  right click on grass and soul sand with flint and steel and hit with sword on creative mode

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|       |             |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
