### PR TITLE
fix(entity): add the missing glow squid, pillager and warden drops

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityPillager.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityPillager.java
@@ -21,12 +21,16 @@ import org.powernukkitx.entity.ai.sensor.NearestTargetEntitySensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.item.Item;
+import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
+import org.powernukkitx.utils.Utils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -106,5 +110,18 @@ public class EntityPillager extends EntityIllager implements EntityWalkable {
     @Override
     public boolean attackTarget(Entity entity) {
         return super.attackTarget(entity) || entity instanceof EntityGolem;
+    }
+
+    @Override
+    public Item[] getDrops(@NotNull Item weapon) {
+        List<Item> drops = new ArrayList<>(Arrays.asList(super.getDrops(weapon)));
+
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        int arrows = Utils.rand(0, 2 + looting);
+        if (arrows > 0) {
+            drops.add(Item.get(Item.ARROW, 0, arrows));
+        }
+
+        return drops.toArray(Item.EMPTY_ARRAY);
     }
 }

--- a/src/main/java/org/powernukkitx/entity/mob/EntityWarden.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityWarden.java
@@ -2,6 +2,7 @@ package org.powernukkitx.entity.mob;
 
 import org.powernukkitx.Player;
 import org.powernukkitx.Server;
+import org.powernukkitx.block.BlockID;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityCreature;
 import org.powernukkitx.entity.EntityWalkable;
@@ -30,6 +31,7 @@ import org.powernukkitx.entity.effect.EffectType;
 import org.powernukkitx.entity.projectile.EntityProjectile;
 import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.event.entity.EntityDamageEvent;
+import org.powernukkitx.item.Item;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.level.vibration.VibrationEvent;
@@ -359,5 +361,10 @@ public class EntityWarden extends EntityMob implements EntityWalkable, Vibration
     @Override
     public void setOnFire(int seconds) {
         //against fire
+    }
+
+    @Override
+    public Item[] getDrops(@NotNull Item weapon) {
+        return new Item[]{Item.get(BlockID.SCULK_CATALYST)};
     }
 }

--- a/src/main/java/org/powernukkitx/entity/passive/EntityGlowSquid.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityGlowSquid.java
@@ -3,8 +3,12 @@ package org.powernukkitx.entity.passive;
 import org.powernukkitx.entity.EntitySwimmable;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
+import org.powernukkitx.item.Item;
+import org.powernukkitx.item.ItemID;
+import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
+import org.powernukkitx.utils.Utils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -49,5 +53,13 @@ public class EntityGlowSquid extends EntityAnimal implements EntitySwimmable {
     @Override
     public Set<String> typeFamily() {
         return Set.of("squid", "mob");
+    }
+
+    @Override
+    public Item[] getDrops(@NotNull Item weapon) {
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        return new Item[]{
+                Item.get(ItemID.GLOW_INK_SAC, 0, Utils.rand(1, 3 + looting))
+        };
     }
 }


### PR DESCRIPTION
## What does this PR do?

It adds the drops of the glow squid, the pillager and the warden, which had none at all.

## Why?

It match vanilla behaviour. None of these three had a `getDrops`, so they fell back to the inherited one and dropped nothing. The glow squid gives glow ink sacs, the pillager gives arrows and the warden gives a sculk catalyst.

Source: [glow_squid.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/glow_squid.json), [pillager.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/pillager.json) and [warden.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/warden.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** ea344049b
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled