### PR TITLE
fix(entity): stop shooting mobs from breaking their own physics

### DIFF
--- a/src/main/java/org/powernukkitx/entity/ai/executor/CrossBowShootExecutor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/executor/CrossBowShootExecutor.java
@@ -197,7 +197,7 @@ public class CrossBowShootExecutor implements EntityControl, IBehaviorExecutor {
             entity.level.addSound(entity, Sound.CROSSBOW_LOADING_START);
             entity.setDataProperty(ActorDataTypes.TARGET, this.target.getId());
             entity.setDataFlag(ActorFlags.USING_ITEM);
-        } else entity.setDataProperty(ActorDataTypes.CHARGE_AMOUNT, chargeAmount*2);
+        } else entity.setDataProperty(ActorDataTypes.CHARGE_AMOUNT, (byte) (chargeAmount * 2));
         if(chargeAmount == 30) entity.level.addSound(entity, Sound.CROSSBOW_LOADING_MIDDLE);
         if(chargeAmount == 60) {
             entity.setDataFlag(ActorFlags.CHARGED);
@@ -207,7 +207,7 @@ public class CrossBowShootExecutor implements EntityControl, IBehaviorExecutor {
 
     private void stopBowAnimation(Entity entity) {
         entity.setDataProperty(ActorDataTypes.TARGET, 0L);
-        entity.setDataProperty(ActorDataTypes.CHARGE_AMOUNT, 0);
+        entity.setDataProperty(ActorDataTypes.CHARGE_AMOUNT, (byte) 0);
         entity.setDataFlag(ActorFlags.USING_ITEM, false);
         entity.setDataFlag(ActorFlags.CHARGED, false);
     }

--- a/src/main/java/org/powernukkitx/entity/ai/executor/GhastShootExecutor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/executor/GhastShootExecutor.java
@@ -202,14 +202,14 @@ public class GhastShootExecutor implements EntityControl, IBehaviorExecutor {
         this.shootSequenceEndDelay = 0;
         entity.setDataProperty(ActorDataTypes.TARGET, this.target.getId());
         entity.setDataFlag(ActorFlags.CHARGED, true);
-        entity.setDataProperty(ActorDataTypes.CHARGE_AMOUNT, 0x1);
+        entity.setDataProperty(ActorDataTypes.CHARGE_AMOUNT, (byte) 0x1);
         entity.level.addLevelEvent(entity, LevelEvent.SOUND_GHAST_WARNING);
     }
 
     private void endShootSequence(Entity entity) {
         entity.setDataProperty(ActorDataTypes.TARGET, 0L);
         entity.setDataFlag(ActorFlags.CHARGED, false);
-        entity.setDataProperty(ActorDataTypes.CHARGE_AMOUNT, 0x0);
+        entity.setDataProperty(ActorDataTypes.CHARGE_AMOUNT, (byte) 0x0);
         entity.level.addLevelEvent(entity, LevelEvent.SOUND_GHAST_FIREBALL);
     }
 }

--- a/src/main/java/org/powernukkitx/entity/ai/executor/ShulkerAttackExecutor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/executor/ShulkerAttackExecutor.java
@@ -81,7 +81,7 @@ public class ShulkerAttackExecutor implements IBehaviorExecutor {
     @Override
     public void onStop(EntityIntelligent entity) {
         if (entity instanceof EntityShulker shulker) {
-            shulker.setDataProperty(ActorDataTypes.TARGET, 0);
+            shulker.setDataProperty(ActorDataTypes.TARGET, 0L);
             shulker.setPeeking(0);
         }
     }


### PR DESCRIPTION
## What does this PR do?

It stores `CHARGE_AMOUNT` as a `byte` and the shulker's `TARGET` as a `long`, the types
those actor data fields hold.

## Why?

Because right now, if you hit a pillager during he want to charge he will start flying. (be in survival and hit him multiple times) 
Measured on a pillager knocked back by a player: `motionY` stays at 0.4000 for as long as
it charges, against 0.4 then 0.304, 0.213, 0.126, 0.044 and negative once it does not.

The same field is written as `(byte) 0` in `Entity.java:4440`. The ghast and the shulker
have the same mistake in their own executors.

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** b7bea86b2
- **Bedrock client version:** 1.26.45
- **Plugins loaded:** none

**Steps performed and results:**

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fix)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

- [x] The disclosure above covers **all** AI use in this PR - code, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind                                                                                                    - [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled