### PR TITLE
fix(entity): align shulker and cow drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityShulker.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityShulker.java
@@ -174,16 +174,14 @@ public class EntityShulker extends EntityMob implements EntityVariant {
     public Item[] getDrops(@NotNull Item weapon) {
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
 
-        if (Utils.rand(0, 1) == 0) {
-            int amount = Utils.rand(0, 1 + looting);
-            if (amount > 0) {
-                return new Item[]{
-                        Item.get(Item.SHULKER_SHELL, 0, amount)
-                };
-            }
+        int shells = Utils.rand(0, 1 + looting);
+        if (shells == 0) {
+            return Item.EMPTY_ARRAY;
         }
 
-        return Item.EMPTY_ARRAY;
+        return new Item[]{
+                Item.get(Item.SHULKER_SHELL, 0, shells)
+        };
     }
 
     public void teleport() {

--- a/src/main/java/org/powernukkitx/entity/passive/EntityCow.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityCow.java
@@ -168,11 +168,9 @@ public class EntityCow extends EntityAnimal implements EntityWalkable, ClimateVa
                 beefAmount
         ));
 
-        if (Utils.rand(0f, 1f) < (2f / 3f)) {
-            int leatherAmount = Utils.rand(0, 2 + looting);
-            if (leatherAmount > 0) {
-                drops.add(Item.get(Item.LEATHER, 0, leatherAmount));
-            }
+        int leatherAmount = Utils.rand(0, 2 + looting);
+        if (leatherAmount > 0) {
+            drops.add(Item.get(Item.LEATHER, 0, leatherAmount));
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);


### PR DESCRIPTION
## What does this PR do?

It aligns the shulker and cow drops with the vanilla loot tables.

## Why?

It match vanilla behaviour. 

Source: [shulker.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/shulker.json) and [cow.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/cow.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** cc0f2a5ce
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bu
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled