### PR TITLE
fix(entity): remove the extra roll before the leather and bone drops

### DIFF
--- a/src/main/java/org/powernukkitx/entity/passive/EntityCamelHusk.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityCamelHusk.java
@@ -169,11 +169,9 @@ public class EntityCamelHusk extends EntityCamel {
         ArrayList<Item> drops = new ArrayList<>();
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
 
-        if (Utils.rand(0, 2) != 0) {
-            int rottenFlesh = Utils.rand(2, 3 + looting);
-            if (rottenFlesh > 0) {
-                drops.add(Item.get(Item.ROTTEN_FLESH, 0, rottenFlesh));
-            }
+        int rottenFlesh = Utils.rand(2, 3 + looting);
+        if (rottenFlesh > 0) {
+            drops.add(Item.get(Item.ROTTEN_FLESH, 0, rottenFlesh));
         }
 
         // Drop Ride Inventory

--- a/src/main/java/org/powernukkitx/entity/passive/EntityHorse.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityHorse.java
@@ -344,11 +344,9 @@ public class EntityHorse extends EntityAnimal implements EntityWalkable, EntityV
         ArrayList<Item> drops = new ArrayList<>();
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
 
-        if (Utils.rand(0, 2) != 0) {
-            int leatherAmount = Utils.rand(0, 2 + looting);
-            if (leatherAmount > 0) {
-                drops.add(Item.get(Item.LEATHER, 0, leatherAmount));
-            }
+        int leatherAmount = Utils.rand(0, 2 + looting);
+        if (leatherAmount > 0) {
+            drops.add(Item.get(Item.LEATHER, 0, leatherAmount));
         }
 
         // Drop Ride Inventory

--- a/src/main/java/org/powernukkitx/entity/passive/EntityLlama.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityLlama.java
@@ -294,11 +294,9 @@ public class EntityLlama extends EntityAnimal implements EntityWalkable, Invento
         ArrayList<Item> drops = new ArrayList<>();
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
 
-        if (Utils.rand(0, 2) != 0) {
-            int amount = Utils.rand(0, 2 + looting);
-            if (amount > 0) {
-                drops.add(Item.get(Item.LEATHER, 0, amount));
-            }
+        int amount = Utils.rand(0, 2 + looting);
+        if (amount > 0) {
+            drops.add(Item.get(Item.LEATHER, 0, amount));
         }
 
         // Drop Ride Inventory

--- a/src/main/java/org/powernukkitx/entity/passive/EntityMooshroom.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityMooshroom.java
@@ -210,11 +210,9 @@ public class EntityMooshroom extends EntityAnimal implements EntityWalkable, Ent
                 meatAmount
         ));
 
-        if (Utils.rand(0, 2) != 0) {
-            int leatherAmount = Utils.rand(0, 2 + looting);
-            if (leatherAmount > 0) {
-                drops.add(Item.get(Item.LEATHER, 0, leatherAmount));
-            }
+        int leatherAmount = Utils.rand(0, 2 + looting);
+        if (leatherAmount > 0) {
+            drops.add(Item.get(Item.LEATHER, 0, leatherAmount));
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);

--- a/src/main/java/org/powernukkitx/entity/passive/EntitySkeletonHorse.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntitySkeletonHorse.java
@@ -211,13 +211,11 @@ public class EntitySkeletonHorse extends EntityAnimal implements EntityWalkable 
     public Item[] getDrops(@NotNull Item weapon) {
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
 
-        if (Utils.rand(0, 2) != 0) {
-            int amount = Utils.rand(0, 2 + looting);
-            if (amount > 0) {
-                return new Item[]{
-                        Item.get(Item.BONE, 0, amount)
-                };
-            }
+        int amount = Utils.rand(0, 2 + looting);
+        if (amount > 0) {
+            return new Item[]{
+                    Item.get(Item.BONE, 0, amount)
+            };
         }
 
         return Item.EMPTY_ARRAY;


### PR DESCRIPTION
## What does this PR do?

It removes an extra roll that ran before the leather and bone drop counts of five mobs.

## Why?

It match vanilla behaviour. The horse, the llama, the mooshroom, the skeleton horse and the husk camel all had the same `Utils.rand(0, 2) != 0` gate before rolling their count, so their leather, bone and rotten flesh only dropped two thirds of the time. None of the loot tables has that gate, the count itself is what is rolled.

Source: [horse.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/horse.json), [llama.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/llama.json), [mooshroom.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/mooshroom.json), [skeleton_horse.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/skeleton_horse.json) and [camel_husk.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/camel_husk.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 0a007a679
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
