### PR TITLE
fix(entity) : apply attack exhaustion to all mobs

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -5152,10 +5152,6 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         if (super.attack(source)) {
             if (this.getLastDamageCause() == source && this.spawned) {
                 if (source instanceof EntityDamageByEntityEvent entityDamageByEntityEvent) {
-                    Entity damager = entityDamageByEntityEvent.getDamager();
-                    if (damager instanceof Player) {
-                        ((Player) damager).getFoodData().exhaust(0.1);
-                    }
                     // Save the entity that last attacked the player in lastBeAttackEntity
                     this.lastBeAttackEntity = entityDamageByEntityEvent.getDamager();
                 }

--- a/src/main/java/org/powernukkitx/network/process/handler/InventoryTransactionHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/InventoryTransactionHandler.java
@@ -267,6 +267,9 @@ public class InventoryTransactionHandler implements PacketHandler<InventoryTrans
                     living.postAttack(player);
                 }
             }
+            if (target instanceof EntityLiving && (player.isSurvival() || player.isAdventure())) {
+                player.getFoodData().exhaust(0.3);
+            }
             if (item instanceof ItemMace mace) {
                 mace.onPostAttack(target, itemDamage);
             }

--- a/src/main/java/org/powernukkitx/network/process/handler/InventoryTransactionHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/InventoryTransactionHandler.java
@@ -268,7 +268,7 @@ public class InventoryTransactionHandler implements PacketHandler<InventoryTrans
                 }
             }
             if (target instanceof EntityLiving && (player.isSurvival() || player.isAdventure())) {
-                player.getFoodData().exhaust(0.3);
+                player.getFoodData().exhaust(0.1);
             }
             if (item instanceof ItemMace mace) {
                 mace.onPostAttack(target, itemDamage);


### PR DESCRIPTION
## What does this PR do?

It apply the attack exhaustion to every mob and with the vanilla value.

## Why?

It match vanilla behaviour.

The exhaustion was applied in `Player.attack(EntityDamageEvent)` in `Player.java`. That method is the one of the entity that **receive** the damage, and it only exist on `Player`, so the code only run when the victim is a player. Hitting a zombie, a cow or a villager was costing no hunger at all, only PvP was.

Last thing, `EntityDamageByChildEntityEvent extends EntityDamageByEntityEvent`, so an arrow shot by a player was passing the `instanceof EntityDamageByEntityEvent` check and was exhausting the shooter. In vanilla only the melee attack cost exhaustion, not the projectiles.

So the block is moved to the melee attack path in `InventoryTransactionHandler`, after a successful `target.attack()`, guarded with `target instanceof EntityLiving` and the survival/adventure check that the rest of that handler already use.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 64e3c21e1
- **Bedrock client version:**
- **Plugins loaded:** none

**Steps performed and results:**


- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [x] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| Claude Opus 5 | Found the bug, wrote the diff, the commit message and a first draft of this description, reversed the minecraft bedrock exhaustion constants |

- [x] The disclosure above covers **all** AI use in this PR - code, tes config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party c
- [x] "Allow maintainer edits" is enabled