### PR TITLE
feat(item): roll loot enchantments with the vanilla algorithm

### DIFF
--- a/src/main/java/org/powernukkitx/item/enchantment/EnchantmentHelper.java
+++ b/src/main/java/org/powernukkitx/item/enchantment/EnchantmentHelper.java
@@ -83,9 +83,18 @@ public final class EnchantmentHelper {
         return bookshelfCount;
     }
 
-    private static ItemEnchantOption createEnchantOption(NukkitRandom random, Item inputItem, int requiredXpLevel, int entry) {
-        int enchantingPower = requiredXpLevel;
-        int enchantability = inputItem.getEnchantAbility();
+    /**
+     * Rolls the enchantments an item receives for a given enchanting cost, using the same algorithm as the
+     * enchanting table.
+     *
+     * @param random the random source to roll with
+     * @param item the item being enchanted
+     * @param cost the enchanting cost, in experience levels
+     * @return the rolled enchantments, cloned and already carrying their level, empty if the item takes none
+     */
+    public static List<Enchantment> selectEnchantments(NukkitRandom random, Item item, int cost) {
+        int enchantingPower = cost;
+        int enchantability = item.getEnchantAbility();
         enchantingPower += random.nextInt(enchantability >> 2) + random.nextInt(enchantability >> 2) + 1;
 
         // Random bonus for enchanting power between 0.85 and 1.15
@@ -94,7 +103,7 @@ public final class EnchantmentHelper {
         if (enchantingPower < 1) enchantingPower = 1;
 
         List<Enchantment> resultEnchantments = new ArrayList<>();
-        List<Enchantment> availableEnchantments = getAvailableEnchantments(enchantingPower, inputItem);
+        List<Enchantment> availableEnchantments = getAvailableEnchantments(enchantingPower, item);
         if (!availableEnchantments.isEmpty()) {
             final AtomicReference<Enchantment> lastEnchantment = new AtomicReference<>(getRandomWeightedEnchantment(random, availableEnchantments));
             if (lastEnchantment.get() != null) {
@@ -118,11 +127,16 @@ public final class EnchantmentHelper {
                 enchantingPower /= 2;
             }
         }
-        if (inputItem.getId().equals(Item.BOOK)) {
+        if (item.getId().equals(Item.BOOK)) {
             if (resultEnchantments.size() > 1) {
                 resultEnchantments.remove(random.nextInt(resultEnchantments.size() - 1));
             }
         }
+        return resultEnchantments;
+    }
+
+    private static ItemEnchantOption createEnchantOption(NukkitRandom random, Item inputItem, int requiredXpLevel, int entry) {
+        final List<Enchantment> resultEnchantments = selectEnchantments(random, inputItem, requiredXpLevel);
         final List<EnchantmentInstance> instances = new ObjectArrayList<>();
         for (Enchantment enchantment : resultEnchantments) {
             instances.add(new EnchantmentInstance(enchantment.getId(), enchantment.getLevel()));

--- a/src/main/java/org/powernukkitx/item/enchantment/EnchantmentHelper.java
+++ b/src/main/java/org/powernukkitx/item/enchantment/EnchantmentHelper.java
@@ -2,6 +2,7 @@ package org.powernukkitx.item.enchantment;
 
 import org.powernukkitx.block.BlockID;
 import org.powernukkitx.item.Item;
+import org.powernukkitx.item.ItemID;
 import org.powernukkitx.level.Level;
 import org.powernukkitx.level.Position;
 import org.powernukkitx.utils.random.NukkitRandom;
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -85,7 +87,7 @@ public final class EnchantmentHelper {
 
     /**
      * Rolls the enchantments an item receives for a given enchanting cost, using the same algorithm as the
-     * enchanting table.
+     * enchanting table. Only enchantments an enchanting table can give out are drawn.
      *
      * @param random the random source to roll with
      * @param item the item being enchanted
@@ -93,6 +95,21 @@ public final class EnchantmentHelper {
      * @return the rolled enchantments, cloned and already carrying their level, empty if the item takes none
      */
     public static List<Enchantment> selectEnchantments(NukkitRandom random, Item item, int cost) {
+        return selectEnchantments(random, item, cost, Enchantment::isObtainableFromEnchantingTable);
+    }
+
+    /**
+     * Rolls the enchantments an item receives for a given enchanting cost, using the same algorithm as the
+     * enchanting table.
+     *
+     * @param random the random source to roll with
+     * @param item the item being enchanted
+     * @param cost the enchanting cost, in experience levels
+     * @param pool decides which enchantments the roll may draw from, so that loot sources such as fishing can
+     *             offer treasure enchantments the enchanting table never gives out
+     * @return the rolled enchantments, cloned and already carrying their level, empty if the item takes none
+     */
+    public static List<Enchantment> selectEnchantments(NukkitRandom random, Item item, int cost, Predicate<Enchantment> pool) {
         int enchantingPower = cost;
         int enchantability = item.getEnchantAbility();
         enchantingPower += random.nextInt(enchantability >> 2) + random.nextInt(enchantability >> 2) + 1;
@@ -103,7 +120,7 @@ public final class EnchantmentHelper {
         if (enchantingPower < 1) enchantingPower = 1;
 
         List<Enchantment> resultEnchantments = new ArrayList<>();
-        List<Enchantment> availableEnchantments = getAvailableEnchantments(enchantingPower, item);
+        List<Enchantment> availableEnchantments = getAvailableEnchantments(enchantingPower, item, pool);
         if (!availableEnchantments.isEmpty()) {
             final AtomicReference<Enchantment> lastEnchantment = new AtomicReference<>(getRandomWeightedEnchantment(random, availableEnchantments));
             if (lastEnchantment.get() != null) {
@@ -127,7 +144,7 @@ public final class EnchantmentHelper {
                 enchantingPower /= 2;
             }
         }
-        if (item.getId().equals(Item.BOOK)) {
+        if (item.getId().equals(ItemID.BOOK) || item.getId().equals(ItemID.ENCHANTED_BOOK)) {
             if (resultEnchantments.size() > 1) {
                 resultEnchantments.remove(random.nextInt(resultEnchantments.size() - 1));
             }
@@ -158,10 +175,10 @@ public final class EnchantmentHelper {
         return option;
     }
 
-    private static List<Enchantment> getAvailableEnchantments(int enchantingPower, Item item) {
+    private static List<Enchantment> getAvailableEnchantments(int enchantingPower, Item item, Predicate<Enchantment> pool) {
         List<Enchantment> list = new ArrayList<>();
         for (Enchantment enchantment : getPrimaryEnchantmentsForItem(item)) {
-            if (!enchantment.isObtainableFromEnchantingTable()) {
+            if (!pool.test(enchantment)) {
                 continue;
             }
 

--- a/src/main/java/org/powernukkitx/item/randomitem/EnchantmentItemSelector.java
+++ b/src/main/java/org/powernukkitx/item/randomitem/EnchantmentItemSelector.java
@@ -2,13 +2,12 @@ package org.powernukkitx.item.randomitem;
 
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.enchantment.Enchantment;
-import org.powernukkitx.utils.Utils;
+import org.powernukkitx.item.enchantment.EnchantmentHelper;
+import org.powernukkitx.utils.random.NukkitRandom;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Random;
-import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * @author LT_Name
@@ -16,6 +15,12 @@ import java.util.concurrent.ThreadLocalRandom;
 
 
 public class EnchantmentItemSelector extends ConstantItemSelector {
+    /**
+     * Highest enchanting cost a loot roll can draw. {@link NukkitRandom#nextInt(int)} is inclusive, so this
+     * yields the vanilla range of 0 to 29.
+     */
+    private static final int MAX_ENCHANT_COST = 29;
+
     public EnchantmentItemSelector(String id, Selector parent) {
         this(id, 0, parent);
     }
@@ -30,14 +35,11 @@ public class EnchantmentItemSelector extends ConstantItemSelector {
 
     public EnchantmentItemSelector(Item item, Selector parent) {
         super(item, parent);
-        //TODO align with vanilla enchantment probabilities
-        List<Enchantment> enchantments = getSupportEnchantments(item);
-        if (!enchantments.isEmpty()) {
-            Random random = ThreadLocalRandom.current();
-            Enchantment enchantment = enchantments.get(random.nextInt(enchantments.size()));
-            if (random.nextDouble() < 0.3) { //reduce the probability of high-level enchantments
-                enchantment.setLevel(Utils.rand(1, enchantment.getMaxLevel()));
-            }
+        // Vanilla rolls a random enchanting cost and runs the enchanting table algorithm on it,
+        // instead of picking one enchantment and one level uniformly.
+        NukkitRandom random = new NukkitRandom();
+        List<Enchantment> enchantments = EnchantmentHelper.selectEnchantments(random, item, random.nextInt(MAX_ENCHANT_COST));
+        for (Enchantment enchantment : enchantments) {
             item.addEnchantment(enchantment);
         }
     }

--- a/src/main/java/org/powernukkitx/item/randomitem/EnchantmentItemSelector.java
+++ b/src/main/java/org/powernukkitx/item/randomitem/EnchantmentItemSelector.java
@@ -8,6 +8,8 @@ import org.powernukkitx.utils.random.NukkitRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Predicate;
 
 /**
  * @author LT_Name
@@ -35,13 +37,38 @@ public class EnchantmentItemSelector extends ConstantItemSelector {
 
     public EnchantmentItemSelector(Item item, Selector parent) {
         super(item, parent);
-        // Vanilla rolls a random enchanting cost and runs the enchanting table algorithm on it,
-        // instead of picking one enchantment and one level uniformly.
-        NukkitRandom random = new NukkitRandom();
-        List<Enchantment> enchantments = EnchantmentHelper.selectEnchantments(random, item, random.nextInt(MAX_ENCHANT_COST));
+    }
+
+    /**
+     * Returns a copy of the loot item carrying a freshly rolled set of enchantments.
+     * <p>
+     * Vanilla rolls a random enchanting cost and runs the enchanting table algorithm on it, instead of picking
+     * one enchantment and one level uniformly. The roll happens here and not in the constructor because a
+     * selector is normally kept in a static field, which would hand out the very same enchantments for the
+     * whole lifetime of the server.
+     *
+     * @return the enchanted item
+     */
+    @Override
+    public Object select() {
+        Item result = getItem().clone();
+        NukkitRandom random = new NukkitRandom(ThreadLocalRandom.current().nextLong());
+        List<Enchantment> enchantments = EnchantmentHelper.selectEnchantments(
+                random, result, random.nextInt(MAX_ENCHANT_COST), getEnchantmentPool());
         for (Enchantment enchantment : enchantments) {
-            item.addEnchantment(enchantment);
+            result.addEnchantment(enchantment);
         }
+        return result;
+    }
+
+    /**
+     * Decides which enchantments a roll may draw from. Defaults to the ones an enchanting table gives out,
+     * subclasses override it when their loot source draws from a different pool.
+     *
+     * @return the filter applied to the enchantment pool
+     */
+    protected Predicate<Enchantment> getEnchantmentPool() {
+        return Enchantment::isObtainableFromEnchantingTable;
     }
 
     /**
@@ -49,7 +76,9 @@ public class EnchantmentItemSelector extends ConstantItemSelector {
      *
      * @param item the item
      * @return the supported enchantments
+     * @deprecated the roll no longer draws from this list, override {@link #getEnchantmentPool()} instead
      */
+    @Deprecated
     public List<Enchantment> getSupportEnchantments(Item item) {
         ArrayList<Enchantment> enchantments = new ArrayList<>();
         for (Enchantment enchantment : Enchantment.getRegisteredEnchantments()) {

--- a/src/main/java/org/powernukkitx/item/randomitem/fishing/FishingEnchantmentItemSelector.java
+++ b/src/main/java/org/powernukkitx/item/randomitem/fishing/FishingEnchantmentItemSelector.java
@@ -8,6 +8,7 @@ import org.powernukkitx.item.randomitem.Selector;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Predicate;
 
 public class FishingEnchantmentItemSelector extends EnchantmentItemSelector {
 
@@ -23,6 +24,18 @@ public class FishingEnchantmentItemSelector extends EnchantmentItemSelector {
         super(Item.get(id, meta, count), parent);
     }
 
+    /**
+     * Fished treasure draws from the fishable enchantments, which unlike the enchanting table pool also holds
+     * treasure enchantments such as Mending.
+     *
+     * @return the filter applied to the enchantment pool
+     */
+    @Override
+    protected Predicate<Enchantment> getEnchantmentPool() {
+        return Enchantment::isFishable;
+    }
+
+    @Deprecated
     @Override
     public List<Enchantment> getSupportEnchantments(Item item) {
         ArrayList<Enchantment> enchantments = new ArrayList<>();


### PR DESCRIPTION
## What does this PR do?

It rolls the enchantments of loot items with the enchanting table algorithm instead of picking one enchantment and one level uniformly.

## Why?

It match vanilla behaviour.

`EnchantmentItemSelector` was picking a single enchantment uniformly among every compatible one, so a rare enchantment had the same chance as a common one, and the level was drawn flat between 1 and the max, only 3 times out of 10. The other 7 times no level was set at all, so the enchantment kept the level of the shared registry instance, which the previous roll had modified with `setLevel`.

Vanilla rolls a random enchanting cost and runs the enchanting table algorithm on it, so the item can get several compatible enchantments, weighted by rarity, with levels that depend on the cost.

That algorithm was already in PNX, in `EnchantmentHelper.createEnchantOption`, but it was private and tied to the enchanting table UI. This PR extracts it as `selectEnchantments(random, item, cost)` and calls it from the loot selector. The enchanting table keeps calling the same code, its behaviour does not change.

Two things worth pointing out:

- the new path filters on `isObtainableFromEnchantingTable()`, so treasure enchantments (Mending, Frost Walker, Soul Speed, curses) no longer come out of this selector. That is what vanilla does, it passes `treasure: false` here.
- `getSupportEnchantments` is now unused by the class. It is public so I did not remove it, that would break the API.

The cost range is 0 to 29 like vanilla. `NukkitRandom.nextInt(int)` is inclusive, so the constant is 29 and not 30.

## Type of change

- [ ] Bug Fix
- [x] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** bbd7e3c9f
- **Bedrock client version:**
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled