### PR TITLE
fix(entity): align breeze and evoker drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityBreeze.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityBreeze.java
@@ -1,5 +1,6 @@
 package org.powernukkitx.entity.mob;
 
+import org.powernukkitx.Player;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.ai.behavior.Behavior;
 import org.powernukkitx.entity.ai.behaviorgroup.BehaviorGroup;
@@ -20,6 +21,7 @@ import org.powernukkitx.entity.ai.route.posevaluator.WalkingPosEvaluator;
 import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.event.entity.EntityDamageEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.enchantment.Enchantment;
@@ -90,6 +92,10 @@ public class EntityBreeze extends EntityMob {
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
+        if (!killedByPlayer()) {
+            return Item.EMPTY_ARRAY;
+        }
+
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
 
         int min = 1 + looting;
@@ -100,6 +106,11 @@ public class EntityBreeze extends EntityMob {
         return new Item[]{
                 Item.get(Item.BREEZE_ROD, 0, amount)
         };
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityEvocationIllager.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityEvocationIllager.java
@@ -206,9 +206,14 @@ public class EntityEvocationIllager extends EntityIllager implements EntityWalka
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
         int lootingLevel = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        int emeralds = Utils.rand(0, 1 + lootingLevel);
+        if (emeralds == 0) {
+            return new Item[] {Item.get(Item.TOTEM_OF_UNDYING)};
+        }
+
         return new Item[] {
                 Item.get(Item.TOTEM_OF_UNDYING),
-                Item.get(Item.EMERALD, 0, Utils.rand(0, 2 + lootingLevel))
+                Item.get(Item.EMERALD, 0, emeralds)
         };
     }
 


### PR DESCRIPTION
## What does this PR do?

It aligns the breeze and evoker drops with the vanilla loot tables.

## Why?

It match vanilla behaviour. The breeze rod was dropping on any death instead of only when killed by a player, and the evoker emerald count went up to 2 instead of 1 before the looting bonus.

Source: [breeze.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/breeze.json) and [evocation_illager.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/evocation_illager.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** ee5f0f48f
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
