### PR TITLE
feat(entity): make a cat leave a gift after sleeping with its owner

### DIFF
--- a/src/main/java/org/powernukkitx/entity/ai/executor/CatSleepOnOwnerBedExecutor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/executor/CatSleepOnOwnerBedExecutor.java
@@ -1,0 +1,60 @@
+package org.powernukkitx.entity.ai.executor;
+
+import org.powernukkitx.Player;
+import org.powernukkitx.entity.EntityIntelligent;
+import org.powernukkitx.item.Item;
+import org.powernukkitx.utils.Utils;
+import org.cloudburstmc.protocol.bedrock.data.actor.ActorFlags;
+
+/**
+ * Sleeps in the owner's bed like {@link SleepOnOwnerBedExecutor} does, and leaves a gift next to
+ * the owner on waking up.
+ */
+public class CatSleepOnOwnerBedExecutor extends SleepOnOwnerBedExecutor {
+
+    private static final float GIFT_CHANCE = 0.7f;
+
+    /**
+     * The gift pool, each item repeated as many times as its weight. The phantom membrane is
+     * five times rarer than the six other entries.
+     */
+    private static final String[] GIFTS = {
+            Item.RABBIT_HIDE, Item.RABBIT_HIDE, Item.RABBIT_HIDE, Item.RABBIT_HIDE, Item.RABBIT_HIDE,
+            Item.RABBIT_FOOT, Item.RABBIT_FOOT, Item.RABBIT_FOOT, Item.RABBIT_FOOT, Item.RABBIT_FOOT,
+            Item.CHICKEN, Item.CHICKEN, Item.CHICKEN, Item.CHICKEN, Item.CHICKEN,
+            Item.FEATHER, Item.FEATHER, Item.FEATHER, Item.FEATHER, Item.FEATHER,
+            Item.ROTTEN_FLESH, Item.ROTTEN_FLESH, Item.ROTTEN_FLESH, Item.ROTTEN_FLESH, Item.ROTTEN_FLESH,
+            Item.STRING, Item.STRING, Item.STRING, Item.STRING, Item.STRING,
+            Item.PHANTOM_MEMBRANE
+    };
+
+    private boolean slept;
+
+    @Override
+    public boolean execute(EntityIntelligent entity) {
+        boolean running = super.execute(entity);
+        if (entity.getDataFlag(ActorFlags.RESTING)) {
+            this.slept = true;
+        }
+        return running;
+    }
+
+    @Override
+    protected void stop(EntityIntelligent entity) {
+        boolean gift = this.slept;
+        this.slept = false;
+        super.stop(entity);
+
+        if (gift && Utils.rand(0f, 1f) < GIFT_CHANCE) {
+            dropGift(entity);
+        }
+    }
+
+    protected void dropGift(EntityIntelligent entity) {
+        Player owner = entity.getOwner();
+        if (owner == null) {
+            return;
+        }
+        entity.getLevel().dropItem(owner, Item.get(GIFTS[Utils.rand(0, GIFTS.length - 1)]));
+    }
+}

--- a/src/main/java/org/powernukkitx/entity/passive/EntityCat.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityCat.java
@@ -24,7 +24,7 @@ import org.powernukkitx.entity.ai.executor.FlatRandomRoamExecutor;
 import org.powernukkitx.entity.ai.executor.LookAtTargetExecutor;
 import org.powernukkitx.entity.ai.executor.LoveTimeoutExecutor;
 import org.powernukkitx.entity.ai.executor.MeleeAttackExecutor;
-import org.powernukkitx.entity.ai.executor.SleepOnOwnerBedExecutor;
+import org.powernukkitx.entity.ai.executor.CatSleepOnOwnerBedExecutor;
 import org.powernukkitx.entity.ai.executor.TemptExecutor;
 import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
 import org.powernukkitx.entity.ai.route.finder.impl.SimpleFlatAStarRouteFinder;
@@ -332,7 +332,7 @@ public class EntityCat extends EntityAnimal implements EntityWalkable, EntityCan
                 )
                 .behaviors(
                         new Behavior( // Sleep Priority 7
-                                new SleepOnOwnerBedExecutor(),
+                                new CatSleepOnOwnerBedExecutor(),
                                 entity -> {
                                     if (this.isSitting()) return false; // sitting should block sleeping pathing
                                     var player = this.getOwner();


### PR DESCRIPTION
## What does this PR do?

It makes a tamed cat leave a gift next to its owner after sleeping in their bed.

## Why?

It match vanilla behaviour. Sleeping in the owner's bed was already implemented but the gift was not, so the cat never gave anything.

The chance is 70% and the item is picked from the seven entries of the gift table, the phantom membrane being five times rarer than the six others.

Source: [cat.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/entities/cat.json) and [cat_gift.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/cat_gift.json)

## Type of change

- [ ] Bug Fix
- [x] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** ab5672257
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
