### PR TITLE
fix(entity): align guardian drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityGuardian.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityGuardian.java
@@ -27,6 +27,7 @@ import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.event.entity.EntityDamageEvent;
 import org.powernukkitx.item.Item;
+import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
@@ -34,6 +35,7 @@ import org.powernukkitx.utils.Utils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -136,13 +138,31 @@ public class EntityGuardian extends EntityMob implements EntitySwimmable {
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
-        int secondLoot = ThreadLocalRandom.current().nextInt(6);
-        return new Item[]{
-                Item.get(Item.PRISMARINE_SHARD, 0, Utils.rand(0, 2)),
-                ThreadLocalRandom.current().nextInt(1000) <= 25 ? Item.get(Item.COD, 0, 1) : Item.AIR,
-                secondLoot <= 2 ? Item.get(Item.COD, 0, Utils.rand(0, 1)) : Item.AIR,
-                secondLoot > 2 && secondLoot <= 4 ? Item.get(Item.PRISMARINE_CRYSTALS, 0, Utils.rand(0, 1)) : Item.AIR
-        };
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        List<Item> drops = new ArrayList<>();
+
+        int shards = Utils.rand(0, 2 + looting);
+        if (shards > 0) {
+            drops.add(Item.get(Item.PRISMARINE_SHARD, 0, shards));
+        }
+
+        int secondLoot = ThreadLocalRandom.current().nextInt(5);
+        if (secondLoot <= 1) {
+            drops.add(Item.get(Item.COD, 0, 1 + Utils.rand(0, looting)));
+        } else if (secondLoot <= 3) {
+            drops.add(Item.get(Item.PRISMARINE_CRYSTALS, 0, 1 + Utils.rand(0, looting)));
+        }
+
+        if (killedByPlayer() && Utils.rand(0, 999) < (25 + looting * 10)) {
+            drops.add(Item.get(Item.COD, 0, 1));
+        }
+
+        return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?

It aligns the guardian drops with the vanilla loot table.

## Why?

It match vanilla behaviour. 

Source: [guardian.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/guardian.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** d4f0be1d9
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors                                                                                            - [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled