### PR TITLE
fix(entity): align dolphin and slime drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntitySlime.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntitySlime.java
@@ -185,7 +185,10 @@ public class EntitySlime extends EntityMob implements EntityWalkable, EntityVari
         }
 
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
-        int amount = Utils.rand(1, 2) + looting;
+        int amount = Utils.rand(0, 2 + looting);
+        if (amount == 0) {
+            return Item.EMPTY_ARRAY;
+        }
 
         return new Item[]{
                 Item.get(Item.SLIME_BALL, 0, amount)

--- a/src/main/java/org/powernukkitx/entity/passive/EntityDolphin.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityDolphin.java
@@ -82,10 +82,6 @@ public class EntityDolphin extends EntityAnimal implements EntitySwimmable {
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
-        if (Utils.rand(0f, 1f) >= 0.5f) {
-            return Item.EMPTY_ARRAY;
-        }
-
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
 
         int amount = Utils.rand(0, 1 + looting);


### PR DESCRIPTION
## What does this PR do?

It aligns the dolphin and slime drops with the vanilla loot tables.

## Why?

It match vanilla behaviour. The dolphin had a 50% gate before rolling its fish count, which no loot table has. The slime ball count was rolled as 1 to 2 plus the looting level, so it could never be zero and looting was added on top instead of raising the maximum.

Source: [dolphin.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/dolphin.json) and [slime.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/slime.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 1f08afdc0
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
