### PR TITLE
feat(entity): show the interact button on sheep, mooshroom and golems

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityCopperGolem.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityCopperGolem.java
@@ -15,6 +15,7 @@ import org.powernukkitx.block.property.enums.MinecraftCardinalDirection;
 import org.powernukkitx.block.property.enums.OxidizationLevel;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityID;
+import org.powernukkitx.entity.EntityInteractable;
 import org.powernukkitx.entity.ai.behavior.Behavior;
 import org.powernukkitx.entity.ai.behaviorgroup.BehaviorGroup;
 import org.powernukkitx.entity.ai.behaviorgroup.IBehaviorGroup;
@@ -76,7 +77,7 @@ import java.util.Set;
  * @author Buddelbubi
  * @since 2025/11/18
  */
-public class EntityCopperGolem extends EntityGolem implements InventoryHolder {
+public class EntityCopperGolem extends EntityGolem implements InventoryHolder, EntityInteractable {
 
     public static final EntityProperty[] PROPERTIES = new EntityProperty[]{
             new EnumEntityProperty("minecraft:chest_interaction", new String[]{
@@ -318,6 +319,31 @@ public class EntityCopperGolem extends EntityGolem implements InventoryHolder {
 
     public boolean hasFlower() {
         return this.getBooleanEntityProperty(PROPERTIES[1].getIdentifier());
+    }
+
+    @Override
+    public String getInteractButtonText(Player player) {
+        Item held = player.getInventory().getItemInMainHand();
+        if (held instanceof ItemShears) {
+            return hasFlower() ? "action.interact.shear" : "";
+        }
+        if (held instanceof ItemHoneycomb) {
+            return isWaxed() ? "" : "action.interact.wax_on";
+        }
+        if (held.isAxe()) {
+            if (isWaxed()) {
+                return "action.interact.wax_off";
+            }
+            if (getOxidation() != Oxidation.UNOXIDIZED) {
+                return "action.interact.scrape";
+            }
+        }
+        return "";
+    }
+
+    @Override
+    public boolean canDoInteraction() {
+        return true;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityCopperGolem.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityCopperGolem.java
@@ -44,6 +44,7 @@ import org.powernukkitx.inventory.EntityEquipmentInventory;
 import org.powernukkitx.inventory.InventoryHolder;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemHoneycomb;
+import org.powernukkitx.item.ItemID;
 import org.powernukkitx.item.ItemShears;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.GameRule;
@@ -324,10 +325,10 @@ public class EntityCopperGolem extends EntityGolem implements InventoryHolder, E
     @Override
     public String getInteractButtonText(Player player) {
         Item held = player.getInventory().getItemInMainHand();
-        if (held instanceof ItemShears) {
+        if (held.isShears()) {
             return hasFlower() ? "action.interact.shear" : "";
         }
-        if (held instanceof ItemHoneycomb) {
+        if (held.getId().equals(ItemID.HONEYCOMB)) {
             return isWaxed() ? "" : "action.interact.wax_on";
         }
         if (held.isAxe()) {

--- a/src/main/java/org/powernukkitx/entity/mob/EntitySnowGolem.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntitySnowGolem.java
@@ -7,6 +7,7 @@ import org.powernukkitx.block.BlockPumpkin;
 import org.powernukkitx.block.BlockSnow;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityID;
+import org.powernukkitx.entity.EntityInteractable;
 import org.powernukkitx.entity.ai.behavior.Behavior;
 import org.powernukkitx.entity.ai.behaviorgroup.BehaviorGroup;
 import org.powernukkitx.entity.ai.behaviorgroup.IBehaviorGroup;
@@ -47,7 +48,7 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
 
-public class EntitySnowGolem extends EntityGolem {
+public class EntitySnowGolem extends EntityGolem implements EntityInteractable {
     @Override
     @NotNull
     public String getIdentifier() {
@@ -133,6 +134,19 @@ public class EntitySnowGolem extends EntityGolem {
     protected void initEntity() {
         setSheared(false);
         super.initEntity();
+    }
+
+    @Override
+    public String getInteractButtonText(Player player) {
+        if (!isSheared() && player.getInventory().getItemInMainHand().isShears()) {
+            return "action.interact.shear";
+        }
+        return "";
+    }
+
+    @Override
+    public boolean canDoInteraction() {
+        return true;
     }
 
     public void setSheared(boolean sheared) {

--- a/src/main/java/org/powernukkitx/entity/passive/EntityMooshroom.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityMooshroom.java
@@ -5,6 +5,7 @@ import org.powernukkitx.Player;
 import org.powernukkitx.block.BlockID;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityID;
+import org.powernukkitx.entity.EntityInteractable;
 import org.powernukkitx.entity.EntityShearable;
 import org.powernukkitx.entity.EntityVariant;
 import org.powernukkitx.entity.EntityWalkable;
@@ -51,7 +52,7 @@ import java.util.Set;
 /**
  * @author BeYkeRYkt (Nukkit Project)
  */
-public class EntityMooshroom extends EntityAnimal implements EntityWalkable, EntityShearable, EntityVariant {
+public class EntityMooshroom extends EntityAnimal implements EntityWalkable, EntityShearable, EntityVariant, EntityInteractable {
 
     /**
      * The mooshroom variants. Adding a new one only means adding a constant here - the id, the
@@ -239,6 +240,26 @@ public class EntityMooshroom extends EntityAnimal implements EntityWalkable, Ent
         }
 
         return false;
+    }
+
+    @Override
+    public String getInteractButtonText(Player player) {
+        Item held = player.getInventory().getItemInMainHand();
+        if (held.isShears()) {
+            return "action.interact.mooshear";
+        }
+        if (held.getId().equals(Item.BUCKET) && held.getDamage() == 0) {
+            return "action.interact.milk";
+        }
+        if (held.getId().equals(Item.BOWL) && held.getDamage() == 0) {
+            return "action.interact.moostew";
+        }
+        return "";
+    }
+
+    @Override
+    public boolean canDoInteraction() {
+        return true;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/passive/EntityMooshroom.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityMooshroom.java
@@ -32,6 +32,7 @@ import org.powernukkitx.entity.components.BreedableComponent;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.item.Item;
+import org.powernukkitx.item.ItemID;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.ParticleEffect;
 import org.powernukkitx.level.Sound;
@@ -248,10 +249,10 @@ public class EntityMooshroom extends EntityAnimal implements EntityWalkable, Ent
         if (held.isShears()) {
             return "action.interact.mooshear";
         }
-        if (held.getId().equals(Item.BUCKET) && held.getDamage() == 0) {
+        if (held.getId().equals(ItemID.BUCKET) && held.getDamage() == 0) {
             return "action.interact.milk";
         }
-        if (held.getId().equals(Item.BOWL) && held.getDamage() == 0) {
+        if (held.getId().equals(ItemID.BOWL) && held.getDamage() == 0) {
             return "action.interact.moostew";
         }
         return "";

--- a/src/main/java/org/powernukkitx/entity/passive/EntitySheep.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntitySheep.java
@@ -4,6 +4,7 @@ import org.powernukkitx.Player;
 import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockID;
 import org.powernukkitx.entity.EntityID;
+import org.powernukkitx.entity.EntityInteractable;
 import org.powernukkitx.entity.EntityShearable;
 import org.powernukkitx.entity.EntityWalkable;
 import org.powernukkitx.entity.ai.behavior.Behavior;
@@ -53,7 +54,7 @@ import java.util.concurrent.ThreadLocalRandom;
 /**
  * @author BeYkeRYkt (Nukkit Project)
  */
-public class EntitySheep extends EntityAnimal implements EntityWalkable, EntityShearable {
+public class EntitySheep extends EntityAnimal implements EntityWalkable, EntityShearable, EntityInteractable {
     @Override
     @NotNull
     public String getIdentifier() {
@@ -198,6 +199,23 @@ public class EntitySheep extends EntityAnimal implements EntityWalkable, EntityS
     public void growWool() {
         this.setDataFlag(ActorFlags.SHEARED, false);
         this.sheared = false;
+    }
+
+    @Override
+    public String getInteractButtonText(Player player) {
+        Item held = player.getInventory().getItemInMainHand();
+        if (held instanceof ItemDye) {
+            return "action.interact.dye";
+        }
+        if (held.isShears() && !this.sheared && !this.isBaby()) {
+            return "action.interact.shear";
+        }
+        return "";
+    }
+
+    @Override
+    public boolean canDoInteraction() {
+        return true;
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?

It shows the interact button on the sheep, the mooshroom, the snow golem and the copper golem.

## Why?

It match vanilla behaviour.

Source: [sheep.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/entities/sheep.json), [mooshroom.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/entities/mooshroom.json) and [copper_golem.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/entities/copper_golem.json)

## Type of change

- [ ] Bug Fix
- [x] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** e4dcba7fb
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
