### PR TITLE
fix: snapshot actor data before sending to avoid ConcurrentModificationException

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -1515,7 +1515,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
           mode update packet.
          */
         this.setGamemode(this.gamemode, false, null, true);
-        this.sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), actorDataMap);
+        this.sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), null);
         this.sendAttributes();
         this.spawnToAll();
         Arrays.stream(this.level.getEntities()).filter(entity -> entity.getViewers().containsKey(this.getLoaderId()) && entity instanceof EntityBoss).forEach(entity -> ((EntityBoss) entity).addBossbar(this));

--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -1515,7 +1515,7 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
           mode update packet.
          */
         this.setGamemode(this.gamemode, false, null, true);
-        this.sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), null);
+        this.sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY));
         this.sendAttributes();
         this.spawnToAll();
         Arrays.stream(this.level.getEntities()).filter(entity -> entity.getViewers().containsKey(this.getLoaderId()) && entity instanceof EntityBoss).forEach(entity -> ((EntityBoss) entity).addBossbar(this));

--- a/src/main/java/org/powernukkitx/entity/Entity.java
+++ b/src/main/java/org/powernukkitx/entity/Entity.java
@@ -624,17 +624,19 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         // =========================================================
         // Initialize entity data defaults first
         // =========================================================
-        this.actorDataMap.getOrCreateFlags();
-        this.actorDataMap.put(AIR_SUPPLY, nbtMap.getShort("Air"));
-        this.actorDataMap.put(ActorDataTypes.AIR_SUPPLY_MAX, (short) 400);
-        this.actorDataMap.put(ActorDataTypes.NAME, "");
-        this.actorDataMap.put(ActorDataTypes.LEASH_HOLDER, -1L);
-        this.actorDataMap.put(ActorDataTypes.SCALE, 1f);
-        this.actorDataMap.put(ActorDataTypes.HEIGHT, this.getHeight());
-        this.actorDataMap.put(ActorDataTypes.WIDTH, this.getWidth());
-        this.actorDataMap.put(ActorDataTypes.STRUCTURAL_INTEGRITY, (int) this.getHealthCurrent());
-        this.actorDataMap.put(ActorDataTypes.RESERVED_139, 0L);
-        this.actorDataMap.put(ActorDataTypes.NAMEPLATE_RENDER_DISTANCE_MAX, 64.0f);
+        synchronized (this.actorDataMap) {
+            this.actorDataMap.getOrCreateFlags();
+            this.actorDataMap.put(AIR_SUPPLY, nbtMap.getShort("Air"));
+            this.actorDataMap.put(ActorDataTypes.AIR_SUPPLY_MAX, (short) 400);
+            this.actorDataMap.put(ActorDataTypes.NAME, "");
+            this.actorDataMap.put(ActorDataTypes.LEASH_HOLDER, -1L);
+            this.actorDataMap.put(ActorDataTypes.SCALE, 1f);
+            this.actorDataMap.put(ActorDataTypes.HEIGHT, this.getHeight());
+            this.actorDataMap.put(ActorDataTypes.WIDTH, this.getWidth());
+            this.actorDataMap.put(ActorDataTypes.STRUCTURAL_INTEGRITY, (int) this.getHealthCurrent());
+            this.actorDataMap.put(ActorDataTypes.RESERVED_139, 0L);
+            this.actorDataMap.put(ActorDataTypes.NAMEPLATE_RENDER_DISTANCE_MAX, 64.0f);
+        }
 
         // =========================================================
         // Load Effects from NBT
@@ -686,7 +688,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         // =========================================================
         // Send initial data + default flags
         // =========================================================
-        this.sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), actorDataMap);
+        this.sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), null);
         if (this.isFireImmune()) {
             this.setFireImmune(true);
         }
@@ -855,18 +857,22 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
     }
 
     public void setSneaking(boolean value) {
-        boolean changed = this.getActorDataMap().getOrCreateFlags().contains(ActorFlags.SNEAKING) ^ value;
-
-        if (changed) {
-            this.getActorDataMap().setFlag(ActorFlags.SNEAKING, value);
+        boolean changed;
+        synchronized (this.actorDataMap) {
+            changed = this.actorDataMap.getOrCreateFlags().contains(ActorFlags.SNEAKING) ^ value;
+            if (changed) {
+                this.actorDataMap.setFlag(ActorFlags.SNEAKING, value);
+            }
         }
 
         recalculateBoundingBox(false);
-        float newHeight = (float) this.getActorDataMap().getOrDefault(ActorDataTypes.HEIGHT, getCurrentHeight());
+        float newHeight = (float) this.getDataProperty(ActorDataTypes.HEIGHT, getCurrentHeight());
 
         if (changed) {
             ActorDataMap delta = new ActorDataMap();
-            delta.put(ActorDataTypes.FLAGS, this.getActorDataMap().getFlags());
+            synchronized (this.actorDataMap) {
+                delta.put(ActorDataTypes.FLAGS, this.actorDataMap.getFlags());
+            }
             delta.putType(ActorDataTypes.HEIGHT, newHeight);
             sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), delta);
         } else {
@@ -1081,13 +1087,15 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         );
 
         boolean change = false;
-        if (!this.getActorDataMap().containsKey(ActorDataTypes.HEIGHT) || this.getActorDataMap().get(ActorDataTypes.HEIGHT) != entityHeight) {
-            change = true;
-            this.getActorDataMap().put(ActorDataTypes.HEIGHT, entityHeight);
-        }
-        if (!this.getActorDataMap().containsKey(ActorDataTypes.WIDTH) || this.getActorDataMap().get(ActorDataTypes.WIDTH) != this.getWidth()) {
-            change = true;
-            this.getActorDataMap().put(ActorDataTypes.WIDTH, this.getWidth());
+        synchronized (this.actorDataMap) {
+            if (!this.actorDataMap.containsKey(ActorDataTypes.HEIGHT) || this.actorDataMap.get(ActorDataTypes.HEIGHT) != entityHeight) {
+                change = true;
+                this.actorDataMap.put(ActorDataTypes.HEIGHT, entityHeight);
+            }
+            if (!this.actorDataMap.containsKey(ActorDataTypes.WIDTH) || this.actorDataMap.get(ActorDataTypes.WIDTH) != this.getWidth()) {
+                change = true;
+                this.actorDataMap.put(ActorDataTypes.WIDTH, this.getWidth());
+            }
         }
         if (send && change) {
             sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), this.copyEntityData(ActorDataTypes.WIDTH, ActorDataTypes.HEIGHT));
@@ -1096,9 +1104,11 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
 
     private ActorDataMap copyEntityData(ActorDataType<?>... types) {
         final ActorDataMap map = new ActorDataMap();
-        for (ActorDataType<?> type : types) {
-            if (this.actorDataMap.containsKey(type)) {
-                map.put(type, this.actorDataMap.get(type));
+        synchronized (this.actorDataMap) {
+            for (ActorDataType<?> type : types) {
+                if (this.actorDataMap.containsKey(type)) {
+                    map.put(type, this.actorDataMap.get(type));
+                }
             }
         }
         return map;
@@ -1390,7 +1400,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         this.sendData(player, null);
     }
 
-    private ActorDataMap snapshotActorData() {
+    protected ActorDataMap snapshotActorData() {
         final ActorDataMap copy = new ActorDataMap();
         synchronized (this.actorDataMap) {
             copy.putAll(this.actorDataMap);
@@ -2921,32 +2931,34 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
     protected ActorDataMap getSeatDataMap() {
         ActorDataMap data = new ActorDataMap();
 
-        if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_OFFSET)) {
-            data.put(ActorDataTypes.SEAT_OFFSET, this.actorDataMap.get(ActorDataTypes.SEAT_OFFSET));
-        }
+        synchronized (this.actorDataMap) {
+            if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_OFFSET)) {
+                data.put(ActorDataTypes.SEAT_OFFSET, this.actorDataMap.get(ActorDataTypes.SEAT_OFFSET));
+            }
 
-        if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_THIRD_PERSON_CAMERA_RADIUS)) {
-            data.put(ActorDataTypes.SEAT_THIRD_PERSON_CAMERA_RADIUS, this.actorDataMap.get(ActorDataTypes.SEAT_THIRD_PERSON_CAMERA_RADIUS));
-        }
+            if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_THIRD_PERSON_CAMERA_RADIUS)) {
+                data.put(ActorDataTypes.SEAT_THIRD_PERSON_CAMERA_RADIUS, this.actorDataMap.get(ActorDataTypes.SEAT_THIRD_PERSON_CAMERA_RADIUS));
+            }
 
-        if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_CAMERA_RELAX_DISTANCE_SMOOTHING)) {
-            data.put(ActorDataTypes.SEAT_CAMERA_RELAX_DISTANCE_SMOOTHING, this.actorDataMap.get(ActorDataTypes.SEAT_CAMERA_RELAX_DISTANCE_SMOOTHING));
-        }
+            if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_CAMERA_RELAX_DISTANCE_SMOOTHING)) {
+                data.put(ActorDataTypes.SEAT_CAMERA_RELAX_DISTANCE_SMOOTHING, this.actorDataMap.get(ActorDataTypes.SEAT_CAMERA_RELAX_DISTANCE_SMOOTHING));
+            }
 
-        if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION)) {
-            data.put(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION, this.actorDataMap.get(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION));
-        }
+            if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION)) {
+                data.put(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION, this.actorDataMap.get(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION));
+            }
 
-        if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION_DEGREES)) {
-            data.put(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION_DEGREES, this.actorDataMap.get(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION_DEGREES));
-        }
+            if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION_DEGREES)) {
+                data.put(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION_DEGREES, this.actorDataMap.get(ActorDataTypes.SEAT_LOCK_PASSENGER_ROTATION_DEGREES));
+            }
 
-        if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_ROTATION_OFFSET)) {
-            data.put(ActorDataTypes.SEAT_ROTATION_OFFSET, this.actorDataMap.get(ActorDataTypes.SEAT_ROTATION_OFFSET));
-        }
+            if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_ROTATION_OFFSET)) {
+                data.put(ActorDataTypes.SEAT_ROTATION_OFFSET, this.actorDataMap.get(ActorDataTypes.SEAT_ROTATION_OFFSET));
+            }
 
-        if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_ROTATION_OFFSET_DEGREES)) {
-            data.put(ActorDataTypes.SEAT_ROTATION_OFFSET_DEGREES, this.actorDataMap.get(ActorDataTypes.SEAT_ROTATION_OFFSET_DEGREES));
+            if (this.actorDataMap.containsKey(ActorDataTypes.SEAT_ROTATION_OFFSET_DEGREES)) {
+                data.put(ActorDataTypes.SEAT_ROTATION_OFFSET_DEGREES, this.actorDataMap.get(ActorDataTypes.SEAT_ROTATION_OFFSET_DEGREES));
+            }
         }
 
         return data;
@@ -4446,7 +4458,9 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         if (!hasJumpStrength()) return;
 
         this.setDataFlag(ActorFlags.CAN_POWER_JUMP, true);
-        this.actorDataMap.put(ActorDataTypes.CHARGE_AMOUNT, (byte) 0);
+        synchronized (this.actorDataMap) {
+            this.actorDataMap.put(ActorDataTypes.CHARGE_AMOUNT, (byte) 0);
+        }
     }
 
     public boolean hasGroundInputControlsMeta() {
@@ -5890,14 +5904,16 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
 
     public void setDataProperties(Map<ActorDataType<?>, Object> maps, boolean send) {
         ActorDataMap sendMap = new ActorDataMap();
-        for (var e : maps.entrySet()) {
-            ActorDataType<?> key = e.getKey();
-            Object value = e.getValue();
-            if (this.getActorDataMap().containsKey(key) && this.getActorDataMap().get(key).equals(value)) {
-                continue;
+        synchronized (this.actorDataMap) {
+            for (var e : maps.entrySet()) {
+                ActorDataType<?> key = e.getKey();
+                Object value = e.getValue();
+                if (this.actorDataMap.containsKey(key) && this.actorDataMap.get(key).equals(value)) {
+                    continue;
+                }
+                this.actorDataMap.put(key, value);
+                sendMap.put(key, value);
             }
-            this.getActorDataMap().put(key, value);
-            sendMap.put(key, value);
         }
         if (send) {
             this.sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), sendMap);
@@ -5909,11 +5925,12 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
     }
 
     public boolean setDataProperty(ActorDataType<?> key, Object value, boolean send) {
-        if (this.getActorDataMap().containsKey(key) && this.getActorDataMap().get(key).equals(value)) {
-            return false;
+        synchronized (this.actorDataMap) {
+            if (this.actorDataMap.containsKey(key) && this.actorDataMap.get(key).equals(value)) {
+                return false;
+            }
+            this.actorDataMap.put(key, value);
         }
-
-        this.getActorDataMap().put(key, value);
         if (send) {
             ActorDataMap map = new ActorDataMap();
             map.put(key, value);
@@ -5928,12 +5945,16 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
 
     @Nullable
     public <T> T getDataProperty(ActorDataType<T> key) {
-        return !this.getActorDataMap().containsKey(key) ? null : this.getActorDataMap().get(key);
+        synchronized (this.actorDataMap) {
+            return !this.actorDataMap.containsKey(key) ? null : this.actorDataMap.get(key);
+        }
     }
 
     @NotNull
     public <T> T getDataProperty(ActorDataType<T> key, T d) {
-        return (T) this.getActorDataMap().getOrDefault(key, d);
+        synchronized (this.actorDataMap) {
+            return (T) this.actorDataMap.getOrDefault(key, d);
+        }
     }
 
     public void setDataFlag(ActorFlags entityFlag) {
@@ -5945,11 +5966,15 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
     }
 
     public void setDataFlag(ActorFlags entityFlag, boolean value, boolean send) {
-        if (this.getActorDataMap().getOrCreateFlags().contains(entityFlag) ^ value) {
-            this.getActorDataMap().setFlag(entityFlag, value);
-            if (send) {
-                sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), this.getActorDataMap());
+        boolean changed;
+        synchronized (this.actorDataMap) {
+            changed = this.actorDataMap.getOrCreateFlags().contains(entityFlag) ^ value;
+            if (changed) {
+                this.actorDataMap.setFlag(entityFlag, value);
             }
+        }
+        if (changed && send) {
+            sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), null);
         }
     }
 
@@ -5963,8 +5988,10 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
      * @param entityFlags the complete set of flags the entity should have
      */
     public void setDataFlags(EnumSet<ActorFlags> entityFlags) {
-        this.getActorDataMap().putFlags(entityFlags);
-        sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), this.getActorDataMap());
+        synchronized (this.actorDataMap) {
+            this.actorDataMap.putFlags(entityFlags);
+        }
+        sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), null);
     }
 
     /**
@@ -5973,12 +6000,16 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
      * @param entityFlags the flags to enable
      */
     public void addDataFlags(EnumSet<ActorFlags> entityFlags) {
-        this.getActorDataMap().getOrCreateFlags().addAll(entityFlags);
-        sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), this.getActorDataMap());
+        synchronized (this.actorDataMap) {
+            this.actorDataMap.getOrCreateFlags().addAll(entityFlags);
+        }
+        sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), null);
     }
 
     public boolean getDataFlag(ActorFlags id) {
-        return this.getActorDataMap().getOrCreateFlags().contains(id);
+        synchronized (this.actorDataMap) {
+            return this.actorDataMap.getOrCreateFlags().contains(id);
+        }
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/Entity.java
+++ b/src/main/java/org/powernukkitx/entity/Entity.java
@@ -1338,7 +1338,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
             }
         }
 
-        addActorPacket.setActorData(this.actorDataMap);
+        addActorPacket.setActorData(this.snapshotActorData());
 
         int controlSeat = getControllingSeatIndex();
         for (int i = 0; i < this.passengers.size(); i++) {
@@ -1390,9 +1390,17 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         this.sendData(player, null);
     }
 
+    private ActorDataMap snapshotActorData() {
+        final ActorDataMap copy = new ActorDataMap();
+        synchronized (this.actorDataMap) {
+            copy.putAll(this.actorDataMap);
+        }
+        return copy;
+    }
+
     public void sendData(Player player, ActorDataMap data) {
         final SetActorDataPacket packet = new SetActorDataPacket();
-        packet.setActorData(data == null ? this.actorDataMap : data);
+        packet.setActorData(data == null ? this.snapshotActorData() : data);
         packet.setTargetRuntimeID(this.runtimeId());
         PropertySyncData syncData = this.propertySyncData();
         packet.getSyncedProperties().getFloatProperties().addAll(syncData.getFloatProperties());
@@ -1407,7 +1415,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
 
     public void sendData(Player[] players, ActorDataMap data) {
         final SetActorDataPacket packet = new SetActorDataPacket();
-        packet.setActorData(data == null ? this.actorDataMap : data);
+        packet.setActorData(data == null ? this.snapshotActorData() : data);
         packet.setTargetRuntimeID(this.runtimeId());
         PropertySyncData syncData = this.propertySyncData();
         packet.getSyncedProperties().getFloatProperties().addAll(syncData.getFloatProperties());

--- a/src/main/java/org/powernukkitx/entity/Entity.java
+++ b/src/main/java/org/powernukkitx/entity/Entity.java
@@ -688,7 +688,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         // =========================================================
         // Send initial data + default flags
         // =========================================================
-        this.sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), null);
+        this.sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY));
         if (this.isFireImmune()) {
             this.setFireImmune(true);
         }
@@ -1400,6 +1400,10 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         this.sendData(player, null);
     }
 
+    /**
+     * Returns a copy of this entity's actor data, taken under the map lock so a packet can serialize it
+     * on another thread without risking a {@link java.util.ConcurrentModificationException}.
+     */
     protected ActorDataMap snapshotActorData() {
         final ActorDataMap copy = new ActorDataMap();
         synchronized (this.actorDataMap) {
@@ -1408,6 +1412,9 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         return copy;
     }
 
+    /**
+     * @param data the data to send or {@code null} to send a snapshot of the whole actor data map
+     */
     public void sendData(Player player, ActorDataMap data) {
         final SetActorDataPacket packet = new SetActorDataPacket();
         packet.setActorData(data == null ? this.snapshotActorData() : data);
@@ -1423,6 +1430,9 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         this.sendData(players, null);
     }
 
+    /**
+     * @param data the data to send or {@code null} to send a snapshot of the whole actor data map
+     */
     public void sendData(Player[] players, ActorDataMap data) {
         final SetActorDataPacket packet = new SetActorDataPacket();
         packet.setActorData(data == null ? this.snapshotActorData() : data);
@@ -5974,7 +5984,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
             }
         }
         if (changed && send) {
-            sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), null);
+            sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY));
         }
     }
 
@@ -5991,7 +6001,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         synchronized (this.actorDataMap) {
             this.actorDataMap.putFlags(entityFlags);
         }
-        sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), null);
+        sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY));
     }
 
     /**
@@ -6003,7 +6013,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID {
         synchronized (this.actorDataMap) {
             this.actorDataMap.getOrCreateFlags().addAll(entityFlags);
         }
-        sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), null);
+        sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY));
     }
 
     public boolean getDataFlag(ActorFlags id) {

--- a/src/main/java/org/powernukkitx/entity/EntityFakeInventory.java
+++ b/src/main/java/org/powernukkitx/entity/EntityFakeInventory.java
@@ -64,9 +64,11 @@ public class EntityFakeInventory extends Entity implements InventoryHolder {
             this.setNameTag(this.displayName);
         }
 
-        this.actorDataMap.put(ActorDataTypes.CONTAINER_TYPE, (byte) ContainerType.CONTAINER.getId());
-        this.actorDataMap.put(ActorDataTypes.CONTAINER_SIZE, this.containerSize);
-        this.actorDataMap.put(ActorDataTypes.CONTAINER_STRENGTH_MODIFIER, 0);
+        synchronized (this.actorDataMap) {
+            this.actorDataMap.put(ActorDataTypes.CONTAINER_TYPE, (byte) ContainerType.CONTAINER.getId());
+            this.actorDataMap.put(ActorDataTypes.CONTAINER_SIZE, this.containerSize);
+            this.actorDataMap.put(ActorDataTypes.CONTAINER_STRENGTH_MODIFIER, 0);
+        }
     }
 
     public int getContainerSize() {

--- a/src/main/java/org/powernukkitx/entity/EntityHuman.java
+++ b/src/main/java/org/powernukkitx/entity/EntityHuman.java
@@ -244,11 +244,13 @@ public class EntityHuman extends EntityHumanType {
             else
                 this.server.updatePlayerListData(this.getUniqueId(), this.getId(), this.getName(), this.skin, Color.WHITE, new Player[]{player});
 
-            this.actorDataMap.put(RESERVED_139, 0L);
-            this.actorDataMap.put(NAMEPLATE_RENDER_DISTANCE_MAX,  64.0f);
+            synchronized (this.actorDataMap) {
+                this.actorDataMap.put(RESERVED_139, 0L);
+                this.actorDataMap.put(NAMEPLATE_RENDER_DISTANCE_MAX,  64.0f);
+            }
 
             final AddPlayerPacket addPlayerPacket = new AddPlayerPacket();
-            addPlayerPacket.setActorData(this.actorDataMap);
+            addPlayerPacket.setActorData(this.snapshotActorData());
             addPlayerPacket.setUuid(this.getUniqueId());
             addPlayerPacket.setPlayerName(this.getName());
             addPlayerPacket.setTargetActorID(this.getId());

--- a/src/main/java/org/powernukkitx/entity/EntityLiving.java
+++ b/src/main/java/org/powernukkitx/entity/EntityLiving.java
@@ -962,7 +962,7 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
 
         this.setDataFlags(ext);
 
-        sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), this.actorDataMap);
+        sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), null);
     }
 
     private void tickShieldBlockingState(int tickDiff) {

--- a/src/main/java/org/powernukkitx/entity/EntityLiving.java
+++ b/src/main/java/org/powernukkitx/entity/EntityLiving.java
@@ -962,7 +962,7 @@ public abstract class EntityLiving extends Entity implements EntityDamageable {
 
         this.setDataFlags(ext);
 
-        sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY), null);
+        sendData(this.hasSpawned.values().toArray(Player.EMPTY_ARRAY));
     }
 
     private void tickShieldBlockingState(int tickDiff) {

--- a/src/main/java/org/powernukkitx/entity/item/EntityArmorStand.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityArmorStand.java
@@ -110,8 +110,10 @@ public class EntityArmorStand extends Entity implements EntityInventoryHolder, E
 
         this.equipmentInventory = new EntityEquipmentInventory(this);
         this.armorInventory = new EntityArmorInventory(this);
-        this.actorDataMap.putIfAbsent(ActorDataTypes.HURT, 0);
-        this.actorDataMap.putIfAbsent(ActorDataTypes.POSE_INDEX, 0);
+        synchronized (this.actorDataMap) {
+            this.actorDataMap.putIfAbsent(ActorDataTypes.HURT, 0);
+            this.actorDataMap.putIfAbsent(ActorDataTypes.POSE_INDEX, 0);
+        }
 
         final CompoundTag nbtMap = this.getNbt();
         if (nbtMap.contains(TAG_MAINHAND)) {
@@ -311,7 +313,10 @@ public class EntityArmorStand extends Entity implements EntityInventoryHolder, E
     }
 
     private int getPose() {
-        Integer pose = this.actorDataMap.get(ActorDataTypes.POSE_INDEX);
+        Integer pose;
+        synchronized (this.actorDataMap) {
+            pose = this.actorDataMap.get(ActorDataTypes.POSE_INDEX);
+        }
         return pose == null ? 0 : pose;
     }
 
@@ -321,10 +326,12 @@ public class EntityArmorStand extends Entity implements EntityInventoryHolder, E
     }
 
     private void setPose(int pose) {
-        this.actorDataMap.put(ActorDataTypes.POSE_INDEX, pose);
+        synchronized (this.actorDataMap) {
+            this.actorDataMap.put(ActorDataTypes.POSE_INDEX, pose);
+        }
         final SetActorDataPacket packet = new SetActorDataPacket();
         packet.setTargetRuntimeID(this.runtimeId());
-        packet.setActorData(this.getActorDataMap());
+        packet.setActorData(this.snapshotActorData());
         Server.getInstance().getOnlinePlayers().values().forEach(all -> all.sendPacket(packet));
     }
 

--- a/src/main/java/org/powernukkitx/entity/item/EntityBoat.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityBoat.java
@@ -89,21 +89,23 @@ public class EntityBoat extends EntityVehicle {
 
         this.setDataFlag(ActorFlags.HAS_GRAVITY);
         this.setDataFlag(ActorFlags.STACKABLE);
-        this.actorDataMap.put(ActorDataTypes.VARIANT, woodID);
-        this.actorDataMap.put(ActorDataTypes.STRUCTURAL_INTEGRITY, 40);
-        this.actorDataMap.put(ActorDataTypes.IS_BUOYANT, true);
-        this.actorDataMap.put(ActorDataTypes.BUOYANCY_DATA, "{\"apply_gravity\":true,\"base_buoyancy\":1.0,\"big_wave_probability\":0.02999999932944775,\"big_wave_speed\":10.0,\"can_auto_step_from_liquid\":false,\"drag_down_on_buoyancy_removed\":0.0,\"liquid_blocks\":[\"minecraft:water\",\"minecraft:flowing_water\"],\"movement_type\":\"waves\"}");
-        this.actorDataMap.put(ActorDataTypes.AIR_SUPPLY, (short) 300);
-        this.actorDataMap.put(ActorDataTypes.OWNER, -1L);
-        this.actorDataMap.put(ActorDataTypes.ROW_TIME_LEFT, 0f);
-        this.actorDataMap.put(ActorDataTypes.ROW_TIME_RIGHT, 0f);
-        this.actorDataMap.put(ActorDataTypes.CONTROLLING_RIDER_SEAT_INDEX, (byte) 0);
-        this.actorDataMap.put(ActorDataTypes.DATA_LIFETIME_TICKS, -1);
-        this.actorDataMap.put(ActorDataTypes.NAMETAG_ALWAYS_SHOW, (byte) -1);
-        this.actorDataMap.put(ActorDataTypes.AMBIENT_SOUND_INTERVAL, 8F);
-        this.actorDataMap.put(ActorDataTypes.AMBIENT_SOUND_INTERVAL_RANGE, 16F);
-        this.actorDataMap.put(ActorDataTypes.AMBIENT_SOUND_EVENT_NAME, "ambient");
-        this.actorDataMap.put(ActorDataTypes.FALL_DAMAGE_MULTIPLIER, 1F);
+        synchronized (this.actorDataMap) {
+            this.actorDataMap.put(ActorDataTypes.VARIANT, woodID);
+            this.actorDataMap.put(ActorDataTypes.STRUCTURAL_INTEGRITY, 40);
+            this.actorDataMap.put(ActorDataTypes.IS_BUOYANT, true);
+            this.actorDataMap.put(ActorDataTypes.BUOYANCY_DATA, "{\"apply_gravity\":true,\"base_buoyancy\":1.0,\"big_wave_probability\":0.02999999932944775,\"big_wave_speed\":10.0,\"can_auto_step_from_liquid\":false,\"drag_down_on_buoyancy_removed\":0.0,\"liquid_blocks\":[\"minecraft:water\",\"minecraft:flowing_water\"],\"movement_type\":\"waves\"}");
+            this.actorDataMap.put(ActorDataTypes.AIR_SUPPLY, (short) 300);
+            this.actorDataMap.put(ActorDataTypes.OWNER, -1L);
+            this.actorDataMap.put(ActorDataTypes.ROW_TIME_LEFT, 0f);
+            this.actorDataMap.put(ActorDataTypes.ROW_TIME_RIGHT, 0f);
+            this.actorDataMap.put(ActorDataTypes.CONTROLLING_RIDER_SEAT_INDEX, (byte) 0);
+            this.actorDataMap.put(ActorDataTypes.DATA_LIFETIME_TICKS, -1);
+            this.actorDataMap.put(ActorDataTypes.NAMETAG_ALWAYS_SHOW, (byte) -1);
+            this.actorDataMap.put(ActorDataTypes.AMBIENT_SOUND_INTERVAL, 8F);
+            this.actorDataMap.put(ActorDataTypes.AMBIENT_SOUND_INTERVAL_RANGE, 16F);
+            this.actorDataMap.put(ActorDataTypes.AMBIENT_SOUND_EVENT_NAME, "ambient");
+            this.actorDataMap.put(ActorDataTypes.FALL_DAMAGE_MULTIPLIER, 1F);
+        }
         setDataFlag(ActorFlags.COLLIDABLE);
         entityCollisionReduction = -0.5;
         this.lastX = this.x;
@@ -156,7 +158,7 @@ public class EntityBoat extends EntityVehicle {
         packet.setPosition(org.cloudburstmc.math.vector.Vector3f.from(this.x, this.y + this.getBaseOffset(), this.z));
         packet.setVelocity(org.cloudburstmc.math.vector.Vector3f.from(this.motionX, this.motionY, this.motionZ));
         packet.setRotation(Vector2f.from(this.pitch, this.yaw));
-        packet.setActorData(this.actorDataMap);
+        packet.setActorData(this.snapshotActorData());
 
         for (int i = 0; i < this.passengers.size(); i++) {
             packet.getActorLinks().add(
@@ -482,7 +484,9 @@ public class EntityBoat extends EntityVehicle {
 
     public void setVariant(int variant) {
         this.woodID = variant;
-        this.actorDataMap.put(ActorDataTypes.VARIANT, variant);
+        synchronized (this.actorDataMap) {
+            this.actorDataMap.put(ActorDataTypes.VARIANT, variant);
+        }
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/item/EntityChestBoat.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityChestBoat.java
@@ -81,7 +81,7 @@ public class EntityChestBoat extends EntityBoat implements InventoryHolder {
         packet.setPosition(Vector3f.from(this.x, this.y + this.getBaseOffset(), this.z));
         packet.setVelocity(Vector3f.from(this.motionX, this.motionY, this.motionZ));
         packet.setRotation(Vector2f.from(this.pitch, this.yaw));
-        packet.setActorData(this.actorDataMap);
+        packet.setActorData(this.snapshotActorData());
 
         for (int i = 0; i < this.passengers.size(); i++) {
             packet.getActorLinks().add(
@@ -120,9 +120,11 @@ public class EntityChestBoat extends EntityBoat implements InventoryHolder {
             }
         }
 
-        this.actorDataMap.put(ActorDataTypes.CONTAINER_TYPE, (byte) ContainerType.CHEST_BOAT.ordinal());
-        actorDataMap.put(ActorDataTypes.CONTAINER_SIZE, this.inventory.getSize());
-        actorDataMap.put(ActorDataTypes.CONTAINER_STRENGTH_MODIFIER, 0);
+        synchronized (this.actorDataMap) {
+            this.actorDataMap.put(ActorDataTypes.CONTAINER_TYPE, (byte) ContainerType.CHEST_BOAT.ordinal());
+            this.actorDataMap.put(ActorDataTypes.CONTAINER_SIZE, this.inventory.getSize());
+            this.actorDataMap.put(ActorDataTypes.CONTAINER_STRENGTH_MODIFIER, 0);
+        }
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/item/EntityChestMinecart.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityChestMinecart.java
@@ -104,9 +104,11 @@ public class EntityChestMinecart extends EntityMinecartAbstract implements Inven
             }
         }
 
-        this.actorDataMap.put(ActorDataTypes.CONTAINER_TYPE, (byte) 10);
-        actorDataMap.put(ActorDataTypes.CONTAINER_SIZE, this.inventory.getSize());
-        actorDataMap.put(ActorDataTypes.CONTAINER_STRENGTH_MODIFIER, 0);
+        synchronized (this.actorDataMap) {
+            this.actorDataMap.put(ActorDataTypes.CONTAINER_TYPE, (byte) 10);
+            this.actorDataMap.put(ActorDataTypes.CONTAINER_SIZE, this.inventory.getSize());
+            this.actorDataMap.put(ActorDataTypes.CONTAINER_STRENGTH_MODIFIER, 0);
+        }
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/item/EntityFishingHook.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityFishingHook.java
@@ -295,8 +295,10 @@ public class EntityFishingHook extends SlenderProjectile {
         if (this.shootingEntity != null) {
             ownerId = this.shootingEntity.getId();
         }
-        this.actorDataMap.put(ActorDataTypes.OWNER, ownerId);
-        pk.setActorData(this.actorDataMap);
+        synchronized (this.actorDataMap) {
+            this.actorDataMap.put(ActorDataTypes.OWNER, ownerId);
+        }
+        pk.setActorData(this.snapshotActorData());
         return pk;
     }
 

--- a/src/main/java/org/powernukkitx/entity/item/EntityHopperMinecart.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityHopperMinecart.java
@@ -151,9 +151,11 @@ public class EntityHopperMinecart extends EntityMinecartAbstract implements Inve
             }
         }
 
-        this.actorDataMap.put(ActorDataTypes.CONTAINER_TYPE, (byte) 11);
-        this.actorDataMap.put(ActorDataTypes.CONTAINER_SIZE, this.inventory.getSize());
-        this.actorDataMap.put(ActorDataTypes.CONTAINER_STRENGTH_MODIFIER, 0);
+        synchronized (this.actorDataMap) {
+            this.actorDataMap.put(ActorDataTypes.CONTAINER_TYPE, (byte) 11);
+            this.actorDataMap.put(ActorDataTypes.CONTAINER_SIZE, this.inventory.getSize());
+            this.actorDataMap.put(ActorDataTypes.CONTAINER_STRENGTH_MODIFIER, 0);
+        }
 
         this.updatePickupArea();
 

--- a/src/main/java/org/powernukkitx/entity/item/EntityItem.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityItem.java
@@ -404,7 +404,7 @@ public class EntityItem extends Entity {
     @Override
     public BedrockPacket createAddEntityPacket() {
         final AddItemActorPacket addItemActorPacket = new AddItemActorPacket();
-        addItemActorPacket.setEntityData(this.actorDataMap);
+        addItemActorPacket.setEntityData(this.snapshotActorData());
         addItemActorPacket.setTargetActorID(this.getId());
         addItemActorPacket.setTargetRuntimeID(this.runtimeId());
         addItemActorPacket.setItem(this.getItem().toNetwork());

--- a/src/main/java/org/powernukkitx/entity/item/EntitySplashPotion.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntitySplashPotion.java
@@ -50,7 +50,9 @@ public class EntitySplashPotion extends EntityProjectile {
 
         potionId = this.getNbt().getShort("PotionId");
 
-        this.actorDataMap.put(ActorDataTypes.AUX_VALUE_DATA, this.potionId);
+        synchronized (this.actorDataMap) {
+            this.actorDataMap.put(ActorDataTypes.AUX_VALUE_DATA, this.potionId);
+        }
 
         /*Effect effect = Potion.getEffect(potionId, true); TODO: potion color
 

--- a/src/main/java/org/powernukkitx/entity/item/EntityVehicle.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityVehicle.java
@@ -31,7 +31,7 @@ public abstract class EntityVehicle extends Entity implements EntityInteractable
     }
 
     public int getRollingAmplitude() {
-        return !this.actorDataMap.containsKey(ActorDataTypes.HURT) ? 0 : this.getDataProperty(ActorDataTypes.HURT);
+        return this.getDataProperty(ActorDataTypes.HURT, 0);
     }
 
     public void setRollingAmplitude(int time) {

--- a/src/main/java/org/powernukkitx/entity/item/EntityXpOrb.java
+++ b/src/main/java/org/powernukkitx/entity/item/EntityXpOrb.java
@@ -134,7 +134,9 @@ public class EntityXpOrb extends Entity {
             this.exp = 1;
         }
 
-        this.actorDataMap.put(ActorDataTypes.VALUE, this.exp);
+        synchronized (this.actorDataMap) {
+            this.actorDataMap.put(ActorDataTypes.VALUE, this.exp);
+        }
 
         //call event item spawn event
     }

--- a/src/main/java/org/powernukkitx/entity/mob/EntityCreeper.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityCreeper.java
@@ -181,7 +181,9 @@ public class EntityCreeper extends EntityMob implements EntityWalkable, EntityIn
         if (nbtMap.getBoolean("powered") || nbtMap.getBoolean("IsPowered")) {
             this.setDataFlag(ActorFlags.POWERED, true, false);
         }
-        this.actorDataMap.put(ActorDataTypes.SWELL, (byte) 0);
+        synchronized (this.actorDataMap) {
+            this.actorDataMap.put(ActorDataTypes.SWELL, (byte) 0);
+        }
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?

Send a copy of the actorDataMap in the entity packets instead of the shared map

## Why?

The live map was being serialized on the Netty I/O thread while the server thread was modifying it -> ConcurrentModificationException (random crashes when a player)

## Type of change

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** e6ad45529
- **Bedrock client version:** 26.45
- **Plugins loaded:** none

**Steps performed and results:**

1.

Note: this is a race condition so it can't be reproduced 100% reliably

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|       |             |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [X] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X]  Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
