### PR TITLE
fix(entity): drop the ravager saddle when killed by a player

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityRavager.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityRavager.java
@@ -16,6 +16,8 @@ import org.powernukkitx.entity.ai.route.posevaluator.WalkingPosEvaluator;
 import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
+import org.powernukkitx.item.Item;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
 
@@ -94,5 +96,18 @@ public class EntityRavager extends EntityMob implements EntityWalkable {
     @Override
     public Integer getExperienceDrops() {
         return 20;
+    }
+
+    @Override
+    public Item[] getDrops(@NotNull Item weapon) {
+        if (!killedByPlayer()) {
+            return Item.EMPTY_ARRAY;
+        }
+        return new Item[]{Item.get(Item.SADDLE)};
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 }


### PR DESCRIPTION
## What does this PR do?

It makes the ravager drop its saddle, which it never did.

## Why?

It match vanilla behaviour. `EntityRavager` had no `getDrops` at all, so it fell back to the one from `EntityMob` which only returns the mob inventory. The saddle is a guaranteed drop when the ravager is killed by a player.

Source: [ravager.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/ravager.json) and [Minecraft Wiki](https://minecraft.wiki/w/Ravager)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 7feec4821
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. killed a ravager, it now drops one saddle, it dropped nothing before
2. let a ravager die without a player killing it, no saddle drops

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled