### PR TITLE
fix(entity): align skeleton equipment drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntitySkeleton.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntitySkeleton.java
@@ -107,27 +107,28 @@ public class EntitySkeleton extends EntityMob implements EntityWalkable, EntityS
         }
 
         for (Item equipped : this.getEquipmentInventory().getContents().values()) {
-            if (!equipped.isNull() && !equipped.hasEnchantment(Enchantment.ID_VANISHING_CURSE)) {
-                if (equipped.isBow()) {
-                    int chance = 85 + looting * 10;
-                    if (Utils.rand(0, 999) < chance) {
-                        Item drop = equipped.clone();
-                        drop.setDamage(Utils.rand(193, 384));
-                        drops.add(drop);
-                    }
-                } else {
-                    drops.add(equipped.clone());
-                }
-            }
+            addEquipmentDrop(drops, equipped, looting);
         }
 
         for (Item armor : this.getArmorInventory().getContents().values()) {
-            if (!armor.isNull() && !armor.hasEnchantment(Enchantment.ID_VANISHING_CURSE)) {
-                drops.add(armor.clone());
-            }
+            addEquipmentDrop(drops, armor, looting);
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private void addEquipmentDrop(List<Item> drops, Item item, int looting) {
+        if (item.isNull() || item.hasEnchantment(Enchantment.ID_VANISHING_CURSE)) {
+            return;
+        }
+        if (Utils.rand(0, 99) >= (25 + looting * 5)) {
+            return;
+        }
+        Item drop = item.clone();
+        if (drop.isBow()) {
+            drop.setDamage(Utils.rand(193, 384));
+        }
+        drops.add(drop);
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?

It aligns the skeleton equipment and armor drop chances with vanilla.

## Why?

It match vanilla behaviour. The bow was using the Java chance of 8.5% + 1% per looting level instead of 25% + 5%, and the armor was dropping every time with no roll at all.

Source: [Minecraft Wiki](https://minecraft.wiki/w/Skeleton) and [skeleton_gear.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/skeleton_gear.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** da6d2847a
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled