### PR TITLE
fix(entity): stop applying the knockback enchantment twice

### DIFF
--- a/src/main/java/org/powernukkitx/network/process/handler/InventoryTransactionHandler.java
+++ b/src/main/java/org/powernukkitx/network/process/handler/InventoryTransactionHandler.java
@@ -235,12 +235,6 @@ public class InventoryTransactionHandler implements PacketHandler<InventoryTrans
             Map<EntityDamageEvent.DamageModifier, Float> damage = new EnumMap<>(EntityDamageEvent.DamageModifier.class);
             damage.put(EntityDamageEvent.DamageModifier.BASE, itemDamage);
             float knockBack = 0.3f;
-            if (item.applyEnchantments()) {
-                Enchantment knockBackEnchantment = item.getEnchantment(Enchantment.ID_KNOCKBACK);
-                if (knockBackEnchantment != null) {
-                    knockBack += knockBackEnchantment.getLevel() * 0.1f;
-                }
-            }
             EntityDamageByEntityEvent entityDamageByEntityEvent = new EntityDamageByEntityEvent(player, target, EntityDamageEvent.DamageCause.ENTITY_ATTACK, damage, knockBack, item.applyEnchantments() ? enchantments : null);
             entityDamageByEntityEvent.setBreakShield(item.canBreakShield());
             if (player.isSpectator()) entityDamageByEntityEvent.setCancelled();


### PR DESCRIPTION
## What does this PR do?

It stop applying the knockback enchantment twice on melee attacks.

## Why?

It match vanilla behaviour.

The Knockback enchantment is applied two times on the same event. `InventoryTransactionHandler` build the event with `knockBack = 0.3f + level * 0.1f`, then `Entity.attack()` loop on the weapon enchantments and call `EnchantmentKnockback.doAttack()` which does `setKnockBack(getKnockBack() + level * 0.5f)` on that same event. `EntityLiving` then read `getKnockBack()` once as the knockback base, so the two additions are summed. With Knockback II the base is `1.5f` instead of `1.3f`.

The `0.1f` block is not supposed to be there. It was removed in #2505, the commit that implemented `doAttack` for this enchantment, and it came back in #2580 when `InventoryTransactionProcessor` was replaced by `InventoryTransactionHandler`, the new file was created with the old version of that block. This PR just removes it again, the diff is the same as the one in #2505.

`ID_KNOCKBACK` has no other usage in the attack path after this, so the enchantment is now applied once, like vanilla where the knockback bonus is the enchant level used a single time.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 4e2ce4514
- **Bedrock client version:**
- **Plugins loaded:** none

**Steps performed and results:**

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not ai generated.

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party c
- [x] "Allow maintainer edits" is enabled