### PR TITLE
fix(entity): stop growing up baby sheep when they eat grass

### DIFF
--- a/src/main/java/org/powernukkitx/entity/ai/executor/EatGrassExecutor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/executor/EatGrassExecutor.java
@@ -35,13 +35,8 @@ public class EatGrassExecutor implements IBehaviorExecutor {
                     entity.level.setBlock(entity.add(0, -1, 0), Block.get(Block.DIRT));
                 }
             }
-            if (entity instanceof EntitySheep sheep) {
-                if (sheep.isSheared()) {
-                    sheep.growWool();
-                    return false;
-                }
-                if (sheep.isBaby()) //TODO: Accelerated growth instead of instant growth
-                    sheep.setBaby(false);
+            if (entity instanceof EntitySheep sheep && sheep.isSheared()) {
+                sheep.growWool();
             }
             return false;
         }


### PR DESCRIPTION
## What does this PR do?

It stops a baby sheep from growing up when it eats grass.

## Why?

It match vanilla behaviour.

`EatGrassExecutor` was calling `sheep.setBaby(false)`, so a baby sheep became an adult the first time it ate grass. The TODO next to it said the growth should be accelerated instead of instant, but that is the Java Edition behaviour, Bedrock does not do either.

The vanilla behaviour pack shipped with the server defines what eating grass does, in `minecraft:on_eat_block` of `entities/sheep.json`:

```json
"minecraft:on_eat_block": { "sequence": [
    { "add": {"component_groups": ["minecraft:sheep_dyeable"]},
      "remove": {"component_groups": ["minecraft:sheep_sheared"]} },
    { "filters": {"test": "has_component", "operator": "!=", "subject": "other", "value": "minecraft:is_baby"},
      "add": {"component_groups": ["minecraft:rideable_wooly", "minecraft:loot_wooly"]},
      "remove": {"component_groups": ["minecraft:loot_sheared"]} }
]}
```

It regrows the wool and updates the loot state, and it never touches the age. So the growth line is removed and the TODO with it. A baby sheep keeps growing on its normal minecraft:ageable duration, handled by AnimalGrowExecutor.

Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

How was this tested?

- Server build tested: 9970efc24
- Bedrock client version:
- Plugins loaded: none

Steps performed and results:


1. summoned a baby sheep on grass with `/summon sheep ~ ~ ~`
2. let it eat the grass several times, the grass blocks under it turned to dirt
3. it stayed a baby sheep, it did not grow up
4. did the same on vanilla Bedrock 1.26.45, same result, the baby sheep does not grow up either
5. sheared an adult sheep and let it eat, the wool grows back like before

- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (gradlew test)
- [ ] I added tests for the new logic, or explained below why that isn't practical

Breaking changes / API impact

None

Performance notes

N/A

AI usage disclosure


- [x] The disclosure above covers all AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [ ] This PR description and any review replies are written by me, not generated

Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
