### PR TITLE
fix(entity): drop one to three wool when shearing a sheep

### DIFF
--- a/src/main/java/org/powernukkitx/entity/passive/EntitySheep.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntitySheep.java
@@ -187,7 +187,7 @@ public class EntitySheep extends EntityAnimal implements EntityWalkable, EntityS
         this.setDataFlag(ActorFlags.SHEARED, true);
 
         Item woolItem = this.getWoolItem();
-        woolItem.setCount(ThreadLocalRandom.current().nextInt(2) + 1);
+        woolItem.setCount(Utils.rand(1, 3));
         this.level.dropItem(this, woolItem);
 
         level.addSound(this, Sound.MOB_SHEEP_SHEAR);


### PR DESCRIPTION
## What does this PR do?

It makes a sheared sheep drop 1 to 3 wool instead of 1 to 2.

## Why?

It match vanilla behaviour. `nextInt(2) + 1` only ever returns 1 or 2, so the third wool was never reachable.

Source: [sheep_shear.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/sheep_shear.json) and [Minecraft Wiki](https://minecraft.wiki/w/Sheep)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** de3499adc
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
