### PR TITLE
fix(item): shorten the suspicious stew saturation to six ticks

### DIFF
--- a/src/main/java/org/powernukkitx/item/ItemSuspiciousStew.java
+++ b/src/main/java/org/powernukkitx/item/ItemSuspiciousStew.java
@@ -46,7 +46,7 @@ public class ItemSuspiciousStew extends ItemFood {
             case 2 -> Effect.get(EffectType.WEAKNESS).setDuration(7 * 20);
             case 3, 11 -> Effect.get(EffectType.BLINDNESS).setDuration(7 * 20);
             case 4 -> Effect.get(EffectType.POISON).setDuration(11 * 20);
-            case 5, 6 -> Effect.get(EffectType.SATURATION).setDuration(3 * 20);
+            case 5, 6 -> Effect.get(EffectType.SATURATION).setDuration(6);
             case 7 -> Effect.get(EffectType.FIRE_RESISTANCE).setDuration(3 * 20);
             case 8 -> Effect.get(EffectType.REGENERATION).setDuration(7 * 20);
             case 9 -> Effect.get(EffectType.WITHER).setDuration(7 * 20);


### PR DESCRIPTION
## What does this PR do?

It shortens the saturation given by a dandelion or blue orchid suspicious stew from 3 seconds to 0.3 seconds.

## Why?

It match vanilla behaviour. Saturation restores food every tick, so 60 ticks instead of 6 made those two stews far more filling than they should be.

Source: [Minecraft Wiki](https://minecraft.wiki/w/Suspicious_Stew)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 5b7cb44c8
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
