### PR TITLE
feat(entity): equip mobs with the gear they spawn with

### DIFF
--- a/src/main/java/org/powernukkitx/entity/mob/EntityBogged.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityBogged.java
@@ -48,8 +48,13 @@ public class EntityBogged extends EntityMob implements EntityWalkable, EntitySmi
     protected void initEntity() {
         super.initEntity();
         if (getItemInHand().isNull()) {
-            setItemInHand(Item.get(ItemID.BOW));
+            setItemInHand(enchantGear(Item.get(ItemID.BOW), 0.1f));
         }
+    }
+
+    @Override
+    protected void equipOnSpawn() {
+        equipArmorSet(3, 3, 0.1087f);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityDrowned.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityDrowned.java
@@ -133,6 +133,13 @@ public class EntityDrowned extends EntityZombie implements EntitySwimmable, Enti
         return 0;
     }
 
+    /**
+     * A drowned carries its own gear, set below, and never the iron tools and armour of a zombie.
+     */
+    @Override
+    protected void equipOnSpawn() {
+    }
+
     @Override
     protected void initEntity() {
         this.diffHandDamage = new float[]{2.5f, 3f, 4.5f};

--- a/src/main/java/org/powernukkitx/entity/mob/EntityMob.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityMob.java
@@ -13,7 +13,9 @@ import org.powernukkitx.inventory.EntityEquipmentInventory;
 import org.powernukkitx.inventory.EntityInventoryHolder;
 import org.powernukkitx.inventory.Inventory;
 import org.powernukkitx.item.Item;
+import org.powernukkitx.item.ItemID;
 import org.powernukkitx.item.enchantment.Enchantment;
+import org.powernukkitx.item.enchantment.EnchantmentHelper;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.math.NukkitMath;
@@ -21,6 +23,7 @@ import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.nbt.tag.ListTag;
 import org.powernukkitx.utils.ItemHelper;
 import org.powernukkitx.utils.Utils;
+import org.powernukkitx.utils.random.NukkitRandom;
 import lombok.Getter;
 import org.jetbrains.annotations.NotNull;
 
@@ -34,6 +37,15 @@ import java.util.concurrent.ThreadLocalRandom;
  */
 
 public abstract class EntityMob extends EntityIntelligent implements EntityInventoryHolder, EntityCanAttack {
+    private static final String[][] ARMOR_SETS = {
+            {ItemID.LEATHER_HELMET, ItemID.LEATHER_CHESTPLATE, ItemID.LEATHER_LEGGINGS, ItemID.LEATHER_BOOTS},
+            {ItemID.COPPER_HELMET, ItemID.COPPER_CHESTPLATE, ItemID.COPPER_LEGGINGS, ItemID.COPPER_BOOTS},
+            {ItemID.GOLDEN_HELMET, ItemID.GOLDEN_CHESTPLATE, ItemID.GOLDEN_LEGGINGS, ItemID.GOLDEN_BOOTS},
+            {ItemID.CHAINMAIL_HELMET, ItemID.CHAINMAIL_CHESTPLATE, ItemID.CHAINMAIL_LEGGINGS, ItemID.CHAINMAIL_BOOTS},
+            {ItemID.IRON_HELMET, ItemID.IRON_CHESTPLATE, ItemID.IRON_LEGGINGS, ItemID.IRON_BOOTS},
+            {ItemID.DIAMOND_HELMET, ItemID.DIAMOND_CHESTPLATE, ItemID.DIAMOND_LEGGINGS, ItemID.DIAMOND_BOOTS}
+    };
+
     private static final String TAG_MAINHAND = "Mainhand";
     private static final String TAG_OFFHAND = "Offhand";
     private static final String TAG_ARMOR = "Armor";
@@ -71,6 +83,82 @@ public abstract class EntityMob extends EntityIntelligent implements EntityInven
             for (CompoundTag armorTag : armorList.getAll()) {
                 this.armorInventory.setItem(armorTag.getByte("Slot"), ItemHelper.read(armorTag));
             }
+        } else if (!this.nbt.contains(TAG_MAINHAND)) {
+            equipOnSpawn();
+        }
+    }
+
+    /**
+     * Gives this mob the gear it spawns with. Only called on a mob that is spawning, never on one
+     * being loaded back, since a saved mob always carries its own equipment tags.
+     */
+    protected void equipOnSpawn() {
+    }
+
+    /**
+     * Rolls one of the chances the equipment tables scale with the regional difficulty, so a mob
+     * spawns better geared on a hard difficulty and bare on peaceful and easy.
+     *
+     * @param maxChance the chance reached at the highest regional difficulty
+     */
+    protected boolean rollGearChance(float maxChance) {
+        return ThreadLocalRandom.current().nextFloat() < this.level.getSpecialMultiplier() * maxChance;
+    }
+
+    /**
+     * Enchants a piece of gear the way the equipment tables do, with a strength that follows the
+     * regional difficulty.
+     *
+     * @param chance the probability the piece is enchanted at the highest regional difficulty
+     */
+    protected Item enchantGear(Item item, float chance) {
+        float multiplier = this.level.getSpecialMultiplier();
+        if (chance * multiplier <= ThreadLocalRandom.current().nextFloat()) {
+            return item;
+        }
+
+        int cost = (int) (multiplier * ThreadLocalRandom.current().nextInt(18) + 5);
+        for (Enchantment enchantment : EnchantmentHelper.selectEnchantments(new NukkitRandom(), item, cost)) {
+            item.addEnchantment(enchantment);
+        }
+        return item;
+    }
+
+    /**
+     * Gives this mob a full armour set, picked between leather and diamond and thinning out from
+     * the helmet down, the way the armour set tables do.
+     *
+     * @param initialRange the number of materials reachable without a bonus roll, starting at leather
+     * @param bonusRolls   how many times the material can be upgraded
+     * @param bonusChance  the probability of each upgrade
+     */
+    protected void equipArmorSet(int initialRange, int bonusRolls, float bonusChance) {
+        if (!rollGearChance(0.15f)) {
+            return;
+        }
+
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        int tier = random.nextInt(initialRange);
+        for (int i = 0; i < bonusRolls; i++) {
+            if (random.nextFloat() < bonusChance) {
+                tier++;
+            }
+        }
+        equipArmorSet(Math.min(tier, ARMOR_SETS.length - 1));
+    }
+
+    /**
+     * @param tier the index in {@link #ARMOR_SETS} of the material to wear
+     */
+    protected void equipArmorSet(int tier) {
+        String[] set = ARMOR_SETS[tier];
+        float pieceChance = this.getServer().getDifficulty() == 3 ? 0.6f : 0.5f;
+
+        for (int slot = 0; slot < set.length; slot++) {
+            if (slot > 0 && ThreadLocalRandom.current().nextFloat() >= pieceChance) {
+                return;
+            }
+            this.armorInventory.setItem(slot, enchantGear(Item.get(set[slot]), 0.25f));
         }
     }
 

--- a/src/main/java/org/powernukkitx/entity/mob/EntityParched.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityParched.java
@@ -37,7 +37,7 @@ public class EntityParched extends EntitySkeleton {
     protected void initEntity() {
         super.initEntity();
         if (getItemInHand().isNull()) {
-            setItemInHand(Item.get(ItemID.BOW));
+            setItemInHand(enchantGear(Item.get(ItemID.BOW), 0.1f));
         }
     }
 

--- a/src/main/java/org/powernukkitx/entity/mob/EntityPiglin.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityPiglin.java
@@ -41,6 +41,7 @@ import org.powernukkitx.inventory.EntityInventoryHolder;
 import org.powernukkitx.inventory.InventorySlice;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.item.ItemCrossbow;
+import org.powernukkitx.item.ItemID;
 import org.powernukkitx.item.ItemGoldIngot;
 import org.powernukkitx.item.ItemPorkchop;
 import org.powernukkitx.item.ItemTool;
@@ -186,11 +187,12 @@ public class EntityPiglin extends EntityMob implements EntityWalkable {
     protected void initEntity() {
         this.diffHandDamage = new float[]{3f, 5f, 7f};
         super.initEntity();
-        if (!isBaby()) setItemInHand(Item.get(Utils.rand() ? Item.GOLDEN_SWORD : Item.CROSSBOW));
-        if (Utils.rand(0, 10) == 0) setHelmet(Item.get(Item.GOLDEN_HELMET));
-        if (Utils.rand(0, 10) == 0) setChestplate(Item.get(Item.GOLDEN_CHESTPLATE));
-        if (Utils.rand(0, 10) == 0) setLeggings(Item.get(Item.GOLDEN_LEGGINGS));
-        if (Utils.rand(0, 10) == 0) setBoots(Item.get(Item.GOLDEN_BOOTS));
+        if (!isBaby()) {
+            Item weapon = Utils.rand()
+                    ? Item.get(Utils.rand(0, 19) == 0 ? ItemID.GOLDEN_SPEAR : ItemID.GOLDEN_SWORD)
+                    : Item.get(Item.CROSSBOW);
+            setItemInHand(enchantGear(weapon, 0.1f));
+        }
     }
 
     @Override
@@ -214,6 +216,13 @@ public class EntityPiglin extends EntityMob implements EntityWalkable {
     @Override
     public HealthComponent getComponentHealth() {
         return HealthComponent.value(16);
+    }
+
+    @Override
+    protected void equipOnSpawn() {
+        if (rollGearChance(0.15f)) {
+            equipArmorSet(2);
+        }
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityPillager.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityPillager.java
@@ -65,7 +65,7 @@ public class EntityPillager extends EntityIllager implements EntityWalkable {
     protected void initEntity() {
         this.diffHandDamage = new float[]{2.5f, 3f, 4.5f};
         super.initEntity();
-        setItemInHand(Item.get(Item.CROSSBOW));
+        setItemInHand(enchantGear(Item.get(Item.CROSSBOW), 0.1f));
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntitySkeleton.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntitySkeleton.java
@@ -57,8 +57,13 @@ public class EntitySkeleton extends EntityMob implements EntityWalkable, EntityS
     protected void initEntity() {
         super.initEntity();
         if (getItemInHand().isNull()) {
-            setItemInHand(Item.get(ItemID.BOW));
+            setItemInHand(enchantGear(Item.get(ItemID.BOW), 0.1f));
         }
+    }
+
+    @Override
+    protected void equipOnSpawn() {
+        equipArmorSet(3, 3, 0.1087f);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityStray.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityStray.java
@@ -52,8 +52,13 @@ public class EntityStray extends EntityMob implements EntityWalkable, EntitySmit
     protected void initEntity() {
         super.initEntity();
         if (getItemInHand().isNull()) {
-            setItemInHand(Item.get(ItemID.BOW));
+            setItemInHand(enchantGear(Item.get(ItemID.BOW), 0.1f));
         }
+    }
+
+    @Override
+    protected void equipOnSpawn() {
+        equipArmorSet(3, 3, 0.1087f);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityVindicator.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityVindicator.java
@@ -89,7 +89,7 @@ public class EntityVindicator extends EntityIllager implements EntityWalkable {
     protected void initEntity() {
         this.diffHandDamage = new float[]{3.5f, 5f, 7.5f};
         super.initEntity();
-        setItemInHand(Item.get(Item.IRON_AXE));
+        setItemInHand(enchantGear(Item.get(Item.IRON_AXE), 0.25f));
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityZombie.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityZombie.java
@@ -35,6 +35,7 @@ import org.powernukkitx.event.entity.EntityDamageEvent;
 import org.powernukkitx.event.entity.EntityTransformEvent;
 import org.powernukkitx.inventory.EntityInventoryHolder;
 import org.powernukkitx.item.Item;
+import org.powernukkitx.item.ItemID;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
@@ -48,6 +49,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class EntityZombie extends EntityMob implements EntityWalkable, EntitySmite {
     @Override
@@ -117,6 +119,20 @@ public class EntityZombie extends EntityMob implements EntityWalkable, EntitySmi
     @Override
     public HealthComponent getComponentHealth() {
         return HealthComponent.value(20);
+    }
+
+    @Override
+    protected void equipOnSpawn() {
+        if (rollGearChance(0.05f)) {
+            String weapon = switch (ThreadLocalRandom.current().nextInt(6)) {
+                case 0 -> ItemID.IRON_SPEAR;
+                case 1, 2 -> ItemID.IRON_SWORD;
+                default -> ItemID.IRON_SHOVEL;
+            };
+            getEquipmentInventory().setItemInHand(enchantGear(Item.get(weapon), 0.25f));
+        }
+
+        equipArmorSet(3, 3, 0.1087f);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityZombiePigman.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityZombiePigman.java
@@ -28,6 +28,7 @@ import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.event.entity.EntityDamageEvent;
 import org.powernukkitx.item.Item;
+import org.powernukkitx.item.ItemID;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
@@ -92,6 +93,12 @@ public class EntityZombiePigman extends EntityMob implements EntityWalkable, Ent
         this.diffHandDamage = new float[]{2.5f, 3f, 4.5f};
         super.initEntity();
         getMemoryStorage().put(CoreMemoryTypes.LOOKING_BLOCK, BlockTurtleEgg.class);
+    }
+
+    @Override
+    protected void equipOnSpawn() {
+        Item weapon = Item.get(Utils.rand(0, 19) == 0 ? ItemID.GOLDEN_SPEAR : ItemID.GOLDEN_SWORD);
+        getEquipmentInventory().setItemInHand(enchantGear(weapon, 0.25f));
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityZombieVillager.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityZombieVillager.java
@@ -35,4 +35,11 @@ public class EntityZombieVillager extends EntityZombie implements EntityWalkable
         return Set.of("zombie", "zombie_villager", "undead", "monster", "mob");
     }
 
+    /**
+     * A zombie villager spawns empty handed, it keeps nothing from the villager it was.
+     */
+    @Override
+    protected void equipOnSpawn() {
+    }
+
 }

--- a/src/main/java/org/powernukkitx/entity/mob/EntityZombieVillagerV2.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityZombieVillagerV2.java
@@ -95,6 +95,13 @@ public class EntityZombieVillagerV2 extends EntityZombie implements EntityWalkab
         return HealthComponent.value(20);
     }
 
+    /**
+     * A zombie villager spawns empty handed, it keeps nothing from the villager it was.
+     */
+    @Override
+    protected void equipOnSpawn() {
+    }
+
     @Override
     protected @Nullable MovementComponent getComponentMovement() {
         float ageMovement = this.isBaby() ? 0.35f : 0.23f;

--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -194,6 +194,7 @@ public class Level implements Metadatable {
     private static final double INV_CHUNK_SIZE = 1.0d / CHUNK_SIZE;
     // endregion finals - number finals
 
+    private static final float[] MOON_BRIGHTNESS_PER_PHASE = {1f, 0.75f, 0.5f, 0.25f, 0f, 0.25f, 0.5f, 0.75f};
     private static final Set<String> randomTickBlocks = new HashSet<>(64);  // The blocks that can randomly tick
     private static final ThreadLocal<Entity[]> ENTITY_BUFFER = ThreadLocal.withInitial(() -> new Entity[512]);
 
@@ -2888,6 +2889,34 @@ public class Level implements Metadatable {
 
     public int getMoonPhase(long worldTime) {
         return (int) (worldTime / 24000 % 8 + 8) % 8;
+    }
+
+    /**
+     * Returns how much harder this level currently is than the bare minimum, from 0 to 1. Loot
+     * tables scale their chances with it, so a mob spawning with a weapon or a piece of armour is
+     * more likely on a hard difficulty and impossible on peaceful and easy.
+     *
+     * @return the regional difficulty of this level, between 0 and 1
+     */
+    public float getSpecialMultiplier() {
+        int difficulty = this.server.getDifficulty();
+        if (difficulty == 0) {
+            return 0f;
+        }
+
+        float timeFactor = Math.min(Math.max(getTime() - 0.5f, 0f) * 0.25f, 0.25f);
+        float moonFactor = Math.min(MOON_BRIGHTNESS_PER_PHASE[getMoonPhase(getTime())] * 0.25f, timeFactor);
+
+        float bonus = moonFactor + (difficulty == 3 ? 0.5f : 0.375f);
+        if (difficulty == 1) {
+            bonus *= 0.5f;
+        }
+
+        float total = (timeFactor + 0.75f + bonus) * difficulty;
+        if (total < 2f) {
+            return 0f;
+        }
+        return total <= 4f ? (total - 2f) * 0.5f : 1f;
     }
 
     public int getBlockRuntimeId(int x, int y, int z) {


### PR DESCRIPTION
## What does this PR do?

It gives mobs the weapons and armour they are supposed to spawn with. A zombie can now
spawn with an iron shovel and a piece of armour, a skeleton with an enchanted bow, a
zombified piglin with a golden sword, and so on. How likely and how good that gear is
follows the regional difficulty, so a mob spawns bare on peaceful and easy and fully
geared on hard.

This adds three things to `EntityMob`, shared by every mob that has an equipment table:

- an `equipOnSpawn()` hook, called only when the mob is spawning. A mob loaded back from
  disk always carries its own equipment tags, so it never runs for it.
- `rollGearChance(maxChance)`, the chance an equipment pool is rolled at all.
- `equipArmorSet(...)`, which picks a material between leather and diamond, always gives
  a helmet, then thins out from the chestplate down, and enchants each piece.

`Level` gains `getSpecialMultiplier()`, the regional difficulty of the level, between 0
and 1. It is what every equipment chance is scaled by. It comes out at 0 on peaceful and
easy, 0.375 to 0.625 on normal depending on the moon phase, and 1 on hard.

## Why?

To match vanilla. A mob that spawns bare handed on hard is a noticeable difference, and
the piglin's armour was rolled with values that appear in no table.

Sources: the equipment tables shipped with the game
([zombie_equipment](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/loot_tables/entities/zombie_equipment.json),
`skeleton_gear.json`, `piglin_gear_melee.json`, `zombie_pigman_gear.json`,
`vindicator_gear.json`, `pillager_gear.json` and the six `armor_set_*.json`), the
[entity files](https://github.com/Mojang/bedrock-samples/tree/main/behavior_pack/entities)
that attach them, and the [loot table reference](https://wiki.bedrock.dev/loot/loot-tables)
for how the `tiers` field picks a material.

## Type of change

- [ ] Bug Fix
- [x] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 96a30f322
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
