### PR TITLE
fix(entity): align drowned drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityDrowned.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityDrowned.java
@@ -32,6 +32,7 @@ import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.ai.sensor.NearestTargetEntitySensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.passive.EntityAxolotl;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemTrident;
 import org.powernukkitx.item.enchantment.Enchantment;
@@ -42,6 +43,7 @@ import org.powernukkitx.utils.Utils;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -161,18 +163,28 @@ public class EntityDrowned extends EntityZombie implements EntitySwimmable, Enti
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
-        Item trident = Item.AIR;
-        if (getItemInHand() instanceof ItemTrident) {
-            int lootingLevel = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        List<Item> drops = new ArrayList<>();
 
-            if (Utils.rand(0, 100) < Math.min(37, 25 + lootingLevel)) {
-                trident = Item.get(Item.TRIDENT);
-            }
+        int flesh = Utils.rand(0, 2 + looting);
+        if (flesh > 0) {
+            drops.add(Item.get(Item.ROTTEN_FLESH, 0, flesh));
         }
-        return new Item[]{
-                Item.get(Item.ROTTEN_FLESH),
-                trident
-        };
+
+        if (killedByPlayer() && Utils.rand(0, 999) < (110 + looting * 20)) {
+            drops.add(Item.get(Item.COPPER_INGOT));
+        }
+
+        if (getItemInHand() instanceof ItemTrident && Utils.rand(0, 999) < (85 + looting * 10)) {
+            drops.add(Item.get(Item.TRIDENT));
+        }
+
+        return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?

It aligns the drowned drops with the vanilla loot table.

## Why?

It match vanilla behaviour. The rotten flesh count was always exactly 1 instead of 0 to 2, the copper ingot was missing entirely, and the trident was still using the old 25% chance from before it was lowered to 8.5%.

Source: [drowned.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/drowned.json) and [Minecraft Wiki](https://minecraft.wiki/w/Drowned)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 92e3da515
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. killed drowned with a looting sword, they now drop 0 to 2 rotten fle
2. copper ingots now drop, they never did before

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or r
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled