### PR TITLE
fix(item): align the fishing junk and treasure tables with vanilla

### DIFF
--- a/src/main/java/org/powernukkitx/item/randomitem/Fishing.java
+++ b/src/main/java/org/powernukkitx/item/randomitem/Fishing.java
@@ -24,18 +24,27 @@ public final class Fishing {
     public static final Selector SALMON = putSelector(new ConstantItemSelector(ItemID.SALMON, FISHES), 0.25F);
     public static final Selector TROPICAL_FISH = putSelector(new ConstantItemSelector(ItemID.TROPICAL_FISH, FISHES), 0.02F);
     public static final Selector PUFFERFISH = putSelector(new ConstantItemSelector(ItemID.PUFFERFISH, FISHES), 0.13F);
-    public static final Selector TREASURE_BOW = putSelector(new ConstantItemSelector(ItemID.BOW, TREASURES), 0.1667F);
-    public static final Selector TREASURE_ENCHANTED_BOOK = putSelector(new FishingEnchantmentItemSelector(ItemID.ENCHANTED_BOOK, TREASURES),  0.1667F);
-    public static final Selector JUNK_BOWL = putSelector(new ConstantItemSelector(ItemID.BOWL, JUNKS), 0.12F);
-    public static final Selector JUNK_FISHING_ROD = putSelector(new ConstantItemSelector(ItemID.FISHING_ROD, JUNKS), 0.024F);
-    public static final Selector JUNK_LEATHER = putSelector(new ConstantItemSelector(ItemID.LEATHER, JUNKS), 0.12F);
-    public static final Selector JUNK_LEATHER_BOOTS = putSelector(new ConstantItemSelector(ItemID.LEATHER_BOOTS, JUNKS), 0.12F);
-    public static final Selector JUNK_ROTTEN_FLESH = putSelector(new ConstantItemSelector(ItemID.ROTTEN_FLESH, JUNKS), 0.12F);
-    public static final Selector JUNK_STICK = putSelector(new ConstantItemSelector(ItemID.STICK, JUNKS), 0.06F);
-    public static final Selector JUNK_STRING_ITEM = putSelector(new ConstantItemSelector(ItemID.STRING, JUNKS), 0.06F);
-    public static final Selector JUNK_WATTER_BOTTLE = putSelector(new ConstantItemSelector(ItemID.POTION, 0, JUNKS), 0.12F);
-    public static final Selector JUNK_BONE = putSelector(new ConstantItemSelector(ItemID.BONE, JUNKS), 0.12F);
-    public static final Selector JUNK_TRIPWIRE_HOOK = putSelector(new ConstantItemSelector(Item.get(BlockID.TRIPWIRE_HOOK), JUNKS), 0.12F);
+    // treasure weights out of 31: 5 each, except the book which is 6
+    public static final Selector TREASURE_NAUTILUS_SHELL = putSelector(new ConstantItemSelector(ItemID.NAUTILUS_SHELL, TREASURES), 0.1613F);
+    public static final Selector TREASURE_NAME_TAG = putSelector(new ConstantItemSelector(ItemID.NAME_TAG, TREASURES), 0.1613F);
+    public static final Selector TREASURE_SADDLE = putSelector(new ConstantItemSelector(ItemID.SADDLE, TREASURES), 0.1613F);
+    public static final Selector TREASURE_BOW = putSelector(new ConstantItemSelector(ItemID.BOW, TREASURES), 0.1613F);
+    public static final Selector TREASURE_FISHING_ROD = putSelector(new ConstantItemSelector(ItemID.FISHING_ROD, TREASURES), 0.1613F);
+    public static final Selector TREASURE_ENCHANTED_BOOK = putSelector(new FishingEnchantmentItemSelector(ItemID.ENCHANTED_BOOK, TREASURES),  0.1935F);
+    // junk weights out of 101
+    public static final Selector JUNK_WATERLILY = putSelector(new ConstantItemSelector(Item.get(BlockID.WATERLILY), JUNKS), 0.1683F);
+    public static final Selector JUNK_BOWL = putSelector(new ConstantItemSelector(ItemID.BOWL, JUNKS), 0.099F);
+    public static final Selector JUNK_FISHING_ROD = putSelector(new ConstantItemSelector(ItemID.FISHING_ROD, JUNKS), 0.0198F);
+    public static final Selector JUNK_LEATHER = putSelector(new ConstantItemSelector(ItemID.LEATHER, JUNKS), 0.099F);
+    public static final Selector JUNK_LEATHER_BOOTS = putSelector(new ConstantItemSelector(ItemID.LEATHER_BOOTS, JUNKS), 0.099F);
+    public static final Selector JUNK_ROTTEN_FLESH = putSelector(new ConstantItemSelector(ItemID.ROTTEN_FLESH, JUNKS), 0.099F);
+    public static final Selector JUNK_STICK = putSelector(new ConstantItemSelector(ItemID.STICK, JUNKS), 0.0495F);
+    public static final Selector JUNK_STRING_ITEM = putSelector(new ConstantItemSelector(ItemID.STRING, JUNKS), 0.0495F);
+    public static final Selector JUNK_WATTER_BOTTLE = putSelector(new ConstantItemSelector(ItemID.POTION, 0, JUNKS), 0.099F);
+    public static final Selector JUNK_BONE = putSelector(new ConstantItemSelector(ItemID.BONE, JUNKS), 0.099F);
+    public static final Selector JUNK_TRIPWIRE_HOOK = putSelector(new ConstantItemSelector(Item.get(BlockID.TRIPWIRE_HOOK), JUNKS), 0.099F);
+    public static final Selector JUNK_INK_SAC = putSelector(new ConstantItemSelector(ItemID.INK_SAC, JUNKS), 0.0099F);
+    public static final Selector JUNK_INK_SAC_STACK = putSelector(new ConstantItemSelector(ItemID.INK_SAC, 0, 10, JUNKS), 0.0099F);
 
     public static Item getFishingResult(Item rod) {
         int fortuneLevel = 0;


### PR DESCRIPTION
## What does this PR do?

It aligns the fishing junk and treasure tables with the vanilla loot tables.

## Why?

It match vanilla behaviour.

Four of the six treasures were missing, only the bow and the enchanted book were there, so two treasure rolls out of three gave nothing. The nautilus shell, the name tag, the saddle and the fishing rod are added.

Three junk entries were missing, the waterlily being the second most common one at 17 out of 101, along with the two ink sac entries, one giving a single sac and one giving ten.

The weights were also rounded, 0.12 and 0.06 and 0.024 instead of 10, 5 and 2 out of 101.

Source: [junk.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/gameplay/fishing/junk.json) and [treasure.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/gameplay/fishing/treasure.json)

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** c76726cb1
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
