### PR TITLE
fix(entity): align all mob drops with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityBlaze.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityBlaze.java
@@ -21,6 +21,7 @@ import org.powernukkitx.entity.ai.route.posevaluator.FlyingPosEvaluator;
 import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.event.entity.EntityDamageEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.enchantment.Enchantment;
@@ -126,17 +127,22 @@ public class EntityBlaze extends EntityMob implements EntityFlyable {
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
-        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
-
-        float chance = 0.5f + (0.25f * looting);
-        chance = Math.min(chance, 1.0f);
-
-        if (Utils.rand(0f, 1f) < chance) {
-            int amount = Utils.rand(1, 1 + looting);
-            return new Item[]{Item.get(Item.BLAZE_ROD, 0, amount)};
+        if (!killedByPlayer()) {
+            return Item.EMPTY_ARRAY;
         }
 
-        return Item.EMPTY_ARRAY;
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        int rods = Utils.rand(0, 1 + looting);
+        if (rods == 0) {
+            return Item.EMPTY_ARRAY;
+        }
+
+        return new Item[]{Item.get(Item.BLAZE_ROD, 0, rods)};
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityBogged.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityBogged.java
@@ -101,7 +101,7 @@ public class EntityBogged extends EntityMob implements EntityWalkable, EntitySmi
         if (killedByPlayer()) {
             int poisonAmount = Utils.rand(0, 1 + looting);
             if (poisonAmount > 0) {
-                drops.add(Item.get(Item.ARROW, 27, poisonAmount));
+                drops.add(Item.get(Item.ARROW, 26, poisonAmount));
             }
         }
 

--- a/src/main/java/org/powernukkitx/entity/mob/EntityBogged.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityBogged.java
@@ -19,6 +19,7 @@ import org.powernukkitx.entity.ai.route.posevaluator.WalkingPosEvaluator;
 import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemID;
 import org.powernukkitx.item.enchantment.Enchantment;
@@ -97,17 +98,19 @@ public class EntityBogged extends EntityMob implements EntityWalkable, EntitySmi
             drops.add(Item.get(Item.ARROW, 0, arrowAmount));
         }
 
-        float poisonChance = 0.5f - (looting * (1f / 12f));
-        if (poisonChance < 0f) {
-            poisonChance = 0f;
-        }
-
-        if (Utils.rand(0f, 1f) < poisonChance) {
-            int poisonAmount = Utils.rand(1, Math.min(1 + looting, 4));
-            drops.add(Item.get(Item.ARROW, 27, poisonAmount));
+        if (killedByPlayer()) {
+            int poisonAmount = Utils.rand(0, 1 + looting);
+            if (poisonAmount > 0) {
+                drops.add(Item.get(Item.ARROW, 27, poisonAmount));
+            }
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityBreeze.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityBreeze.java
@@ -1,5 +1,6 @@
 package org.powernukkitx.entity.mob;
 
+import org.powernukkitx.Player;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.ai.behavior.Behavior;
 import org.powernukkitx.entity.ai.behaviorgroup.BehaviorGroup;
@@ -20,6 +21,7 @@ import org.powernukkitx.entity.ai.route.posevaluator.WalkingPosEvaluator;
 import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.event.entity.EntityDamageEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.enchantment.Enchantment;
@@ -90,6 +92,10 @@ public class EntityBreeze extends EntityMob {
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
+        if (!killedByPlayer()) {
+            return Item.EMPTY_ARRAY;
+        }
+
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
 
         int min = 1 + looting;
@@ -100,6 +106,11 @@ public class EntityBreeze extends EntityMob {
         return new Item[]{
                 Item.get(Item.BREEZE_ROD, 0, amount)
         };
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityCaveSpider.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityCaveSpider.java
@@ -25,6 +25,7 @@ import org.powernukkitx.entity.ai.sensor.NearestTargetEntitySensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.entity.passive.EntityArmadillo;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
@@ -138,15 +139,18 @@ public class EntityCaveSpider extends EntityMob implements EntityWalkable, Entit
             drops.add(Item.get(Item.STRING, 0, stringAmount));
         }
 
-        float eyeChance = 0.5f - (looting * (1f / 12f));
-        if (eyeChance < 0f) {
-            eyeChance = 0f;
-        }
-
-        if (Utils.rand(0f, 1f) < eyeChance) {
-            drops.add(Item.get(Item.SPIDER_EYE, 0, 1));
+        if (killedByPlayer()) {
+            int eyes = Utils.rand(0, 1 + looting);
+            if (eyes > 0) {
+                drops.add(Item.get(Item.SPIDER_EYE, 0, eyes));
+            }
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 }

--- a/src/main/java/org/powernukkitx/entity/mob/EntityCopperGolem.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityCopperGolem.java
@@ -44,7 +44,6 @@ import org.powernukkitx.inventory.InventoryHolder;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemHoneycomb;
 import org.powernukkitx.item.ItemShears;
-import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.GameRule;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.entity.condition.Condition;
@@ -70,6 +69,8 @@ import org.cloudburstmc.protocol.bedrock.data.SoundEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -342,13 +343,19 @@ public class EntityCopperGolem extends EntityGolem implements InventoryHolder {
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
-        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
-        int amount = Utils.rand(1, 3 + looting);
+        List<Item> drops = new ArrayList<>();
+        drops.add(Item.get(Item.COPPER_INGOT, 0, Utils.rand(1, 3)));
 
-        return new Item[]{
-                Item.get(Item.COPPER_INGOT, 0, amount),
-                getInventory().getItemInHand()
-        };
+        if (hasFlower()) {
+            drops.add(Item.get(Block.POPPY));
+        }
+
+        Item held = getInventory().getItemInHand();
+        if (!held.isNull()) {
+            drops.add(held.clone());
+        }
+
+        return drops.toArray(Item.EMPTY_ARRAY);
     }
 
     public static void checkAndSpawnGolem(Block block) {

--- a/src/main/java/org/powernukkitx/entity/mob/EntityDrowned.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityDrowned.java
@@ -32,6 +32,7 @@ import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.ai.sensor.NearestTargetEntitySensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.passive.EntityAxolotl;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemTrident;
 import org.powernukkitx.item.enchantment.Enchantment;
@@ -42,6 +43,7 @@ import org.powernukkitx.utils.Utils;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -161,18 +163,28 @@ public class EntityDrowned extends EntityZombie implements EntitySwimmable, Enti
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
-        Item trident = Item.AIR;
-        if (getItemInHand() instanceof ItemTrident) {
-            int lootingLevel = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        List<Item> drops = new ArrayList<>();
 
-            if (Utils.rand(0, 100) < Math.min(37, 25 + lootingLevel)) {
-                trident = Item.get(Item.TRIDENT);
-            }
+        int flesh = Utils.rand(0, 2 + looting);
+        if (flesh > 0) {
+            drops.add(Item.get(Item.ROTTEN_FLESH, 0, flesh));
         }
-        return new Item[]{
-                Item.get(Item.ROTTEN_FLESH),
-                trident
-        };
+
+        if (killedByPlayer() && Utils.rand(0, 999) < (110 + looting * 20)) {
+            drops.add(Item.get(Item.COPPER_INGOT));
+        }
+
+        if (getItemInHand() instanceof ItemTrident && Utils.rand(0, 999) < (85 + looting * 10)) {
+            drops.add(Item.get(Item.TRIDENT));
+        }
+
+        return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityElderGuardian.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityElderGuardian.java
@@ -29,6 +29,8 @@ import org.powernukkitx.entity.effect.EffectType;
 import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.event.entity.EntityDamageEvent;
 import org.powernukkitx.item.Item;
+import org.powernukkitx.item.enchantment.Enchantment;
+import org.powernukkitx.item.randomitem.Fishing;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
@@ -41,6 +43,7 @@ import org.cloudburstmc.protocol.bedrock.packet.LevelEventPacket;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -137,15 +140,39 @@ public class EntityElderGuardian extends EntityMob implements EntitySwimmable {
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        List<Item> drops = new ArrayList<>();
+
+        int shards = Utils.rand(0, 2 + looting);
+        if (shards > 0) {
+            drops.add(Item.get(Item.PRISMARINE_SHARD, 0, shards));
+        }
+
         int secondLoot = ThreadLocalRandom.current().nextInt(6);
-        return new Item[]{
-                Item.get(Item.PRISMARINE_SHARD, 0, Utils.rand(0, 2)),
-                Item.get(Block.WET_SPONGE, 0, 1),
-                ThreadLocalRandom.current().nextInt(100) < 20 ? Item.get(Item.TIDE_ARMOR_TRIM_SMITHING_TEMPLATE, 0, 1) : Item.AIR,
-                ThreadLocalRandom.current().nextInt(1000) < 25 ? Item.get(Item.COD, 0, 1) : Item.AIR,
-                secondLoot <= 2 ? Item.get(Item.COD, 0, Utils.rand(0, 1)) : Item.AIR,
-                secondLoot > 2 && secondLoot <= 4 ? Item.get(Item.PRISMARINE_CRYSTALS, 0, Utils.rand(0, 1)) : Item.AIR
-        };
+        if (secondLoot <= 2) {
+            drops.add(Item.get(Item.COD, 0, 1 + Utils.rand(0, looting)));
+        } else if (secondLoot <= 4) {
+            drops.add(Item.get(Item.PRISMARINE_CRYSTALS, 0, 1 + Utils.rand(0, looting)));
+        }
+
+        if (killedByPlayer()) {
+            drops.add(Item.get(Block.WET_SPONGE, 0, 1));
+
+            if (Utils.rand(0, 999) < (25 + looting * 10)) {
+                drops.add(Fishing.getRandomFish());
+            }
+        }
+
+        if (ThreadLocalRandom.current().nextInt(5) == 0) {
+            drops.add(Item.get(Item.TIDE_ARMOR_TRIM_SMITHING_TEMPLATE, 0, 1));
+        }
+
+        return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityEnderman.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityEnderman.java
@@ -151,12 +151,9 @@ public class EntityEnderman extends EntityMob implements EntityWalkable {
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
         List<Item> drops = new ArrayList<>();
 
-        float pearlChance = 0.5f + (0.05f * looting);
-        pearlChance = Math.min(pearlChance, 1.0f);
-
-        if (Utils.rand(0f, 1f) < pearlChance) {
-            int amount = Utils.rand(1, 1 + looting);
-            drops.add(Item.get(Item.ENDER_PEARL, 0, amount));
+        int pearls = Utils.rand(0, 1 + looting);
+        if (pearls > 0) {
+            drops.add(Item.get(Item.ENDER_PEARL, 0, pearls));
         }
 
         Item hand = getItemInHand();

--- a/src/main/java/org/powernukkitx/entity/mob/EntityEvocationIllager.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityEvocationIllager.java
@@ -206,9 +206,14 @@ public class EntityEvocationIllager extends EntityIllager implements EntityWalka
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
         int lootingLevel = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        int emeralds = Utils.rand(0, 1 + lootingLevel);
+        if (emeralds == 0) {
+            return new Item[] {Item.get(Item.TOTEM_OF_UNDYING)};
+        }
+
         return new Item[] {
                 Item.get(Item.TOTEM_OF_UNDYING),
-                Item.get(Item.EMERALD, 0, Utils.rand(0, 2 + lootingLevel))
+                Item.get(Item.EMERALD, 0, emeralds)
         };
     }
 

--- a/src/main/java/org/powernukkitx/entity/mob/EntityGhast.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityGhast.java
@@ -1,5 +1,6 @@
 package org.powernukkitx.entity.mob;
 
+import org.powernukkitx.Player;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityFlyable;
 import org.powernukkitx.entity.ai.behavior.Behavior;
@@ -20,6 +21,8 @@ import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.entity.projectile.EntityFireball;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
+import org.powernukkitx.event.entity.EntityDamageEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
@@ -113,18 +116,20 @@ public class EntityGhast extends EntityMob implements EntityFlyable {
 
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
 
-        if (Utils.rand(0, 1) == 1) {
-            int amount = Utils.rand(0, 1 + looting);
-            if (amount > 0) {
-                drops.add(Item.get(Item.GHAST_TEAR, 0, amount));
-            }
+        int tears = Utils.rand(0, 1 + looting);
+        if (tears > 0) {
+            drops.add(Item.get(Item.GHAST_TEAR, 0, tears));
         }
 
-        if (Utils.rand(0, 2) != 0) {
-            int amount = Utils.rand(0, 2 + looting);
-            if (amount > 0) {
-                drops.add(Item.get(Item.GUNPOWDER, 0, amount));
-            }
+        int gunpowder = Utils.rand(0, 2 + looting);
+        if (gunpowder > 0) {
+            drops.add(Item.get(Item.GUNPOWDER, 0, gunpowder));
+        }
+
+        if (this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getCause() == EntityDamageEvent.DamageCause.ENTITY_EXPLOSION
+                && event.getDamager() instanceof Player) {
+            drops.add(Item.get(Item.MUSIC_DISC_TEARS));
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);

--- a/src/main/java/org/powernukkitx/entity/mob/EntityGuardian.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityGuardian.java
@@ -27,6 +27,7 @@ import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.event.entity.EntityDamageEvent;
 import org.powernukkitx.item.Item;
+import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
@@ -34,6 +35,7 @@ import org.powernukkitx.utils.Utils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
@@ -136,13 +138,31 @@ public class EntityGuardian extends EntityMob implements EntitySwimmable {
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
-        int secondLoot = ThreadLocalRandom.current().nextInt(6);
-        return new Item[]{
-                Item.get(Item.PRISMARINE_SHARD, 0, Utils.rand(0, 2)),
-                ThreadLocalRandom.current().nextInt(1000) <= 25 ? Item.get(Item.COD, 0, 1) : Item.AIR,
-                secondLoot <= 2 ? Item.get(Item.COD, 0, Utils.rand(0, 1)) : Item.AIR,
-                secondLoot > 2 && secondLoot <= 4 ? Item.get(Item.PRISMARINE_CRYSTALS, 0, Utils.rand(0, 1)) : Item.AIR
-        };
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        List<Item> drops = new ArrayList<>();
+
+        int shards = Utils.rand(0, 2 + looting);
+        if (shards > 0) {
+            drops.add(Item.get(Item.PRISMARINE_SHARD, 0, shards));
+        }
+
+        int secondLoot = ThreadLocalRandom.current().nextInt(5);
+        if (secondLoot <= 1) {
+            drops.add(Item.get(Item.COD, 0, 1 + Utils.rand(0, looting)));
+        } else if (secondLoot <= 3) {
+            drops.add(Item.get(Item.PRISMARINE_CRYSTALS, 0, 1 + Utils.rand(0, looting)));
+        }
+
+        if (killedByPlayer() && Utils.rand(0, 999) < (25 + looting * 10)) {
+            drops.add(Item.get(Item.COD, 0, 1));
+        }
+
+        return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityHoglin.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityHoglin.java
@@ -169,11 +169,9 @@ public class EntityHoglin extends EntityMob implements EntityWalkable {
                 porkAmount
         ));
 
-        if (Utils.rand(0, 1) == 1) {
-            int leatherAmount = Utils.rand(0, 1 + looting);
-            if (leatherAmount > 0) {
-                drops.add(Item.get(Item.LEATHER, 0, leatherAmount));
-            }
+        int leatherAmount = Utils.rand(0, 1 + looting);
+        if (leatherAmount > 0) {
+            drops.add(Item.get(Item.LEATHER, 0, leatherAmount));
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);

--- a/src/main/java/org/powernukkitx/entity/mob/EntityMagmaCube.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityMagmaCube.java
@@ -195,8 +195,8 @@ public class EntityMagmaCube extends EntityMob implements EntityWalkable, Entity
             return new Item[]{Item.get(froglight)};
         }
 
-        if (getVariant() != SIZE_SMALL && Utils.rand(0, 2) != 0) {
-            int amount = Utils.rand(0, 2 + looting);
+        if (getVariant() != SIZE_SMALL) {
+            int amount = Utils.rand(0, 1 + looting);
             if (amount > 0) {
                 drops.add(Item.get(Item.MAGMA_CREAM, 0, amount));
             }

--- a/src/main/java/org/powernukkitx/entity/mob/EntityParched.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityParched.java
@@ -1,6 +1,8 @@
 package org.powernukkitx.entity.mob;
 
+import org.powernukkitx.Player;
 import org.powernukkitx.entity.components.HealthComponent;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemID;
 import org.powernukkitx.item.enchantment.Enchantment;
@@ -66,14 +68,14 @@ public class EntityParched extends EntitySkeleton {
             drops.add(Item.get(Item.ARROW, 0, arrows));
         }
 
-        float weaknessChance = 0.10f + (0.05f * looting);
-        if (Utils.rand(0f, 1f) < weaknessChance) {
-            Item weaknessArrow = Item.get(Item.ARROW, 35, 1);
-            drops.add(weaknessArrow);
+        if (killedByPlayer()) {
+            int weaknessArrows = Utils.rand(0, 2 + looting);
+            if (weaknessArrows > 0) {
+                drops.add(Item.get(Item.ARROW, 35, weaknessArrows));
+            }
         }
 
-        float bowChance = 0.08f + (0.02f * looting);
-        if (Utils.rand(0f, 1f) < bowChance) {
+        if (Utils.rand(0, 99) < (25 + looting * 5)) {
             Item bow = Item.get(Item.BOW);
 
             int maxDurability = bow.getMaxDurability();
@@ -89,4 +91,8 @@ public class EntityParched extends EntitySkeleton {
         return drops.toArray(Item.EMPTY_ARRAY);
     }
 
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
+    }
 }

--- a/src/main/java/org/powernukkitx/entity/mob/EntityPhantom.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityPhantom.java
@@ -27,6 +27,7 @@ import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.ai.sensor.NearestTargetEntitySensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemID;
 import org.powernukkitx.item.enchantment.Enchantment;
@@ -128,20 +129,24 @@ public class EntityPhantom extends EntityMob implements EntityFlyable, EntitySmi
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
-        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
-
-        if (Utils.rand(0, 1) == 0) {
+        if (!killedByPlayer()) {
             return Item.EMPTY_ARRAY;
         }
 
-        int amount = Utils.rand(0, 1 + looting);
-        if (amount <= 0) {
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        int membranes = Utils.rand(0, 1 + looting);
+        if (membranes == 0) {
             return Item.EMPTY_ARRAY;
         }
 
         return new Item[]{
-                Item.get(ItemID.PHANTOM_MEMBRANE, 0, amount)
+                Item.get(ItemID.PHANTOM_MEMBRANE, 0, membranes)
         };
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityPillager.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityPillager.java
@@ -21,12 +21,16 @@ import org.powernukkitx.entity.ai.sensor.NearestTargetEntitySensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.item.Item;
+import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
+import org.powernukkitx.utils.Utils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -106,5 +110,18 @@ public class EntityPillager extends EntityIllager implements EntityWalkable {
     @Override
     public boolean attackTarget(Entity entity) {
         return super.attackTarget(entity) || entity instanceof EntityGolem;
+    }
+
+    @Override
+    public Item[] getDrops(@NotNull Item weapon) {
+        List<Item> drops = new ArrayList<>(Arrays.asList(super.getDrops(weapon)));
+
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        int arrows = Utils.rand(0, 2 + looting);
+        if (arrows > 0) {
+            drops.add(Item.get(Item.ARROW, 0, arrows));
+        }
+
+        return drops.toArray(Item.EMPTY_ARRAY);
     }
 }

--- a/src/main/java/org/powernukkitx/entity/mob/EntityRavager.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityRavager.java
@@ -16,6 +16,8 @@ import org.powernukkitx.entity.ai.route.posevaluator.WalkingPosEvaluator;
 import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
+import org.powernukkitx.item.Item;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
 
@@ -94,5 +96,18 @@ public class EntityRavager extends EntityMob implements EntityWalkable {
     @Override
     public Integer getExperienceDrops() {
         return 20;
+    }
+
+    @Override
+    public Item[] getDrops(@NotNull Item weapon) {
+        if (!killedByPlayer()) {
+            return Item.EMPTY_ARRAY;
+        }
+        return new Item[]{Item.get(Item.SADDLE)};
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 }

--- a/src/main/java/org/powernukkitx/entity/mob/EntityShulker.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityShulker.java
@@ -174,16 +174,14 @@ public class EntityShulker extends EntityMob implements EntityVariant {
     public Item[] getDrops(@NotNull Item weapon) {
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
 
-        if (Utils.rand(0, 1) == 0) {
-            int amount = Utils.rand(0, 1 + looting);
-            if (amount > 0) {
-                return new Item[]{
-                        Item.get(Item.SHULKER_SHELL, 0, amount)
-                };
-            }
+        int shells = Utils.rand(0, 1 + looting);
+        if (shells == 0) {
+            return Item.EMPTY_ARRAY;
         }
 
-        return Item.EMPTY_ARRAY;
+        return new Item[]{
+                Item.get(Item.SHULKER_SHELL, 0, shells)
+        };
     }
 
     public void teleport() {

--- a/src/main/java/org/powernukkitx/entity/mob/EntitySkeleton.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntitySkeleton.java
@@ -107,27 +107,28 @@ public class EntitySkeleton extends EntityMob implements EntityWalkable, EntityS
         }
 
         for (Item equipped : this.getEquipmentInventory().getContents().values()) {
-            if (!equipped.isNull() && !equipped.hasEnchantment(Enchantment.ID_VANISHING_CURSE)) {
-                if (equipped.isBow()) {
-                    int chance = 85 + looting * 10;
-                    if (Utils.rand(0, 999) < chance) {
-                        Item drop = equipped.clone();
-                        drop.setDamage(Utils.rand(193, 384));
-                        drops.add(drop);
-                    }
-                } else {
-                    drops.add(equipped.clone());
-                }
-            }
+            addEquipmentDrop(drops, equipped, looting);
         }
 
         for (Item armor : this.getArmorInventory().getContents().values()) {
-            if (!armor.isNull() && !armor.hasEnchantment(Enchantment.ID_VANISHING_CURSE)) {
-                drops.add(armor.clone());
-            }
+            addEquipmentDrop(drops, armor, looting);
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private void addEquipmentDrop(List<Item> drops, Item item, int looting) {
+        if (item.isNull() || item.hasEnchantment(Enchantment.ID_VANISHING_CURSE)) {
+            return;
+        }
+        if (Utils.rand(0, 99) >= (25 + looting * 5)) {
+            return;
+        }
+        Item drop = item.clone();
+        if (drop.isBow()) {
+            drop.setDamage(Utils.rand(193, 384));
+        }
+        drops.add(drop);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntitySlime.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntitySlime.java
@@ -185,7 +185,10 @@ public class EntitySlime extends EntityMob implements EntityWalkable, EntityVari
         }
 
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
-        int amount = Utils.rand(1, 2) + looting;
+        int amount = Utils.rand(0, 2 + looting);
+        if (amount == 0) {
+            return Item.EMPTY_ARRAY;
+        }
 
         return new Item[]{
                 Item.get(Item.SLIME_BALL, 0, amount)

--- a/src/main/java/org/powernukkitx/entity/mob/EntitySnowGolem.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntitySnowGolem.java
@@ -33,6 +33,7 @@ import org.powernukkitx.level.vibration.VibrationType;
 import org.powernukkitx.math.BlockFace;
 import org.powernukkitx.math.Vector3;
 import org.powernukkitx.nbt.tag.CompoundTag;
+import org.powernukkitx.utils.Utils;
 import org.powernukkitx.nbt.tag.DoubleTag;
 import org.powernukkitx.nbt.tag.FloatTag;
 import org.powernukkitx.nbt.tag.ListTag;
@@ -44,7 +45,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
 
 
 public class EntitySnowGolem extends EntityGolem {
@@ -165,23 +165,14 @@ public class EntitySnowGolem extends EntityGolem {
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
-        ThreadLocalRandom random = ThreadLocalRandom.current();
-        int randDrop = random.nextInt(3);
-
-        switch (randDrop) {
-            case 0:
-                return new Item[]{
-                        Item.get(ItemID.SNOWBALL, 0, random.nextInt(0, 9))
-                };
-            case 1:
-                return new Item[]{
-                        Item.get(ItemID.SNOWBALL, 0, random.nextInt(8, 17))
-                };
-            case 2:
-                return Item.EMPTY_ARRAY;
-            default:
-                return Item.EMPTY_ARRAY;
+        int snowballs = Utils.rand(0, 15);
+        if (snowballs == 0) {
+            return Item.EMPTY_ARRAY;
         }
+
+        return new Item[]{
+                Item.get(ItemID.SNOWBALL, 0, snowballs)
+        };
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntitySpider.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntitySpider.java
@@ -27,6 +27,7 @@ import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.entity.components.RideableComponent;
 import org.powernukkitx.entity.passive.EntityArmadillo;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
@@ -389,23 +390,24 @@ public class EntitySpider extends EntityMob implements EntityWalkable, EntityArt
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
         List<Item> drops = new ArrayList<>();
 
-        float stringChance = 0.70f + (0.10f * looting);
-        stringChance = Math.min(stringChance, 1.0f);
-
-        if (Utils.rand(0f, 1f) < stringChance) {
-            int amount = Utils.rand(1, 2 + looting);
-            drops.add(Item.get(Item.STRING, 0, amount));
+        int string = Utils.rand(0, 2 + looting);
+        if (string > 0) {
+            drops.add(Item.get(Item.STRING, 0, string));
         }
 
-        float eyeChance = 0.50f + (0.05f * looting);
-        eyeChance = Math.min(eyeChance, 1.0f);
-
-        if (Utils.rand(0f, 1f) < eyeChance) {
-            int amount = Utils.rand(1, 1 + looting);
-            drops.add(Item.get(Item.SPIDER_EYE, 0, amount));
+        if (killedByPlayer()) {
+            int eyes = Utils.rand(0, 1 + looting);
+            if (eyes > 0) {
+                drops.add(Item.get(Item.SPIDER_EYE, 0, eyes));
+            }
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityStray.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityStray.java
@@ -20,6 +20,7 @@ import org.powernukkitx.entity.ai.sensor.NearestEntitySensor;
 import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemID;
 import org.powernukkitx.item.enchantment.Enchantment;
@@ -91,23 +92,29 @@ public class EntityStray extends EntityMob implements EntityWalkable, EntitySmit
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
         List<Item> drops = new ArrayList<>();
 
-        float boneChance = 0.66f + (0.12f * looting);
-        boneChance = Math.min(boneChance, 1.0f);
-
-        if (Utils.rand(0f, 1f) < boneChance) {
-            int amount = Utils.rand(1, 2 + looting);
-            drops.add(Item.get(Item.BONE, 0, amount));
+        int bones = Utils.rand(0, 2 + looting);
+        if (bones > 0) {
+            drops.add(Item.get(Item.BONE, 0, bones));
         }
 
-        float arrowChance = 0.55f + (0.10f * looting);
-        arrowChance = Math.min(arrowChance, 1.0f);
+        int arrows = Utils.rand(0, 2 + looting);
+        if (arrows > 0) {
+            drops.add(Item.get(Item.ARROW, 0, arrows));
+        }
 
-        if (Utils.rand(0f, 1f) < arrowChance) {
-            int amount = Utils.rand(1, 2 + looting);
-            drops.add(Item.get(Item.ARROW, 0, amount));
+        if (killedByPlayer()) {
+            int slownessArrows = Utils.rand(0, 1 + looting);
+            if (slownessArrows > 0) {
+                drops.add(Item.get(Item.ARROW, 18, slownessArrows));
+            }
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityVex.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityVex.java
@@ -28,9 +28,11 @@ import org.powernukkitx.entity.passive.EntityVillagerV2;
 import org.powernukkitx.event.entity.EntityDamageEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemTool;
+import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
+import org.powernukkitx.utils.Utils;
 import lombok.Getter;
 import lombok.Setter;
 import org.cloudburstmc.protocol.bedrock.data.actor.ActorFlags;
@@ -154,10 +156,15 @@ public class EntityVex extends EntityMob implements EntityFlyable {
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
-        if(getItemInHand() instanceof ItemTool tool) {
-            tool.setDamage(ThreadLocalRandom.current().nextInt(tool.getMaxDurability()));
+        if (getItemInHand() instanceof ItemTool tool) {
+            int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+            if (Utils.rand(0, 99) >= (25 + looting * 5)) {
+                return Item.EMPTY_ARRAY;
+            }
+            Item drop = tool.clone();
+            drop.setDamage(ThreadLocalRandom.current().nextInt(tool.getMaxDurability()));
             return new Item[] {
-                tool
+                drop
             };
         }
         return super.getDrops(weapon);

--- a/src/main/java/org/powernukkitx/entity/mob/EntityVindicator.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityVindicator.java
@@ -22,6 +22,7 @@ import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.ai.sensor.NearestTargetEntitySensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
@@ -35,6 +36,7 @@ import org.cloudburstmc.protocol.bedrock.data.actor.ActorFlags;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -130,12 +132,28 @@ public class EntityVindicator extends EntityIllager implements EntityWalkable {
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
-        Item axe = Item.get(Item.IRON_AXE);
-        axe.setDamage(ThreadLocalRandom.current().nextInt(1, axe.getMaxDurability()));
-        return new Item[]{
-                axe,
-                Item.get(Item.EMERALD, 0, Utils.rand(0, 2 + looting))
-        };
+        List<Item> drops = new ArrayList<>();
+
+        Item hand = getItemInHand();
+        if (!hand.isNull() && Utils.rand(0, 99) < (25 + looting * 5)) {
+            Item axe = hand.clone();
+            axe.setDamage(ThreadLocalRandom.current().nextInt(1, axe.getMaxDurability()));
+            drops.add(axe);
+        }
+
+        if (killedByPlayer()) {
+            int emeralds = Utils.rand(0, 1 + looting);
+            if (emeralds > 0) {
+                drops.add(Item.get(Item.EMERALD, 0, emeralds));
+            }
+        }
+
+        return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityWarden.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityWarden.java
@@ -2,6 +2,7 @@ package org.powernukkitx.entity.mob;
 
 import org.powernukkitx.Player;
 import org.powernukkitx.Server;
+import org.powernukkitx.block.BlockID;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityCreature;
 import org.powernukkitx.entity.EntityWalkable;
@@ -30,6 +31,7 @@ import org.powernukkitx.entity.effect.EffectType;
 import org.powernukkitx.entity.projectile.EntityProjectile;
 import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.event.entity.EntityDamageEvent;
+import org.powernukkitx.item.Item;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.level.vibration.VibrationEvent;
@@ -359,5 +361,10 @@ public class EntityWarden extends EntityMob implements EntityWalkable, Vibration
     @Override
     public void setOnFire(int seconds) {
         //against fire
+    }
+
+    @Override
+    public Item[] getDrops(@NotNull Item weapon) {
+        return new Item[]{Item.get(BlockID.SCULK_CATALYST)};
     }
 }

--- a/src/main/java/org/powernukkitx/entity/mob/EntityWitch.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityWitch.java
@@ -120,22 +120,21 @@ public class EntityWitch extends EntityMob implements EntityWalkable {
                 Utils.rand(4, 8 + looting)
         ));
 
-        int max = 6 + (looting * 3);
+        int rolls = Utils.rand(1, 3);
+        for (int i = 0; i < rolls; i++) {
+            // the stick is twice as likely as the five other entries
+            String id = switch (Utils.rand(0, 6)) {
+                case 0, 1 -> Item.STICK;
+                case 2 -> Item.SPIDER_EYE;
+                case 3 -> Item.GLOWSTONE_DUST;
+                case 4 -> Item.GUNPOWDER;
+                case 5 -> Item.SUGAR;
+                default -> Item.GLASS_BOTTLE;
+            };
 
-        record ExtraDrop(String id, int chance) {}
-
-        ExtraDrop[] extras = {
-                new ExtraDrop(Item.STICK, 3349),
-                new ExtraDrop(Item.SPIDER_EYE, 1787),
-                new ExtraDrop(Item.GLOWSTONE_DUST, 1787),
-                new ExtraDrop(Item.GUNPOWDER, 1787),
-                new ExtraDrop(Item.SUGAR, 1787),
-                new ExtraDrop(Item.GLASS_BOTTLE, 1787)
-        };
-
-        for (ExtraDrop drop : extras) {
-            if (Utils.rand(0, 9999) < drop.chance()) {
-                drops.add(Item.get(drop.id(), 0, Utils.rand(0, max)));
+            int amount = Utils.rand(0, 2 + looting);
+            if (amount > 0) {
+                drops.add(Item.get(id, 0, amount));
             }
         }
 

--- a/src/main/java/org/powernukkitx/entity/mob/EntityWitherSkeleton.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityWitherSkeleton.java
@@ -25,7 +25,9 @@ import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.entity.effect.Effect;
 import org.powernukkitx.entity.effect.EffectType;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
+import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
@@ -151,22 +153,34 @@ public class EntityWitherSkeleton extends EntityMob implements EntityWalkable, E
         return true;
     }
 
-    // The probability of dropping a sword is 8.5%, and the probability of dropping a head is 2.5%.
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
         List<Item> drops = new ArrayList<>();
-        drops.add(Item.get(Item.BONE, 0, Utils.rand(0, 2)));
-        if (Utils.rand(0, 2) == 0) {
-            drops.add(Item.get(Item.COAL, 0, 1));
+
+        int bones = Utils.rand(0, 2 + looting);
+        if (bones > 0) {
+            drops.add(Item.get(Item.BONE, 0, bones));
         }
-        // The probability of obtaining a stone sword is 8.5%.
-        if (Utils.rand(0, 200) <= 17) {
+
+        int coal = Utils.rand(0, 1 + looting);
+        if (coal > 0) {
+            drops.add(Item.get(Item.COAL, 0, coal));
+        }
+
+        if (Utils.rand(0, 99) < (25 + looting * 5)) {
             drops.add(Item.get(Item.STONE_SWORD, Utils.rand(0, 131), 1));
         }
-        // The probability of losing your head is 2.5%.
-        if (Utils.rand(0, 40) == 1) {
+
+        if (killedByPlayer() && Utils.rand(0, 999) < (25 + looting * 20)) {
             drops.add(Item.get(BlockID.SKULL, 1, 1));
         }
+
         return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 }

--- a/src/main/java/org/powernukkitx/entity/mob/EntityZombie.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityZombie.java
@@ -170,7 +170,7 @@ public class EntityZombie extends EntityMob implements EntityWalkable, EntitySmi
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
         List<Item> drops = new ArrayList<>();
 
-        int flesh = Utils.rand(0, 3 + looting);
+        int flesh = Utils.rand(0, 2 + looting);
         if (flesh > 0) {
             drops.add(Item.get(Item.ROTTEN_FLESH, 0, flesh));
         }

--- a/src/main/java/org/powernukkitx/entity/mob/EntityZombie.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityZombie.java
@@ -30,7 +30,9 @@ import org.powernukkitx.entity.ai.sensor.NearestTargetEntitySensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.entity.item.EntityItem;
+import org.powernukkitx.entity.passive.EntityChicken;
 import org.powernukkitx.entity.passive.EntityTurtle;
+import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.event.entity.EntityDamageEvent;
 import org.powernukkitx.event.entity.EntityTransformEvent;
 import org.powernukkitx.inventory.EntityInventoryHolder;
@@ -173,17 +175,26 @@ public class EntityZombie extends EntityMob implements EntityWalkable, EntitySmi
             drops.add(Item.get(Item.ROTTEN_FLESH, 0, flesh));
         }
 
-        float rareChance = (1f / 120f) + ((1f / 300f) * looting);
-        if (Utils.rand(0f, 1f) < rareChance) {
-            int roll = Utils.rand(0, 3);
-            switch (roll) {
-                case 0 -> drops.add(Item.get(Item.IRON_INGOT));
-                case 1 -> drops.add(Item.get(Item.CARROT));
-                case 2 -> drops.add(Item.get(Item.POTATO));
+        if (killedByPlayer()) {
+            if (Utils.rand(0, 999) < (25 + looting * 10)) {
+                switch (Utils.rand(0, 2)) {
+                    case 0 -> drops.add(Item.get(Item.IRON_INGOT));
+                    case 1 -> drops.add(Item.get(Item.CARROT));
+                    default -> drops.add(Item.get(Item.POTATO));
+                }
+            }
+
+            if (isBaby() && getRiding() instanceof EntityChicken) {
+                drops.add(Item.get(Item.MUSIC_DISC_LAVA_CHICKEN));
             }
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityZombiePigman.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityZombiePigman.java
@@ -92,6 +92,9 @@ public class EntityZombiePigman extends EntityMob implements EntityWalkable, Ent
         this.diffHandDamage = new float[]{2.5f, 3f, 4.5f};
         super.initEntity();
         getMemoryStorage().put(CoreMemoryTypes.LOOKING_BLOCK, BlockTurtleEgg.class);
+        if (getEquipmentInventory().getItemInHand().isNull()) {
+            setItemInHand(Item.get(Utils.rand(0, 99) < 5 ? Item.GOLDEN_SPEAR : Item.GOLDEN_SWORD));
+        }
     }
 
     @Override
@@ -174,21 +177,12 @@ public class EntityZombiePigman extends EntityMob implements EntityWalkable, Ent
         }
 
         if (weapon != Item.AIR) {
-            if (Utils.rand(0, 199) < (5 + looting)) {
-                Item sword = Item.get(Item.GOLDEN_SWORD);
-                drops.add(sword);
-            }
-
-            if (/* TODO: isPiglinBruteZoombified() &&*/ Utils.rand(0, 199) < (5 + looting)) {
-                Item axe = Item.get(Item.GOLDEN_AXE);
-                drops.add(axe);
-            }
-
-            if (hand.getId() == Item.CROSSBOW) {
+            if (!hand.isNull() && hand.getId() != Item.WARPED_FUNGUS_ON_A_STICK
+                    && Utils.rand(0, 99) < (25 + looting * 5)) {
                 drops.add(hand.clone());
             }
 
-            if (Utils.rand(0, 999) < (10 + looting * 5)) {
+            if (Utils.rand(0, 999) < (25 + looting * 10)) {
                 drops.add(Item.get(Item.GOLD_INGOT, 0, 1));
             }
         }

--- a/src/main/java/org/powernukkitx/entity/passive/EntityCamelHusk.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityCamelHusk.java
@@ -169,11 +169,9 @@ public class EntityCamelHusk extends EntityCamel {
         ArrayList<Item> drops = new ArrayList<>();
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
 
-        if (Utils.rand(0, 2) != 0) {
-            int rottenFlesh = Utils.rand(2, 3 + looting);
-            if (rottenFlesh > 0) {
-                drops.add(Item.get(Item.ROTTEN_FLESH, 0, rottenFlesh));
-            }
+        int rottenFlesh = Utils.rand(2, 3 + looting);
+        if (rottenFlesh > 0) {
+            drops.add(Item.get(Item.ROTTEN_FLESH, 0, rottenFlesh));
         }
 
         // Drop Ride Inventory

--- a/src/main/java/org/powernukkitx/entity/passive/EntityCod.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityCod.java
@@ -59,8 +59,6 @@ public class EntityCod extends EntityFish {
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
-        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
-
         List<Item> drops = new ArrayList<>();
         drops.add(Item.get(
                 this.isOnFire() ? Item.COOKED_COD : Item.COD,
@@ -68,11 +66,7 @@ public class EntityCod extends EntityFish {
                 1
         ));
 
-        float boneChance = 0.25f + (looting * 0.01f);
-        if (Utils.rand(0f, 1f) < boneChance) {
-            int boneAmount = Utils.rand(1 + looting, 2 + (looting * 2));
-            drops.add(Item.get(Item.BONE, 0, boneAmount));
-        }
+        addBoneDrop(drops, weapon);
 
         return drops.toArray(Item.EMPTY_ARRAY);
     }

--- a/src/main/java/org/powernukkitx/entity/passive/EntityCow.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityCow.java
@@ -168,11 +168,9 @@ public class EntityCow extends EntityAnimal implements EntityWalkable, ClimateVa
                 beefAmount
         ));
 
-        if (Utils.rand(0f, 1f) < (2f / 3f)) {
-            int leatherAmount = Utils.rand(0, 2 + looting);
-            if (leatherAmount > 0) {
-                drops.add(Item.get(Item.LEATHER, 0, leatherAmount));
-            }
+        int leatherAmount = Utils.rand(0, 2 + looting);
+        if (leatherAmount > 0) {
+            drops.add(Item.get(Item.LEATHER, 0, leatherAmount));
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);

--- a/src/main/java/org/powernukkitx/entity/passive/EntityDolphin.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityDolphin.java
@@ -82,10 +82,6 @@ public class EntityDolphin extends EntityAnimal implements EntitySwimmable {
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
-        if (Utils.rand(0f, 1f) >= 0.5f) {
-            return Item.EMPTY_ARRAY;
-        }
-
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
 
         int amount = Utils.rand(0, 1 + looting);

--- a/src/main/java/org/powernukkitx/entity/passive/EntityFish.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityFish.java
@@ -10,9 +10,14 @@ import org.powernukkitx.entity.ai.controller.SpaceMoveController;
 import org.powernukkitx.entity.ai.executor.SpaceRandomRoamExecutor;
 import org.powernukkitx.entity.ai.route.finder.impl.SimpleSpaceAStarRouteFinder;
 import org.powernukkitx.entity.ai.route.posevaluator.SwimmingPosEvaluator;
+import org.powernukkitx.item.Item;
+import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
+import org.powernukkitx.utils.Utils;
+import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -36,5 +41,19 @@ public abstract class EntityFish extends EntityAnimal implements EntitySwimmable
                 .controllers(new SpaceMoveController(), new LookController(true, true), new DiveController())
                 .routeFinder(new SimpleSpaceAStarRouteFinder(new SwimmingPosEvaluator(), this))
                 .build();
+    }
+
+    /**
+     * Rolls the bone every fish shares, a 25% chance raised by 1% per looting level, giving
+     * one bone plus a bonus of one to two per looting level.
+     *
+     * @param drops  the drop list to add the bone to
+     * @param weapon the weapon the fish was killed with
+     */
+    protected void addBoneDrop(@NotNull List<Item> drops, @NotNull Item weapon) {
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        if (Utils.rand(0f, 1f) < 0.25f + (looting * 0.01f)) {
+            drops.add(Item.get(Item.BONE, 0, Utils.rand(1 + looting, 1 + (looting * 2))));
+        }
     }
 }

--- a/src/main/java/org/powernukkitx/entity/passive/EntityGlowSquid.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityGlowSquid.java
@@ -3,8 +3,12 @@ package org.powernukkitx.entity.passive;
 import org.powernukkitx.entity.EntitySwimmable;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
+import org.powernukkitx.item.Item;
+import org.powernukkitx.item.ItemID;
+import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
+import org.powernukkitx.utils.Utils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -49,5 +53,13 @@ public class EntityGlowSquid extends EntityAnimal implements EntitySwimmable {
     @Override
     public Set<String> typeFamily() {
         return Set.of("squid", "mob");
+    }
+
+    @Override
+    public Item[] getDrops(@NotNull Item weapon) {
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        return new Item[]{
+                Item.get(ItemID.GLOW_INK_SAC, 0, Utils.rand(1, 3 + looting))
+        };
     }
 }

--- a/src/main/java/org/powernukkitx/entity/passive/EntityHorse.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityHorse.java
@@ -344,11 +344,9 @@ public class EntityHorse extends EntityAnimal implements EntityWalkable, EntityV
         ArrayList<Item> drops = new ArrayList<>();
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
 
-        if (Utils.rand(0, 2) != 0) {
-            int leatherAmount = Utils.rand(0, 2 + looting);
-            if (leatherAmount > 0) {
-                drops.add(Item.get(Item.LEATHER, 0, leatherAmount));
-            }
+        int leatherAmount = Utils.rand(0, 2 + looting);
+        if (leatherAmount > 0) {
+            drops.add(Item.get(Item.LEATHER, 0, leatherAmount));
         }
 
         // Drop Ride Inventory

--- a/src/main/java/org/powernukkitx/entity/passive/EntityLlama.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityLlama.java
@@ -294,11 +294,9 @@ public class EntityLlama extends EntityAnimal implements EntityWalkable, Invento
         ArrayList<Item> drops = new ArrayList<>();
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
 
-        if (Utils.rand(0, 2) != 0) {
-            int amount = Utils.rand(0, 2 + looting);
-            if (amount > 0) {
-                drops.add(Item.get(Item.LEATHER, 0, amount));
-            }
+        int amount = Utils.rand(0, 2 + looting);
+        if (amount > 0) {
+            drops.add(Item.get(Item.LEATHER, 0, amount));
         }
 
         // Drop Ride Inventory

--- a/src/main/java/org/powernukkitx/entity/passive/EntityMooshroom.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityMooshroom.java
@@ -210,11 +210,9 @@ public class EntityMooshroom extends EntityAnimal implements EntityWalkable, Ent
                 meatAmount
         ));
 
-        if (Utils.rand(0, 2) != 0) {
-            int leatherAmount = Utils.rand(0, 2 + looting);
-            if (leatherAmount > 0) {
-                drops.add(Item.get(Item.LEATHER, 0, leatherAmount));
-            }
+        int leatherAmount = Utils.rand(0, 2 + looting);
+        if (leatherAmount > 0) {
+            drops.add(Item.get(Item.LEATHER, 0, leatherAmount));
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);

--- a/src/main/java/org/powernukkitx/entity/passive/EntityPanda.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityPanda.java
@@ -54,6 +54,7 @@ import org.powernukkitx.inventory.EntityEquipmentInventory;
 import org.powernukkitx.inventory.Inventory;
 import org.powernukkitx.inventory.InventoryHolder;
 import org.powernukkitx.item.Item;
+import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
@@ -201,8 +202,13 @@ public class EntityPanda extends EntityAnimal implements EntityWalkable, EntityC
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        int bamboo = Utils.rand(0, 2 + looting);
+        if (bamboo == 0) {
+            return Item.EMPTY_ARRAY;
+        }
         return new Item[]{
-                Item.get(Block.BAMBOO, 0, Utils.rand(0, 3))
+                Item.get(Block.BAMBOO, 0, bamboo)
         };
     }
 

--- a/src/main/java/org/powernukkitx/entity/passive/EntityPolarBear.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityPolarBear.java
@@ -71,26 +71,22 @@ public class EntityPolarBear extends EntityAnimal implements EntityWalkable {
 
         List<Item> drops = new ArrayList<>();
 
-        if (Utils.rand(0, 2) != 0) {
-            int amount = Utils.rand(0, 2 + looting);
-            if (amount > 0) {
-                drops.add(Item.get(
-                        this.isOnFire() ? Item.COOKED_COD : Item.COD,
-                        0,
-                        amount
-                ));
-            }
+        int cod = Utils.rand(0, 2 + looting);
+        if (cod > 0) {
+            drops.add(Item.get(
+                    this.isOnFire() ? Item.COOKED_COD : Item.COD,
+                    0,
+                    cod
+            ));
         }
 
-        if (Utils.rand(0, 2) != 0) {
-            int amount = Utils.rand(0, 2 + looting);
-            if (amount > 0) {
-                drops.add(Item.get(
-                        this.isOnFire() ? Item.COOKED_SALMON : Item.SALMON,
-                        0,
-                        amount
-                ));
-            }
+        int salmon = Utils.rand(0, 2 + looting);
+        if (salmon > 0) {
+            drops.add(Item.get(
+                    this.isOnFire() ? Item.COOKED_SALMON : Item.SALMON,
+                    0,
+                    salmon
+            ));
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);

--- a/src/main/java/org/powernukkitx/entity/passive/EntityPufferfish.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityPufferfish.java
@@ -2,11 +2,14 @@ package org.powernukkitx.entity.passive;
 
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
+import org.powernukkitx.item.Item;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -51,5 +54,15 @@ public class EntityPufferfish extends EntityFish {
     @Override
     protected @Nullable MovementComponent getComponentMovement() {
         return MovementComponent.value(0.13f);
+    }
+
+    @Override
+    public Item[] getDrops(@NotNull Item weapon) {
+        List<Item> drops = new ArrayList<>();
+        drops.add(Item.get(Item.PUFFERFISH));
+
+        addBoneDrop(drops, weapon);
+
+        return drops.toArray(Item.EMPTY_ARRAY);
     }
 }

--- a/src/main/java/org/powernukkitx/entity/passive/EntityRabbit.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityRabbit.java
@@ -162,30 +162,30 @@ public class EntityRabbit extends EntityAnimal implements EntityWalkable, Entity
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
         List<Item> drops = new ArrayList<>();
 
-        if (Utils.rand(0, 1) == 0) {
-            int amount = Utils.rand(0, 1 + looting);
-            if (amount > 0) {
-                drops.add(Item.get(Item.RABBIT_HIDE, 0, amount));
-            }
+        int hide = Utils.rand(0, 1 + looting);
+        if (hide > 0) {
+            drops.add(Item.get(Item.RABBIT_HIDE, 0, hide));
         }
 
-        if (Utils.rand(0, 1) == 0) {
-            int amount = Utils.rand(0, 1 + looting);
-            if (amount > 0) {
-                drops.add(Item.get(
-                        this.isOnFire() ? Item.COOKED_RABBIT : Item.RABBIT,
-                        0,
-                        amount
-                ));
-            }
+        int meat = Utils.rand(0, 1 + looting);
+        if (meat > 0) {
+            drops.add(Item.get(
+                    this.isOnFire() ? Item.COOKED_RABBIT : Item.RABBIT,
+                    0,
+                    meat
+            ));
         }
 
-        float footChance = 0.10f + (0.03f * looting);
-        if (Utils.rand(0f, 1f) < footChance) {
+        if (killedByPlayer() && Utils.rand(0, 999) < (100 + looting * 30)) {
             drops.add(Item.get(Item.RABBIT_FOOT));
         }
 
         return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private boolean killedByPlayer() {
+        return this.lastDamageCause instanceof EntityDamageByEntityEvent event
+                && event.getDamager() instanceof Player;
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/passive/EntitySalmon.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntitySalmon.java
@@ -5,10 +5,11 @@ import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
-import org.powernukkitx.utils.Utils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -63,19 +64,12 @@ public class EntitySalmon extends EntityFish {
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
-        int rand = Utils.rand(0, 3);
-        if (this.isLarge()) {
-            //only a 25% chance to drop a bone - from wiki https://zh.minecraft.wiki/w/%E9%B2%91%E9%B1%BC
-            if (rand == 1) {
-                return new Item[]{Item.get(Item.BONE, 0, Utils.rand(1, 2)), Item.get(((this.isOnFire()) ? Item.COOKED_SALMON : Item.SALMON))};
-            }
-        } else if (!this.isLarge()) {
-            //only a 25% chance to drop a bone - from wiki https://zh.minecraft.wiki/w/%E9%B2%91%E9%B1%BC
-            if (rand == 1) {
-                return new Item[]{Item.get(Item.BONE), Item.get(((this.isOnFire()) ? Item.COOKED_SALMON : Item.SALMON))};
-            }
-        }
-        return new Item[]{Item.get(((this.isOnFire()) ? Item.COOKED_SALMON : Item.SALMON))};
+        List<Item> drops = new ArrayList<>();
+        drops.add(Item.get(this.isOnFire() ? Item.COOKED_SALMON : Item.SALMON));
+
+        addBoneDrop(drops, weapon);
+
+        return drops.toArray(Item.EMPTY_ARRAY);
     }
 
     //large variant

--- a/src/main/java/org/powernukkitx/entity/passive/EntitySkeletonHorse.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntitySkeletonHorse.java
@@ -211,13 +211,11 @@ public class EntitySkeletonHorse extends EntityAnimal implements EntityWalkable 
     public Item[] getDrops(@NotNull Item weapon) {
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
 
-        if (Utils.rand(0, 2) != 0) {
-            int amount = Utils.rand(0, 2 + looting);
-            if (amount > 0) {
-                return new Item[]{
-                        Item.get(Item.BONE, 0, amount)
-                };
-            }
+        int amount = Utils.rand(0, 2 + looting);
+        if (amount > 0) {
+            return new Item[]{
+                    Item.get(Item.BONE, 0, amount)
+            };
         }
 
         return Item.EMPTY_ARRAY;

--- a/src/main/java/org/powernukkitx/entity/passive/EntityTropicalfish.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityTropicalfish.java
@@ -11,6 +11,8 @@ import org.cloudburstmc.protocol.bedrock.data.actor.ActorDataTypes;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -120,10 +122,12 @@ public class EntityTropicalfish extends EntityFish {
 
     @Override
     public Item[] getDrops(@NotNull Item weapon) {
-        if (Utils.rand(0, 3) == 1) {
-            return new Item[]{Item.get(Item.TROPICAL_FISH), Item.get(Item.BONE, 0, Utils.rand(1, 2))};
-        }
-        return new Item[]{Item.get(Item.TROPICAL_FISH)};
+        List<Item> drops = new ArrayList<>();
+        drops.add(Item.get(Item.TROPICAL_FISH));
+
+        addBoneDrop(drops, weapon);
+
+        return drops.toArray(Item.EMPTY_ARRAY);
     }
 
     public int getColor() {

--- a/src/main/java/org/powernukkitx/entity/passive/EntityTurtle.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityTurtle.java
@@ -35,10 +35,13 @@ import org.powernukkitx.entity.components.BreedableComponent;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.event.entity.EntityDamageEvent;
+import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemID;
+import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.math.Vector3;
 import org.powernukkitx.nbt.tag.CompoundTag;
+import org.powernukkitx.utils.Utils;
 import it.unimi.dsi.fastutil.Pair;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -64,6 +67,19 @@ public class EntityTurtle extends EntityAnimal implements EntitySwimmable, Entit
     @Override
     public String getOriginalName() {
         return "Turtle";
+    }
+
+    @Override
+    public Item[] getDrops(@NotNull Item weapon) {
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        int seagrass = Utils.rand(0, 2 + looting);
+        if (seagrass == 0) {
+            return Item.EMPTY_ARRAY;
+        }
+
+        return new Item[]{
+                Item.get(BlockID.SEAGRASS, 0, seagrass)
+        };
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/item/randomitem/Fishing.java
+++ b/src/main/java/org/powernukkitx/item/randomitem/Fishing.java
@@ -37,6 +37,16 @@ public final class Fishing {
     public static final Selector JUNK_BONE = putSelector(new ConstantItemSelector(ItemID.BONE, JUNKS), 0.12F);
     public static final Selector JUNK_TRIPWIRE_HOOK = putSelector(new ConstantItemSelector(Item.get(BlockID.TRIPWIRE_HOOK), JUNKS), 0.12F);
 
+    /**
+     * Selects a fish the way the {@code fishing/fish} loot table does, without the
+     * treasure and junk categories that {@link #getFishingResult(Item)} can also return.
+     *
+     * @return a cod, a salmon, a pufferfish or a tropical fish
+     */
+    public static Item getRandomFish() {
+        return (Item) selectFrom(FISHES);
+    }
+
     public static Item getFishingResult(Item rod) {
         int fortuneLevel = 0;
         int lureLevel = 0;


### PR DESCRIPTION
## What does this PR do?

It aligns the mob drops with the vanilla loot tables, for every mob I opened a separate PR for today, plus the four fish which never had one. Grouped here on request so it can be reviewed in one pass.

It replaces #3152 #3155 #3156 #3157 #3158 #3160 #3161 #3162 #3163 #3164 #3165 #3167 #3168 #3169 #3170 #3171 #3172 #3173 #3174 #3175 #3176 #3177 #3178

## Why?

It match vanilla behaviour. The same few mistakes repeat across the entities:

- a made up chance rolled before the drop count, which no loot table has, halving the drop rate: cow, horse, llama, mooshroom, skeleton horse, husk camel, polar bear, hoglin, rabbit, shulker, dolphin, phantom, ghast, magma cube
- looting lowering the drop chance instead of raising the count: cave spider and bogged
- the java equipment chance of 8.5% + 1% instead of the bedrock 25% + 5%: zombified piglin, wither skeleton, skeleton, vex, vindicator, parched
- a missing killed by player condition: blaze, phantom, spider, cave spider, bogged, stray, breeze, vindicator, guardian, elder guardian, drowned, zombie, ravager
- drops that were missing entirely: ravager saddle, glow squid ink sacs, pillager arrows, warden sculk catalyst, turtle seagrass, stray slowness arrow, drowned copper ingot, ghast music disc, pufferfish

The four fish share the same bone pool, so that roll now lives in `EntityFish` instead of being written again in each of them. The pufferfish had no `getDrops` at all and dropped nothing.

Source: the loot tables in [bedrock-samples](https://github.com/Mojang/bedrock-samples/tree/main/behavior_pack/loot_tables/entities), one per mob.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** cb752e346
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

`Fishing.getRandomFish()` is added, it rolls only the fish category of the fishing loot table. Nothing existing changed.

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
