### PR TITLE
fix(entity): align enderman drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityEnderman.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityEnderman.java
@@ -151,12 +151,9 @@ public class EntityEnderman extends EntityMob implements EntityWalkable {
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
         List<Item> drops = new ArrayList<>();
 
-        float pearlChance = 0.5f + (0.05f * looting);
-        pearlChance = Math.min(pearlChance, 1.0f);
-
-        if (Utils.rand(0f, 1f) < pearlChance) {
-            int amount = Utils.rand(1, 1 + looting);
-            drops.add(Item.get(Item.ENDER_PEARL, 0, amount));
+        int pearls = Utils.rand(0, 1 + looting);
+        if (pearls > 0) {
+            drops.add(Item.get(Item.ENDER_PEARL, 0, pearls));
         }
 
         Item hand = getItemInHand();


### PR DESCRIPTION
It aligns the enderman ender pearl drop with the vanilla loot table.

## Why?

It match vanilla behaviour. 

Source: [enderman.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/enderman.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 4cc31ef77
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. killed endermen with and without a looting sword, the pearl count now scales with looting and can be zero

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bu
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled