### PR TITLE
feat(entity): allow shearing a bogged for its mushrooms

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityBogged.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityBogged.java
@@ -1,6 +1,8 @@
 package org.powernukkitx.entity.mob;
 
 import org.powernukkitx.Player;
+import org.powernukkitx.block.BlockID;
+import org.powernukkitx.entity.EntityShearable;
 import org.powernukkitx.entity.EntitySmite;
 import org.powernukkitx.entity.EntityWalkable;
 import org.powernukkitx.entity.ai.behavior.Behavior;
@@ -24,8 +26,12 @@ import org.powernukkitx.item.ItemID;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
+import org.powernukkitx.level.vibration.VibrationEvent;
+import org.powernukkitx.level.vibration.VibrationType;
+import org.powernukkitx.math.Vector3;
 import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.utils.Utils;
+import org.cloudburstmc.protocol.bedrock.data.SoundEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -33,7 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-public class EntityBogged extends EntityMob implements EntityWalkable, EntitySmite {
+public class EntityBogged extends EntityMob implements EntityWalkable, EntitySmite, EntityShearable {
     @Override
     @NotNull
     public String getIdentifier() {
@@ -42,6 +48,38 @@ public class EntityBogged extends EntityMob implements EntityWalkable, EntitySmi
 
     public EntityBogged(IChunk chunk, CompoundTag nbt) {
         super(chunk, nbt);
+    }
+
+    @Override
+    public boolean onInteract(Player player, Item item, Vector3 clickedPos) {
+        if (super.onInteract(player, item, clickedPos)) {
+            return true;
+        }
+
+        if (item.isShears() && shear()) {
+            item.useOn(this);
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean shear() {
+        if (!EntityShearable.super.shear()) {
+            return false;
+        }
+
+        for (int i = 0; i < 2; i++) {
+            this.level.dropItem(this, Item.get(Utils.rand(0, 1) == 0
+                    ? BlockID.BROWN_MUSHROOM
+                    : BlockID.RED_MUSHROOM));
+        }
+
+        this.level.addLevelSoundEvent(this, SoundEvent.SHEAR);
+        this.level.getVibrationManager().callVibrationEvent(
+                new VibrationEvent(this, this.getVector3(), VibrationType.SHEAR));
+        return true;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityBogged.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityBogged.java
@@ -2,6 +2,7 @@ package org.powernukkitx.entity.mob;
 
 import org.powernukkitx.Player;
 import org.powernukkitx.block.BlockID;
+import org.powernukkitx.entity.EntityInteractable;
 import org.powernukkitx.entity.EntityShearable;
 import org.powernukkitx.entity.EntitySmite;
 import org.powernukkitx.entity.EntityWalkable;
@@ -39,7 +40,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-public class EntityBogged extends EntityMob implements EntityWalkable, EntitySmite, EntityShearable {
+public class EntityBogged extends EntityMob implements EntityWalkable, EntitySmite, EntityShearable, EntityInteractable {
     @Override
     @NotNull
     public String getIdentifier() {
@@ -79,6 +80,19 @@ public class EntityBogged extends EntityMob implements EntityWalkable, EntitySmi
         this.level.addLevelSoundEvent(this, SoundEvent.SHEAR);
         this.level.getVibrationManager().callVibrationEvent(
                 new VibrationEvent(this, this.getVector3(), VibrationType.SHEAR));
+        return true;
+    }
+
+    @Override
+    public String getInteractButtonText(Player player) {
+        if (player.getInventory().getItemInMainHand().isShears() && !this.isSheared()) {
+            return "action.interact.shear";
+        }
+        return "";
+    }
+
+    @Override
+    public boolean canDoInteraction() {
         return true;
     }
 


### PR DESCRIPTION
## What does this PR do?

It lets a bogged be sheared with shears, which drops its two mushrooms.

## Why?

It match vanilla behaviour. Shearing a bogged was not implemented at all, `EntityBogged` had no `onInteract`. In vanilla a bogged drops 2 mushrooms when sheared, each one being brown or red with an equal chance, and it cannot be sheared again afterwards.

Source: [bogged_shear.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/bogged_shear.json) and [Minecraft Wiki](https://minecraft.wiki/w/Bogged)

## Type of change

- [ ] Bug Fix
- [x] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 6e8517d1b
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
