### PR TITLE
fix(entity): align bogged drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityBogged.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityBogged.java
@@ -101,7 +101,7 @@ public class EntityBogged extends EntityMob implements EntityWalkable, EntitySmi
         if (killedByPlayer()) {
             int poisonAmount = Utils.rand(0, 1 + looting);
             if (poisonAmount > 0) {
-                drops.add(Item.get(Item.ARROW, 27, poisonAmount));
+                drops.add(Item.get(Item.ARROW, 26, poisonAmount));
             }
         }
 

--- a/src/main/java/org/powernukkitx/entity/mob/EntityBogged.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityBogged.java
@@ -19,6 +19,7 @@ import org.powernukkitx.entity.ai.route.posevaluator.WalkingPosEvaluator;
 import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemID;
 import org.powernukkitx.item.enchantment.Enchantment;
@@ -97,17 +98,19 @@ public class EntityBogged extends EntityMob implements EntityWalkable, EntitySmi
             drops.add(Item.get(Item.ARROW, 0, arrowAmount));
         }
 
-        float poisonChance = 0.5f - (looting * (1f / 12f));
-        if (poisonChance < 0f) {
-            poisonChance = 0f;
-        }
-
-        if (Utils.rand(0f, 1f) < poisonChance) {
-            int poisonAmount = Utils.rand(1, Math.min(1 + looting, 4));
-            drops.add(Item.get(Item.ARROW, 27, poisonAmount));
+        if (killedByPlayer()) {
+            int poisonAmount = Utils.rand(0, 1 + looting);
+            if (poisonAmount > 0) {
+                drops.add(Item.get(Item.ARROW, 27, poisonAmount));
+            }
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?

It aligns the bogged tipped arrow drop with the vanilla loot table.

## Why?

It match vanilla behaviour. Looting was lowering the drop chance instead of raising the amount, so a bogged killed with looting III dropped the poison arrow half as often as one killed with a bare hand, and with looting VI it never dropped at all. The arrow was also dropping on any death instead of only when killed by a player.

Source: [bogged.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/bogged.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 8ee2ba2d7
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
