### PR TITLE
fix(entity): align witch, magma cube and parched drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityMagmaCube.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityMagmaCube.java
@@ -195,8 +195,8 @@ public class EntityMagmaCube extends EntityMob implements EntityWalkable, Entity
             return new Item[]{Item.get(froglight)};
         }
 
-        if (getVariant() != SIZE_SMALL && Utils.rand(0, 2) != 0) {
-            int amount = Utils.rand(0, 2 + looting);
+        if (getVariant() != SIZE_SMALL) {
+            int amount = Utils.rand(0, 1 + looting);
             if (amount > 0) {
                 drops.add(Item.get(Item.MAGMA_CREAM, 0, amount));
             }

--- a/src/main/java/org/powernukkitx/entity/mob/EntityParched.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityParched.java
@@ -1,6 +1,8 @@
 package org.powernukkitx.entity.mob;
 
+import org.powernukkitx.Player;
 import org.powernukkitx.entity.components.HealthComponent;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemID;
 import org.powernukkitx.item.enchantment.Enchantment;
@@ -66,14 +68,14 @@ public class EntityParched extends EntitySkeleton {
             drops.add(Item.get(Item.ARROW, 0, arrows));
         }
 
-        float weaknessChance = 0.10f + (0.05f * looting);
-        if (Utils.rand(0f, 1f) < weaknessChance) {
-            Item weaknessArrow = Item.get(Item.ARROW, 35, 1);
-            drops.add(weaknessArrow);
+        if (killedByPlayer()) {
+            int weaknessArrows = Utils.rand(0, 2 + looting);
+            if (weaknessArrows > 0) {
+                drops.add(Item.get(Item.ARROW, 35, weaknessArrows));
+            }
         }
 
-        float bowChance = 0.08f + (0.02f * looting);
-        if (Utils.rand(0f, 1f) < bowChance) {
+        if (Utils.rand(0, 99) < (25 + looting * 5)) {
             Item bow = Item.get(Item.BOW);
 
             int maxDurability = bow.getMaxDurability();
@@ -89,4 +91,8 @@ public class EntityParched extends EntitySkeleton {
         return drops.toArray(Item.EMPTY_ARRAY);
     }
 
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
+    }
 }

--- a/src/main/java/org/powernukkitx/entity/mob/EntityWitch.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityWitch.java
@@ -120,22 +120,21 @@ public class EntityWitch extends EntityMob implements EntityWalkable {
                 Utils.rand(4, 8 + looting)
         ));
 
-        int max = 6 + (looting * 3);
+        int rolls = Utils.rand(1, 3);
+        for (int i = 0; i < rolls; i++) {
+            // the stick is twice as likely as the five other entries
+            String id = switch (Utils.rand(0, 6)) {
+                case 0, 1 -> Item.STICK;
+                case 2 -> Item.SPIDER_EYE;
+                case 3 -> Item.GLOWSTONE_DUST;
+                case 4 -> Item.GUNPOWDER;
+                case 5 -> Item.SUGAR;
+                default -> Item.GLASS_BOTTLE;
+            };
 
-        record ExtraDrop(String id, int chance) {}
-
-        ExtraDrop[] extras = {
-                new ExtraDrop(Item.STICK, 3349),
-                new ExtraDrop(Item.SPIDER_EYE, 1787),
-                new ExtraDrop(Item.GLOWSTONE_DUST, 1787),
-                new ExtraDrop(Item.GUNPOWDER, 1787),
-                new ExtraDrop(Item.SUGAR, 1787),
-                new ExtraDrop(Item.GLASS_BOTTLE, 1787)
-        };
-
-        for (ExtraDrop drop : extras) {
-            if (Utils.rand(0, 9999) < drop.chance()) {
-                drops.add(Item.get(drop.id(), 0, Utils.rand(0, max)));
+            int amount = Utils.rand(0, 2 + looting);
+            if (amount > 0) {
+                drops.add(Item.get(id, 0, amount));
             }
         }
 


### PR DESCRIPTION
## What does this PR do?

It aligns the witch, magma cube and parched drops with the vanilla loot tables.

## Why?

It match vanilla behaviour.

The witch was rolling each of its six items independently with a fixed chance and a count of up to 6, or up to 15 with looting III, while the table rolls the pool 1 to 3 times and caps the count at 2 plus the looting bonus.

The magma cube had a two thirds gate before its count, and the count went up to 2 instead of 1.

The parched weakness arrow was using a made up chance and always dropped a single arrow with no killed by player condition, and its bow used the 8% + 2% chance from Java instead of the 25% + 5% equipment chance.

Source: [witch.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/witch.json), [magma_cube.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/magma_cube.json) and [parched.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/parched.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 2c243f462
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
