### PR TITLE
fix(entity): align zombie drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityZombie.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityZombie.java
@@ -170,7 +170,7 @@ public class EntityZombie extends EntityMob implements EntityWalkable, EntitySmi
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
         List<Item> drops = new ArrayList<>();
 
-        int flesh = Utils.rand(0, 3 + looting);
+        int flesh = Utils.rand(0, 2 + looting);
         if (flesh > 0) {
             drops.add(Item.get(Item.ROTTEN_FLESH, 0, flesh));
         }

--- a/src/main/java/org/powernukkitx/entity/mob/EntityZombie.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityZombie.java
@@ -30,7 +30,9 @@ import org.powernukkitx.entity.ai.sensor.NearestTargetEntitySensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.entity.item.EntityItem;
+import org.powernukkitx.entity.passive.EntityChicken;
 import org.powernukkitx.entity.passive.EntityTurtle;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.event.entity.EntityDamageEvent;
 import org.powernukkitx.event.entity.EntityTransformEvent;
 import org.powernukkitx.inventory.EntityInventoryHolder;
@@ -173,17 +175,26 @@ public class EntityZombie extends EntityMob implements EntityWalkable, EntitySmi
             drops.add(Item.get(Item.ROTTEN_FLESH, 0, flesh));
         }
 
-        float rareChance = (1f / 120f) + ((1f / 300f) * looting);
-        if (Utils.rand(0f, 1f) < rareChance) {
-            int roll = Utils.rand(0, 3);
-            switch (roll) {
-                case 0 -> drops.add(Item.get(Item.IRON_INGOT));
-                case 1 -> drops.add(Item.get(Item.CARROT));
-                case 2 -> drops.add(Item.get(Item.POTATO));
+        if (killedByPlayer()) {
+            if (Utils.rand(0, 999) < (25 + looting * 10)) {
+                switch (Utils.rand(0, 2)) {
+                    case 0 -> drops.add(Item.get(Item.IRON_INGOT));
+                    case 1 -> drops.add(Item.get(Item.CARROT));
+                    default -> drops.add(Item.get(Item.POTATO));
+                }
+            }
+
+            if (isBaby() && getRiding() instanceof EntityChicken) {
+                drops.add(Item.get(Item.MUSIC_DISC_LAVA_CHICKEN));
             }
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override


### PR DESCRIPTION

## What does this PR do?

It aligns the zombie rare drops with the vanilla loot table.

## Why?

It match vanilla behaviour. The rare drop chance was 0.83% + 0.33% per looting level instead of 2.5% + 1%, it was rolling on any death instead of only when killed by a player, and the lava chicken disc was missing.

Source: [zombie.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/zombie.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** fbae84eff
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. killed zombies with a looting sword, iron ingots, carrots and potatoes now drop at the vanilla rate
2. let a zombie burn in the sun, it no longer drops the rare items

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled