### PR TITLE
fix(entity): transfer fireball ownership when it is deflected

### DIFF
--- a/src/main/java/org/powernukkitx/entity/projectile/EntityFireball.java
+++ b/src/main/java/org/powernukkitx/entity/projectile/EntityFireball.java
@@ -14,6 +14,7 @@ import org.powernukkitx.level.vibration.VibrationEvent;
 import org.powernukkitx.level.vibration.VibrationType;
 import org.powernukkitx.math.Vector3;
 import org.powernukkitx.nbt.tag.CompoundTag;
+import org.cloudburstmc.protocol.bedrock.data.actor.ActorDataTypes;
 import org.jetbrains.annotations.NotNull;
 
 
@@ -70,6 +71,8 @@ public class EntityFireball extends EntitySmallFireball implements EntityExplosi
     public boolean attack(EntityDamageEvent source) {
         if (this.directionChanged == null && source instanceof EntityDamageByEntityEvent event) {
             this.directionChanged = event.getDamager();
+            this.shootingEntity = event.getDamager();
+            this.setDataProperty(ActorDataTypes.OWNER, event.getDamager().getId());
             this.setMotion(event.getDamager().getDirectionVector());
         }
         return true;


### PR DESCRIPTION
## What does this PR do?

It makes the player the owner of a ghast fireball after deflecting it, so the ghast can be killed by its own fireball.

## Why?

It match vanilla behaviour.

Source: [Minecraft Wiki](https://minecraft.wiki/w/Ghast)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 5ca58427d
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. hit a ghast fireball back at the ghast, before this change the ghast took no damage at all, now it dies like in vanilla
2. the kill is now credited to the player, so the drops and the experience are given

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled