### PR TITLE
fix(entity): align zombified piglin equipment and drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityZombiePigman.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityZombiePigman.java
@@ -92,6 +92,9 @@ public class EntityZombiePigman extends EntityMob implements EntityWalkable, Ent
         this.diffHandDamage = new float[]{2.5f, 3f, 4.5f};
         super.initEntity();
         getMemoryStorage().put(CoreMemoryTypes.LOOKING_BLOCK, BlockTurtleEgg.class);
+        if (getEquipmentInventory().getItemInHand().isNull()) {
+            setItemInHand(Item.get(Utils.rand(0, 99) < 5 ? Item.GOLDEN_SPEAR : Item.GOLDEN_SWORD));
+        }
     }
 
     @Override
@@ -174,21 +177,12 @@ public class EntityZombiePigman extends EntityMob implements EntityWalkable, Ent
         }
 
         if (weapon != Item.AIR) {
-            if (Utils.rand(0, 199) < (5 + looting)) {
-                Item sword = Item.get(Item.GOLDEN_SWORD);
-                drops.add(sword);
-            }
-
-            if (/* TODO: isPiglinBruteZoombified() &&*/ Utils.rand(0, 199) < (5 + looting)) {
-                Item axe = Item.get(Item.GOLDEN_AXE);
-                drops.add(axe);
-            }
-
-            if (hand.getId() == Item.CROSSBOW) {
+            if (!hand.isNull() && hand.getId() != Item.WARPED_FUNGUS_ON_A_STICK
+                    && Utils.rand(0, 99) < (25 + looting * 5)) {
                 drops.add(hand.clone());
             }
 
-            if (Utils.rand(0, 999) < (10 + looting * 5)) {
+            if (Utils.rand(0, 999) < (25 + looting * 10)) {
                 drops.add(Item.get(Item.GOLD_INGOT, 0, 1));
             }
         }


### PR DESCRIPTION
## What does this PR do?

It gives the zombified piglin its weapon on spawn and makes it drop what it carries, instead of making up an item when it dies.

## Why?

It match vanilla behaviour.

Source: [Minecraft Wiki](https://minecraft.wiki/w/Zombified_Piglin) [Zombie Pigman Entity](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/zombie_pigman.json) and [zombie pigman gear](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/zombie_pigman_gear.json)
## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 4e1682b8a
- **Bedrock client version:**
- **Plugins loaded:** none

**Steps performed and results:**

1.
2.

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x]  The disclosure above covers all AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled