### PR TITLE
fix(entity): align panda, vex and copper golem drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityCopperGolem.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityCopperGolem.java
@@ -44,7 +44,6 @@ import org.powernukkitx.inventory.InventoryHolder;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemHoneycomb;
 import org.powernukkitx.item.ItemShears;
-import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.GameRule;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.entity.condition.Condition;
@@ -70,6 +69,8 @@ import org.cloudburstmc.protocol.bedrock.data.SoundEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -342,13 +343,19 @@ public class EntityCopperGolem extends EntityGolem implements InventoryHolder {
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
-        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
-        int amount = Utils.rand(1, 3 + looting);
+        List<Item> drops = new ArrayList<>();
+        drops.add(Item.get(Item.COPPER_INGOT, 0, Utils.rand(1, 3)));
 
-        return new Item[]{
-                Item.get(Item.COPPER_INGOT, 0, amount),
-                getInventory().getItemInHand()
-        };
+        if (hasFlower()) {
+            drops.add(Item.get(Block.POPPY));
+        }
+
+        Item held = getInventory().getItemInHand();
+        if (!held.isNull()) {
+            drops.add(held.clone());
+        }
+
+        return drops.toArray(Item.EMPTY_ARRAY);
     }
 
     public static void checkAndSpawnGolem(Block block) {

--- a/src/main/java/org/powernukkitx/entity/mob/EntityVex.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityVex.java
@@ -28,9 +28,11 @@ import org.powernukkitx.entity.passive.EntityVillagerV2;
 import org.powernukkitx.event.entity.EntityDamageEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemTool;
+import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
+import org.powernukkitx.utils.Utils;
 import lombok.Getter;
 import lombok.Setter;
 import org.cloudburstmc.protocol.bedrock.data.actor.ActorFlags;
@@ -154,10 +156,15 @@ public class EntityVex extends EntityMob implements EntityFlyable {
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
-        if(getItemInHand() instanceof ItemTool tool) {
-            tool.setDamage(ThreadLocalRandom.current().nextInt(tool.getMaxDurability()));
+        if (getItemInHand() instanceof ItemTool tool) {
+            int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+            if (Utils.rand(0, 99) >= (25 + looting * 5)) {
+                return Item.EMPTY_ARRAY;
+            }
+            Item drop = tool.clone();
+            drop.setDamage(ThreadLocalRandom.current().nextInt(tool.getMaxDurability()));
             return new Item[] {
-                tool
+                drop
             };
         }
         return super.getDrops(weapon);

--- a/src/main/java/org/powernukkitx/entity/passive/EntityPanda.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityPanda.java
@@ -54,6 +54,7 @@ import org.powernukkitx.inventory.EntityEquipmentInventory;
 import org.powernukkitx.inventory.Inventory;
 import org.powernukkitx.inventory.InventoryHolder;
 import org.powernukkitx.item.Item;
+import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
@@ -201,8 +202,13 @@ public class EntityPanda extends EntityAnimal implements EntityWalkable, EntityC
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        int bamboo = Utils.rand(0, 2 + looting);
+        if (bamboo == 0) {
+            return Item.EMPTY_ARRAY;
+        }
         return new Item[]{
-                Item.get(Block.BAMBOO, 0, Utils.rand(0, 3))
+                Item.get(Block.BAMBOO, 0, bamboo)
         };
     }
 


### PR DESCRIPTION
## What does this PR do?

It aligns the panda, vex and copper golem drops with the vanilla loot tables.

## Why?

It match vanilla behaviour. 

Source: [panda.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/panda.json), [copper_golem.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/copper_golem.json) and [Minecraft Wiki](https://minecraft.wiki/w/Vex)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 74bd88692
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. killed pandas with a looting sword, the bamboo count now scales with 2 without it
2. killed vexes, the iron sword no longer drops on every kill
3. killed a copper golem holding a flower, it now drops the poppy

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or r
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled