### PR TITLE
fix(entity): align ghast drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityGhast.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityGhast.java
@@ -1,5 +1,6 @@
 package org.powernukkitx.entity.mob;
 
+import org.powernukkitx.Player;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityFlyable;
 import org.powernukkitx.entity.ai.behavior.Behavior;
@@ -20,6 +21,8 @@ import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.entity.projectile.EntityFireball;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
+import org.powernukkitx.event.entity.EntityDamageEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
@@ -113,18 +116,20 @@ public class EntityGhast extends EntityMob implements EntityFlyable {
 
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
 
-        if (Utils.rand(0, 1) == 1) {
-            int amount = Utils.rand(0, 1 + looting);
-            if (amount > 0) {
-                drops.add(Item.get(Item.GHAST_TEAR, 0, amount));
-            }
+        int tears = Utils.rand(0, 1 + looting);
+        if (tears > 0) {
+            drops.add(Item.get(Item.GHAST_TEAR, 0, tears));
         }
 
-        if (Utils.rand(0, 2) != 0) {
-            int amount = Utils.rand(0, 2 + looting);
-            if (amount > 0) {
-                drops.add(Item.get(Item.GUNPOWDER, 0, amount));
-            }
+        int gunpowder = Utils.rand(0, 2 + looting);
+        if (gunpowder > 0) {
+            drops.add(Item.get(Item.GUNPOWDER, 0, gunpowder));
+        }
+
+        if (this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getCause() == EntityDamageEvent.DamageCause.ENTITY_EXPLOSION
+                && event.getDamager() instanceof Player) {
+            drops.add(Item.get(Item.MUSIC_DISC_TEARS));
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);


### PR DESCRIPTION
## What does this PR do?

It aligns the ghast drops with the vanilla loot table and adds the music disc.

## Why?

It match vanilla behaviour. 

Source: [ghast.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/ghast.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 74c3f56d4
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled