### PR TITLE
fix(entity): align wither skeleton drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityWitherSkeleton.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityWitherSkeleton.java
@@ -25,7 +25,9 @@ import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.entity.effect.Effect;
 import org.powernukkitx.entity.effect.EffectType;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
+import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
@@ -151,22 +153,34 @@ public class EntityWitherSkeleton extends EntityMob implements EntityWalkable, E
         return true;
     }
 
-    // The probability of dropping a sword is 8.5%, and the probability of dropping a head is 2.5%.
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
         List<Item> drops = new ArrayList<>();
-        drops.add(Item.get(Item.BONE, 0, Utils.rand(0, 2)));
-        if (Utils.rand(0, 2) == 0) {
-            drops.add(Item.get(Item.COAL, 0, 1));
+
+        int bones = Utils.rand(0, 2 + looting);
+        if (bones > 0) {
+            drops.add(Item.get(Item.BONE, 0, bones));
         }
-        // The probability of obtaining a stone sword is 8.5%.
-        if (Utils.rand(0, 200) <= 17) {
+
+        int coal = Utils.rand(0, 1 + looting);
+        if (coal > 0) {
+            drops.add(Item.get(Item.COAL, 0, coal));
+        }
+
+        if (Utils.rand(0, 99) < (25 + looting * 5)) {
             drops.add(Item.get(Item.STONE_SWORD, Utils.rand(0, 131), 1));
         }
-        // The probability of losing your head is 2.5%.
-        if (Utils.rand(0, 40) == 1) {
+
+        if (killedByPlayer() && Utils.rand(0, 999) < (25 + looting * 20)) {
             drops.add(Item.get(BlockID.SKULL, 1, 1));
         }
+
         return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 }


### PR DESCRIPTION
## What does this PR do?

It aligns the wither skeleton drops with the vanilla loot table.

## Why?

It match vanilla behaviour.

Source: [wither_skeleton.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/wither_skeleton.json) and [wither_skeleton_gear.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/wither_skeleton_gear.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 8363fefeb
- **Bedrock client version:**
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled