### PR TITLE
fix(entity): remove trident enchantments when their level is cleared

### DIFF
--- a/src/main/java/org/powernukkitx/entity/projectile/EntityThrownTrident.java
+++ b/src/main/java/org/powernukkitx/entity/projectile/EntityThrownTrident.java
@@ -360,7 +360,7 @@ public class EntityThrownTrident extends SlenderProjectile {
         if (loyaltyLevel > 0) {
             this.trident.addEnchantment(Enchantment.getEnchantment(Enchantment.ID_TRIDENT_LOYALTY).setLevel(loyaltyLevel));
         } else {
-            // TODO: this.trident.removeEnchantment(Enchantment.ID_TRIDENT_LOYALTY);
+            this.trident.removeEnchantment(Enchantment.ID_TRIDENT_LOYALTY);
         }
     }
 
@@ -373,7 +373,7 @@ public class EntityThrownTrident extends SlenderProjectile {
         if (hasChanneling) {
             this.trident.addEnchantment(Enchantment.getEnchantment(Enchantment.ID_TRIDENT_CHANNELING));
         } else {
-            // TODO: this.trident.removeEnchantment(Enchantment.ID_TRIDENT_CHANNELING);
+            this.trident.removeEnchantment(Enchantment.ID_TRIDENT_CHANNELING);
         }
     }
 
@@ -386,7 +386,7 @@ public class EntityThrownTrident extends SlenderProjectile {
         if (riptideLevel > 0) {
             this.trident.addEnchantment(Enchantment.getEnchantment(Enchantment.ID_TRIDENT_RIPTIDE).setLevel(riptideLevel));
         } else {
-            // TODO: this.trident.removeEnchantment(Enchantment.ID_TRIDENT_RIPTIDE);
+            this.trident.removeEnchantment(Enchantment.ID_TRIDENT_RIPTIDE);
         }
     }
 
@@ -399,7 +399,7 @@ public class EntityThrownTrident extends SlenderProjectile {
         if (impalingLevel > 0) {
             this.trident.addEnchantment(Enchantment.getEnchantment(Enchantment.ID_TRIDENT_IMPALING).setLevel(impalingLevel));
         } else {
-            // TODO: this.trident.removeEnchantment(Enchantment.ID_TRIDENT_IMPALING);
+            this.trident.removeEnchantment(Enchantment.ID_TRIDENT_IMPALING);
         }
     }
 


### PR DESCRIPTION

## What does this PR do?

It remove the trident enchantments from the item when their level is set back to 0.

## Why?

The four setters of `EntityThrownTrident` add the enchantment when the level is above 0, but the `else` branch was an empty `// TODO`, so nothing was removed when the level went back to 0. An enchantment that was taken off the trident stayed on the item.

The TODO dates from ca485c3a5 (December 2020), when Item had no removeEnchantment method at all, so the author could not write the call. removeEnchantment(int) was added a year ago in #2082, the TODO was just never revisited.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** d359292a0
- **Bedrock client version:**
- **Plugins loaded:** none

**Steps performed and results:**

1.
2.

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
| Claude Opus 5 | Found the dates of the TODO and of the commit that added `Item.removeEnchantment(int)`, and generated this description |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it.
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled