### PR TITLE
fix: send empty container slots as clean ItemData.AIR

### DIFF
--- a/src/main/java/org/powernukkitx/inventory/BaseInventory.java
+++ b/src/main/java/org/powernukkitx/inventory/BaseInventory.java
@@ -21,6 +21,7 @@ import org.cloudburstmc.protocol.bedrock.data.actor.ActorFlags;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerEnumName;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ContainerType;
 import org.cloudburstmc.protocol.bedrock.data.inventory.FullContainerName;
+import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.bedrock.packet.InventoryContentPacket;
 import org.cloudburstmc.protocol.bedrock.packet.InventorySlotPacket;
 import org.jetbrains.annotations.ApiStatus;
@@ -541,7 +542,8 @@ public abstract class BaseInventory implements Inventory {
         InventoryContentPacket pk = new InventoryContentPacket();
 
         for (int i = 0; i < this.getSize(); i++) {
-            pk.getSlots().add(this.getUnclonedItem(i).toNetwork());
+            Item item = this.getUnclonedItem(i);
+            pk.getSlots().add(item.isNull() ? ItemData.AIR : item.toNetwork());
         }
 
         for (Player player : players) {
@@ -630,7 +632,8 @@ public abstract class BaseInventory implements Inventory {
         InventorySlotPacket pk = new InventorySlotPacket();
         int slot = toNetworkSlot(index);
         pk.setSlot(slot);
-        pk.setItem(this.getUnclonedItem(index).toNetwork());
+        Item slotItem = this.getUnclonedItem(index);
+        pk.setItem(slotItem.isNull() ? ItemData.AIR : slotItem.toNetwork());
 
         for (Player player : players) {
             int id = player.getWindowId(this);


### PR DESCRIPTION
## What does this PR do?

fixes the right-click “drag-and-distribute” function (1 item per slot) in chests, hoppers, and other containers

## Why?

empty container slots were sent via Item.toNetwork(), which serializes air as a malformed unknown item, the fix sends ItemData.AIR for empty slots in BaseInventory, just as HumanInventory already does for the player's inventory

## Type of change

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 27d554f57
- **Bedrock client version:** 26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. drag and right click on slots chests before fix it just work for one slot and after its fix match vanilla

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|       |             |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
