### PR TITLE
fix(entity): align phantom and spider drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityPhantom.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityPhantom.java
@@ -27,6 +27,7 @@ import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.ai.sensor.NearestTargetEntitySensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemID;
 import org.powernukkitx.item.enchantment.Enchantment;
@@ -128,20 +129,24 @@ public class EntityPhantom extends EntityMob implements EntityFlyable, EntitySmi
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
-        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
-
-        if (Utils.rand(0, 1) == 0) {
+        if (!killedByPlayer()) {
             return Item.EMPTY_ARRAY;
         }
 
-        int amount = Utils.rand(0, 1 + looting);
-        if (amount <= 0) {
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        int membranes = Utils.rand(0, 1 + looting);
+        if (membranes == 0) {
             return Item.EMPTY_ARRAY;
         }
 
         return new Item[]{
-                Item.get(ItemID.PHANTOM_MEMBRANE, 0, amount)
+                Item.get(ItemID.PHANTOM_MEMBRANE, 0, membranes)
         };
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntitySpider.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntitySpider.java
@@ -27,6 +27,7 @@ import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.entity.components.RideableComponent;
 import org.powernukkitx.entity.passive.EntityArmadillo;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
@@ -389,23 +390,24 @@ public class EntitySpider extends EntityMob implements EntityWalkable, EntityArt
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
         List<Item> drops = new ArrayList<>();
 
-        float stringChance = 0.70f + (0.10f * looting);
-        stringChance = Math.min(stringChance, 1.0f);
-
-        if (Utils.rand(0f, 1f) < stringChance) {
-            int amount = Utils.rand(1, 2 + looting);
-            drops.add(Item.get(Item.STRING, 0, amount));
+        int string = Utils.rand(0, 2 + looting);
+        if (string > 0) {
+            drops.add(Item.get(Item.STRING, 0, string));
         }
 
-        float eyeChance = 0.50f + (0.05f * looting);
-        eyeChance = Math.min(eyeChance, 1.0f);
-
-        if (Utils.rand(0f, 1f) < eyeChance) {
-            int amount = Utils.rand(1, 1 + looting);
-            drops.add(Item.get(Item.SPIDER_EYE, 0, amount));
+        if (killedByPlayer()) {
+            int eyes = Utils.rand(0, 1 + looting);
+            if (eyes > 0) {
+                drops.add(Item.get(Item.SPIDER_EYE, 0, eyes));
+            }
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?

It aligns the phantom and spider drops with the vanilla loot tables.

## Why?

It match vanilla behaviour. 

Source: [phantom.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/phantom.json) and [spider.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/spider.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** f1c7c2b4d
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code
- [x] "Allow maintainer edits" is enabled