### PR TITLE
fix(entity): align stray and polar bear drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityStray.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityStray.java
@@ -20,6 +20,7 @@ import org.powernukkitx.entity.ai.sensor.NearestEntitySensor;
 import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemID;
 import org.powernukkitx.item.enchantment.Enchantment;
@@ -91,23 +92,29 @@ public class EntityStray extends EntityMob implements EntityWalkable, EntitySmit
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
         List<Item> drops = new ArrayList<>();
 
-        float boneChance = 0.66f + (0.12f * looting);
-        boneChance = Math.min(boneChance, 1.0f);
-
-        if (Utils.rand(0f, 1f) < boneChance) {
-            int amount = Utils.rand(1, 2 + looting);
-            drops.add(Item.get(Item.BONE, 0, amount));
+        int bones = Utils.rand(0, 2 + looting);
+        if (bones > 0) {
+            drops.add(Item.get(Item.BONE, 0, bones));
         }
 
-        float arrowChance = 0.55f + (0.10f * looting);
-        arrowChance = Math.min(arrowChance, 1.0f);
+        int arrows = Utils.rand(0, 2 + looting);
+        if (arrows > 0) {
+            drops.add(Item.get(Item.ARROW, 0, arrows));
+        }
 
-        if (Utils.rand(0f, 1f) < arrowChance) {
-            int amount = Utils.rand(1, 2 + looting);
-            drops.add(Item.get(Item.ARROW, 0, amount));
+        if (killedByPlayer()) {
+            int slownessArrows = Utils.rand(0, 1 + looting);
+            if (slownessArrows > 0) {
+                drops.add(Item.get(Item.ARROW, 18, slownessArrows));
+            }
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/passive/EntityPolarBear.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityPolarBear.java
@@ -71,26 +71,22 @@ public class EntityPolarBear extends EntityAnimal implements EntityWalkable {
 
         List<Item> drops = new ArrayList<>();
 
-        if (Utils.rand(0, 2) != 0) {
-            int amount = Utils.rand(0, 2 + looting);
-            if (amount > 0) {
-                drops.add(Item.get(
-                        this.isOnFire() ? Item.COOKED_COD : Item.COD,
-                        0,
-                        amount
-                ));
-            }
+        int cod = Utils.rand(0, 2 + looting);
+        if (cod > 0) {
+            drops.add(Item.get(
+                    this.isOnFire() ? Item.COOKED_COD : Item.COD,
+                    0,
+                    cod
+            ));
         }
 
-        if (Utils.rand(0, 2) != 0) {
-            int amount = Utils.rand(0, 2 + looting);
-            if (amount > 0) {
-                drops.add(Item.get(
-                        this.isOnFire() ? Item.COOKED_SALMON : Item.SALMON,
-                        0,
-                        amount
-                ));
-            }
+        int salmon = Utils.rand(0, 2 + looting);
+        if (salmon > 0) {
+            drops.add(Item.get(
+                    this.isOnFire() ? Item.COOKED_SALMON : Item.SALMON,
+                    0,
+                    salmon
+            ));
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);


### PR DESCRIPTION
## What does this PR do?

It aligns the stray and polar bear drops with the vanilla loot tables, and adds the stray slowness arrow.

## Why?

It match vanilla behaviour. The stray was rolling a made up chance of 66% and 55% before its bone and arrow counts, and never dropped the slowness arrow at all. The polar bear had a two thirds gate before each of its two pools, which the table does not have.

Source: [stray.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/stray.json) and [polar_bear.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/polar_bear.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** f7ec15a09
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
