### PR TITLE
fix(entity): align the piglin barter table with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/ai/executor/PiglinTradeExecutor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/executor/PiglinTradeExecutor.java
@@ -64,13 +64,13 @@ public class PiglinTradeExecutor implements EntityControl, IBehaviorExecutor {
 
     public Item getDrop() {
         Item item;
-        int random = ThreadLocalRandom.current().nextInt(459);
+        int random = ThreadLocalRandom.current().nextInt(469);
         if(random < 5) {
             item = Item.get(Item.ENCHANTED_BOOK);
-            item.addEnchantment(Enchantment.get(Enchantment.ID_SOUL_SPEED).setLevel(ThreadLocalRandom.current().nextInt(1, 3)));
+            item.addEnchantment(Enchantment.get(Enchantment.ID_SOUL_SPEED).setLevel(ThreadLocalRandom.current().nextInt(1, 4)));
         } else if(random < 13) {
             item = Item.get(Item.IRON_BOOTS);
-            item.addEnchantment(Enchantment.get(Enchantment.ID_SOUL_SPEED).setLevel(ThreadLocalRandom.current().nextInt(1, 3)));
+            item.addEnchantment(Enchantment.get(Enchantment.ID_SOUL_SPEED).setLevel(ThreadLocalRandom.current().nextInt(1, 4)));
         } else if(random < 21) {
             item = Item.get(Item.SPLASH_POTION, EffectType.FIRE_RESISTANCE.id());
         } else if(random < 29) {
@@ -98,11 +98,13 @@ public class PiglinTradeExecutor implements EntityControl, IBehaviorExecutor {
         } else if(random < 339) {
             item = Item.get(Item.NETHERBRICK, 0 , ThreadLocalRandom.current().nextInt(2, 9));
         } else if(random < 379) {
-            item = Item.get(Item.ARROW, 0 , ThreadLocalRandom.current().nextInt(6, 12));
+            item = Item.get(Item.ARROW, 0 , ThreadLocalRandom.current().nextInt(6, 13));
         } else if(random < 419) {
             item = Item.get(Block.GRAVEL, 0 , ThreadLocalRandom.current().nextInt(8, 17));
-        } else {
+        } else if(random < 459) {
             item = Item.get(Block.BLACKSTONE, 0 , ThreadLocalRandom.current().nextInt(8, 17));
+        } else {
+            item = Item.get(Block.DRIED_GHAST);
         }
         return item;
     }


### PR DESCRIPTION
## What does this PR do?

It aligns the piglin barter table with the vanilla loot table.

## Why?

It match vanilla behaviour. The dried ghast added in 1.21.90 was missing, the arrow count stopped at 11 instead of 12, and the soul speed level on the book and the boots stopped at II instead of III.

Source: [piglin_barter.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/piglin_barter.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** c2b9ec691
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
