### PR TITLE
fix(entity): align cave spider drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityCaveSpider.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityCaveSpider.java
@@ -25,6 +25,7 @@ import org.powernukkitx.entity.ai.sensor.NearestTargetEntitySensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.entity.passive.EntityArmadillo;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
@@ -138,15 +139,18 @@ public class EntityCaveSpider extends EntityMob implements EntityWalkable, Entit
             drops.add(Item.get(Item.STRING, 0, stringAmount));
         }
 
-        float eyeChance = 0.5f - (looting * (1f / 12f));
-        if (eyeChance < 0f) {
-            eyeChance = 0f;
-        }
-
-        if (Utils.rand(0f, 1f) < eyeChance) {
-            drops.add(Item.get(Item.SPIDER_EYE, 0, 1));
+        if (killedByPlayer()) {
+            int eyes = Utils.rand(0, 1 + looting);
+            if (eyes > 0) {
+                drops.add(Item.get(Item.SPIDER_EYE, 0, eyes));
+            }
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 }


### PR DESCRIPTION
## What does this PR do?

It aligns the cave spider spider eye drop with the vanilla loot table.

## Why?

It match vanilla behaviour. Looting was lowering the drop chance instead of raising the amount, so a cave spider killed with looting III dropped the eye half as often as one killed with a bare hand, and with looting VI it never dropped at all. The eye was also dropping on any death instead of only when killed by a player.

Source: [cave_spider.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/cave_spider.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** fa529224e
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. killed cave spiders with a looting III sword, the eye now drops more often instead of less
2. let a cave spider die without a player killing it, the eye no longer drops

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, con
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled