### PR TITLE
feat(entity): give suspicious stew when milking a brown mooshroom that ate a flower

### DIFF
--- a/src/main/java/org/powernukkitx/entity/passive/EntityMooshroom.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityMooshroom.java
@@ -5,6 +5,7 @@ import org.powernukkitx.Player;
 import org.powernukkitx.block.BlockID;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityID;
+import org.powernukkitx.entity.EntityMarkVariant;
 import org.powernukkitx.entity.EntityShearable;
 import org.powernukkitx.entity.EntityVariant;
 import org.powernukkitx.entity.EntityWalkable;
@@ -46,12 +47,13 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
  * @author BeYkeRYkt (Nukkit Project)
  */
-public class EntityMooshroom extends EntityAnimal implements EntityWalkable, EntityShearable, EntityVariant {
+public class EntityMooshroom extends EntityAnimal implements EntityWalkable, EntityShearable, EntityVariant, EntityMarkVariant {
 
     /**
      * The mooshroom variants. Adding a new one only means adding a constant here - the id, the
@@ -95,6 +97,36 @@ public class EntityMooshroom extends EntityAnimal implements EntityWalkable, Ent
     private static final int[] VARIANTS = Arrays.stream(Variant.values()).mapToInt(Variant::getId).toArray();
 
     private static final int SHEAR_MUSHROOM_COUNT = 5;
+
+    /**
+     * Mark variant of a brown mooshroom that has not eaten a flower yet.
+     */
+    private static final int NO_STEW_EFFECT = -1;
+
+    /**
+     * The flower a brown mooshroom ate, mapped to the suspicious stew meta it gives when milked
+     * with a bowl. The value is stored as the mark variant, the way vanilla does it.
+     */
+    private static final Map<String, Integer> STEW_EFFECTS = Map.ofEntries(
+            Map.entry(BlockID.POPPY, 0),
+            Map.entry(BlockID.CORNFLOWER, 1),
+            Map.entry(BlockID.RED_TULIP, 2),
+            Map.entry(BlockID.ORANGE_TULIP, 2),
+            Map.entry(BlockID.WHITE_TULIP, 2),
+            Map.entry(BlockID.PINK_TULIP, 2),
+            Map.entry(BlockID.AZURE_BLUET, 3),
+            Map.entry(BlockID.LILY_OF_THE_VALLEY, 4),
+            Map.entry(BlockID.DANDELION, 5),
+            Map.entry(BlockID.BLUE_ORCHID, 6),
+            Map.entry(BlockID.ALLIUM, 7),
+            Map.entry(BlockID.OXEYE_DAISY, 8),
+            Map.entry(BlockID.WITHER_ROSE, 9),
+            Map.entry(BlockID.TORCHFLOWER, 10),
+            Map.entry(BlockID.OPEN_EYEBLOSSOM, 11),
+            Map.entry(BlockID.CLOSED_EYEBLOSSOM, 12)
+    );
+
+    private static final int[] MARK_VARIANTS = STEW_EFFECTS.values().stream().mapToInt(Integer::intValue).distinct().toArray();
 
     @Override
     @NotNull public String getIdentifier() {
@@ -234,11 +266,44 @@ public class EntityMooshroom extends EntityAnimal implements EntityWalkable, Ent
             return true;
         } else if (item.getId().equals(Item.BOWL) && item.getDamage() == 0) {
             item.count--;
-            player.getInventory().addItem(Item.get(Item.MUSHROOM_STEW));
+            if (hasStewEffect()) {
+                player.getInventory().addItem(Item.get(Item.SUSPICIOUS_STEW, getMarkVariant()));
+                this.level.addSound(this, Sound.MOB_MOOSHROOM_SUSPICIOUS_MILK);
+                clearStewEffect();
+            } else {
+                player.getInventory().addItem(Item.get(Item.MUSHROOM_STEW));
+            }
             return true;
+        } else if (getVariantType() == Variant.BROWN && !hasStewEffect()) {
+            int stewEffect = STEW_EFFECTS.getOrDefault(item.getId(), -1);
+            if (stewEffect != -1) {
+                item.count--;
+                setMarkVariant(stewEffect);
+                this.level.addSound(this, Sound.MOB_MOOSHROOM_EAT);
+                return true;
+            }
         }
 
         return false;
+    }
+
+    /**
+     * @return true if this mooshroom ate a flower and has not been milked since
+     */
+    public boolean hasStewEffect() {
+        return hasMarkVariant() && getMarkVariant() != NO_STEW_EFFECT;
+    }
+
+    /**
+     * Forgets the flower this mooshroom ate, so it gives a plain mushroom stew again.
+     */
+    public void clearStewEffect() {
+        setMarkVariant(NO_STEW_EFFECT);
+    }
+
+    @Override
+    public int[] getAllMarkVariant() {
+        return MARK_VARIANTS;
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?

It lets a brown mooshroom eat a flower, and gives a suspicious stew with that flower effect when it is milked with a bowl.

## Why?

It match vanilla behaviour. Feeding a flower to a mooshroom was not implemented, and a bowl always gave a plain mushroom stew.

The flower is stored as the mark variant, which is what vanilla does, and that value is also the suspicious stew meta. `ItemSuspiciousStew` already maps every meta to its effect.

Source: [mooshroom.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/entities/mooshroom.json) and [Minecraft Wiki](https://minecraft.wiki/w/Mooshroom)

## Type of change

- [ ] Bug Fix
- [x] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** e18dc31f1
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
