### PR TITLE
fix(entity): store the trident owner as a long

### DIFF
--- a/src/main/java/org/powernukkitx/entity/projectile/EntityThrownTrident.java
+++ b/src/main/java/org/powernukkitx/entity/projectile/EntityThrownTrident.java
@@ -411,7 +411,7 @@ public class EntityThrownTrident extends SlenderProjectile {
         if (tridentRope) {
             this.setDataProperty(ActorDataTypes.OWNER, this.shootingEntity.getId());
         } else {
-            this.setDataProperty(ActorDataTypes.OWNER, -1);
+            this.setDataProperty(ActorDataTypes.OWNER, -1L);
         }
         this.setDataFlag(ActorFlags.RETURN_TRIDENT, tridentRope);
     }


### PR DESCRIPTION
## What does this PR do?

It stores the trident owner as a `long` when the loyalty rope is cleared, instead of an `int`.

## Why?

`ActorDataTypes.OWNER` holds a `Long`.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 42345d3
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
