### PR TITLE
fix(command): reject out of range difficulty values

### DIFF
--- a/src/main/java/org/powernukkitx/command/defaults/DifficultyCommand.java
+++ b/src/main/java/org/powernukkitx/command/defaults/DifficultyCommand.java
@@ -38,6 +38,10 @@ public class DifficultyCommand extends VanillaCommand {
         switch (result.getKey()) {
             case "default" -> {
                 difficulty = list.getResult(0);
+                if (difficulty < 0 || difficulty > 3) {
+                    log.addError("commands.generic.parameter.invalid", String.valueOf(difficulty)).output();
+                    return 0;
+                }
             }
             case "byString" -> {
                 String str = list.getResult(0);


### PR DESCRIPTION
## What does this PR do?

It  reject out of range difficulty values like vanilla does.

## Why?

Because it match vanilla behaviour and messages.
## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** c37818d28
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. did /difficulty 99 in vanilla it were doing commands.generic.parameter.invalid, now its also doing it in pnx.

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
