### PR TITLE
fix(entity): align elder guardian drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityElderGuardian.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityElderGuardian.java
@@ -29,6 +29,8 @@ import org.powernukkitx.entity.effect.EffectType;
 import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.event.entity.EntityDamageEvent;
 import org.powernukkitx.item.Item;
+import org.powernukkitx.item.enchantment.Enchantment;
+import org.powernukkitx.item.randomitem.Fishing;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
@@ -41,6 +43,7 @@ import org.cloudburstmc.protocol.bedrock.packet.LevelEventPacket;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -137,15 +140,39 @@ public class EntityElderGuardian extends EntityMob implements EntitySwimmable {
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        List<Item> drops = new ArrayList<>();
+
+        int shards = Utils.rand(0, 2 + looting);
+        if (shards > 0) {
+            drops.add(Item.get(Item.PRISMARINE_SHARD, 0, shards));
+        }
+
         int secondLoot = ThreadLocalRandom.current().nextInt(6);
-        return new Item[]{
-                Item.get(Item.PRISMARINE_SHARD, 0, Utils.rand(0, 2)),
-                Item.get(Block.WET_SPONGE, 0, 1),
-                ThreadLocalRandom.current().nextInt(100) < 20 ? Item.get(Item.TIDE_ARMOR_TRIM_SMITHING_TEMPLATE, 0, 1) : Item.AIR,
-                ThreadLocalRandom.current().nextInt(1000) < 25 ? Item.get(Item.COD, 0, 1) : Item.AIR,
-                secondLoot <= 2 ? Item.get(Item.COD, 0, Utils.rand(0, 1)) : Item.AIR,
-                secondLoot > 2 && secondLoot <= 4 ? Item.get(Item.PRISMARINE_CRYSTALS, 0, Utils.rand(0, 1)) : Item.AIR
-        };
+        if (secondLoot <= 2) {
+            drops.add(Item.get(Item.COD, 0, 1 + Utils.rand(0, looting)));
+        } else if (secondLoot <= 4) {
+            drops.add(Item.get(Item.PRISMARINE_CRYSTALS, 0, 1 + Utils.rand(0, looting)));
+        }
+
+        if (killedByPlayer()) {
+            drops.add(Item.get(Block.WET_SPONGE, 0, 1));
+
+            if (Utils.rand(0, 999) < (25 + looting * 10)) {
+                drops.add(Fishing.getRandomFish());
+            }
+        }
+
+        if (ThreadLocalRandom.current().nextInt(5) == 0) {
+            drops.add(Item.get(Item.TIDE_ARMOR_TRIM_SMITHING_TEMPLATE, 0, 1));
+        }
+
+        return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/randomitem/Fishing.java
+++ b/src/main/java/org/powernukkitx/item/randomitem/Fishing.java
@@ -37,6 +37,16 @@ public final class Fishing {
     public static final Selector JUNK_BONE = putSelector(new ConstantItemSelector(ItemID.BONE, JUNKS), 0.12F);
     public static final Selector JUNK_TRIPWIRE_HOOK = putSelector(new ConstantItemSelector(Item.get(BlockID.TRIPWIRE_HOOK), JUNKS), 0.12F);
 
+    /**
+     * Selects a fish the way the {@code fishing/fish} loot table does, without the
+     * treasure and junk categories that {@link #getFishingResult(Item)} can also return.
+     *
+     * @return a cod, a salmon, a pufferfish or a tropical fish
+     */
+    public static Item getRandomFish() {
+        return (Item) selectFrom(FISHES);
+    }
+
     public static Item getFishingResult(Item rod) {
         int fortuneLevel = 0;
         int lureLevel = 0;


### PR DESCRIPTION
## What does this PR do?

It aligns the elder guardian drops with the vanilla loot table.

## Why?

It match vanilla behaviour. 

Source: [elder_guardian.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/elder_guardian.json) and [fish.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/gameplay/fishing/fish.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** fc28e1314
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. killed elder guardians with a looting sword, the drop counts now scale with looting
2. let an elder guardian die out of water, it no longer drops a wet sponge

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

`Fishing.getRandomFish()` is added, it rolls only the fish category of the fishing loot table. Nothing existing changed.

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code
- [x] "Allow maintainer edits" is enabled