### PR TITLE
fix(entity): align blaze, rabbit and hoglin drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityBlaze.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityBlaze.java
@@ -21,6 +21,7 @@ import org.powernukkitx.entity.ai.route.posevaluator.FlyingPosEvaluator;
 import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.event.entity.EntityDamageEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.enchantment.Enchantment;
@@ -126,17 +127,22 @@ public class EntityBlaze extends EntityMob implements EntityFlyable {
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
-        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
-
-        float chance = 0.5f + (0.25f * looting);
-        chance = Math.min(chance, 1.0f);
-
-        if (Utils.rand(0f, 1f) < chance) {
-            int amount = Utils.rand(1, 1 + looting);
-            return new Item[]{Item.get(Item.BLAZE_ROD, 0, amount)};
+        if (!killedByPlayer()) {
+            return Item.EMPTY_ARRAY;
         }
 
-        return Item.EMPTY_ARRAY;
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        int rods = Utils.rand(0, 1 + looting);
+        if (rods == 0) {
+            return Item.EMPTY_ARRAY;
+        }
+
+        return new Item[]{Item.get(Item.BLAZE_ROD, 0, rods)};
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityHoglin.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityHoglin.java
@@ -169,11 +169,9 @@ public class EntityHoglin extends EntityMob implements EntityWalkable {
                 porkAmount
         ));
 
-        if (Utils.rand(0, 1) == 1) {
-            int leatherAmount = Utils.rand(0, 1 + looting);
-            if (leatherAmount > 0) {
-                drops.add(Item.get(Item.LEATHER, 0, leatherAmount));
-            }
+        int leatherAmount = Utils.rand(0, 1 + looting);
+        if (leatherAmount > 0) {
+            drops.add(Item.get(Item.LEATHER, 0, leatherAmount));
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);

--- a/src/main/java/org/powernukkitx/entity/passive/EntityRabbit.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityRabbit.java
@@ -162,30 +162,30 @@ public class EntityRabbit extends EntityAnimal implements EntityWalkable, Entity
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
         List<Item> drops = new ArrayList<>();
 
-        if (Utils.rand(0, 1) == 0) {
-            int amount = Utils.rand(0, 1 + looting);
-            if (amount > 0) {
-                drops.add(Item.get(Item.RABBIT_HIDE, 0, amount));
-            }
+        int hide = Utils.rand(0, 1 + looting);
+        if (hide > 0) {
+            drops.add(Item.get(Item.RABBIT_HIDE, 0, hide));
         }
 
-        if (Utils.rand(0, 1) == 0) {
-            int amount = Utils.rand(0, 1 + looting);
-            if (amount > 0) {
-                drops.add(Item.get(
-                        this.isOnFire() ? Item.COOKED_RABBIT : Item.RABBIT,
-                        0,
-                        amount
-                ));
-            }
+        int meat = Utils.rand(0, 1 + looting);
+        if (meat > 0) {
+            drops.add(Item.get(
+                    this.isOnFire() ? Item.COOKED_RABBIT : Item.RABBIT,
+                    0,
+                    meat
+            ));
         }
 
-        float footChance = 0.10f + (0.03f * looting);
-        if (Utils.rand(0f, 1f) < footChance) {
+        if (killedByPlayer() && Utils.rand(0, 999) < (100 + looting * 30)) {
             drops.add(Item.get(Item.RABBIT_FOOT));
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?

It aligns the blaze, rabbit and hoglin drops with the vanilla loot tables.

## Why?

It match vanilla behaviour. 

Source: [blaze.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/blaze.json), [rabbit.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/rabbit.json) and [hoglin.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/hoglin.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 231542e3e
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. killed blazes with a sword, they drop rods again, killed one with lathing
2. killed rabbits and hoglins, the hide, the meat and the leather now drop at the vanilla rate

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled