### PR TITLE
fix(entity): align vindicator, snow golem and turtle drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntitySnowGolem.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntitySnowGolem.java
@@ -33,6 +33,7 @@ import org.powernukkitx.level.vibration.VibrationType;
 import org.powernukkitx.math.BlockFace;
 import org.powernukkitx.math.Vector3;
 import org.powernukkitx.nbt.tag.CompoundTag;
+import org.powernukkitx.utils.Utils;
 import org.powernukkitx.nbt.tag.DoubleTag;
 import org.powernukkitx.nbt.tag.FloatTag;
 import org.powernukkitx.nbt.tag.ListTag;
@@ -44,7 +45,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
 
 
 public class EntitySnowGolem extends EntityGolem {
@@ -165,23 +165,14 @@ public class EntitySnowGolem extends EntityGolem {
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
-        ThreadLocalRandom random = ThreadLocalRandom.current();
-        int randDrop = random.nextInt(3);
-
-        switch (randDrop) {
-            case 0:
-                return new Item[]{
-                        Item.get(ItemID.SNOWBALL, 0, random.nextInt(0, 9))
-                };
-            case 1:
-                return new Item[]{
-                        Item.get(ItemID.SNOWBALL, 0, random.nextInt(8, 17))
-                };
-            case 2:
-                return Item.EMPTY_ARRAY;
-            default:
-                return Item.EMPTY_ARRAY;
+        int snowballs = Utils.rand(0, 15);
+        if (snowballs == 0) {
+            return Item.EMPTY_ARRAY;
         }
+
+        return new Item[]{
+                Item.get(ItemID.SNOWBALL, 0, snowballs)
+        };
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityVindicator.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityVindicator.java
@@ -22,6 +22,7 @@ import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.ai.sensor.NearestTargetEntitySensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
@@ -35,6 +36,7 @@ import org.cloudburstmc.protocol.bedrock.data.actor.ActorFlags;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -130,12 +132,28 @@ public class EntityVindicator extends EntityIllager implements EntityWalkable {
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
-        Item axe = Item.get(Item.IRON_AXE);
-        axe.setDamage(ThreadLocalRandom.current().nextInt(1, axe.getMaxDurability()));
-        return new Item[]{
-                axe,
-                Item.get(Item.EMERALD, 0, Utils.rand(0, 2 + looting))
-        };
+        List<Item> drops = new ArrayList<>();
+
+        Item hand = getItemInHand();
+        if (!hand.isNull() && Utils.rand(0, 99) < (25 + looting * 5)) {
+            Item axe = hand.clone();
+            axe.setDamage(ThreadLocalRandom.current().nextInt(1, axe.getMaxDurability()));
+            drops.add(axe);
+        }
+
+        if (killedByPlayer()) {
+            int emeralds = Utils.rand(0, 1 + looting);
+            if (emeralds > 0) {
+                drops.add(Item.get(Item.EMERALD, 0, emeralds));
+            }
+        }
+
+        return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/passive/EntityTurtle.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityTurtle.java
@@ -35,10 +35,13 @@ import org.powernukkitx.entity.components.BreedableComponent;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.event.entity.EntityDamageEvent;
+import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemID;
+import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.math.Vector3;
 import org.powernukkitx.nbt.tag.CompoundTag;
+import org.powernukkitx.utils.Utils;
 import it.unimi.dsi.fastutil.Pair;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -64,6 +67,19 @@ public class EntityTurtle extends EntityAnimal implements EntitySwimmable, Entit
     @Override
     public String getOriginalName() {
         return "Turtle";
+    }
+
+    @Override
+    public Item[] getDrops(@NotNull Item weapon) {
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        int seagrass = Utils.rand(0, 2 + looting);
+        if (seagrass == 0) {
+            return Item.EMPTY_ARRAY;
+        }
+
+        return new Item[]{
+                Item.get(BlockID.SEAGRASS, 0, seagrass)
+        };
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?

It aligns the vindicator, snow golem and turtle drops with the vanilla loot tables.

## Why?

It match vanilla behaviour.

The vindicator was building a brand new iron axe instead of dropping the one it holds, so a vindicator whose weapon was changed still dropped an iron axe and any enchantment on it was lost. The axe also dropped every time instead of the 25% equipment chance, and the emerald went up to 2 instead of 1 and ignored the killed by player condition.

The snow golem was picking one of three branches, so a third of them dropped nothing at all and the count could reach 16, while the table is a plain 0 to 15 roll.

The turtle had no `getDrops` at all, so it never dropped seagrass.

Source: [vindication_illager.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/vindication_illager.json), [snowman.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/snowman.json) and [sea_turtle.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/sea_turtle.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 7388d037f
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
