### PR TITLE
feat(system): Implement village raids

### DIFF
--- a/src/main/java/org/powernukkitx/Player.java
+++ b/src/main/java/org/powernukkitx/Player.java
@@ -92,6 +92,7 @@ import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityHuman;
 import org.powernukkitx.entity.EntityInteractable;
 import org.powernukkitx.entity.EntityLiving;
+import org.powernukkitx.entity.effect.EffectType;
 import org.powernukkitx.entity.components.NameableComponent;
 import org.powernukkitx.entity.data.human.Skin;
 import org.powernukkitx.entity.data.warden.WardenWarningData;
@@ -3978,6 +3979,17 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
         pk.setMessageType(TextPacketType.TEXT_OBJECT);
         pk.setSendersXUID("");
         pk.setBody(messageOnly);
+        this.sendPacket(pk);
+    }
+
+    /**
+     * Plays the screen animation of an effect.
+     *
+     * @param effect the effect whose animation is played
+     */
+    public void sendEffectAnimation(EffectType effect) {
+        final OnScreenTextureAnimationPacket pk = new OnScreenTextureAnimationPacket();
+        pk.setEffectId(effect.id());
         this.sendPacket(pk);
     }
 

--- a/src/main/java/org/powernukkitx/entity/ai/executor/CelebrateSurviveExecutor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/executor/CelebrateSurviveExecutor.java
@@ -1,0 +1,70 @@
+package org.powernukkitx.entity.ai.executor;
+
+import org.powernukkitx.entity.Entity;
+import org.powernukkitx.entity.EntityIntelligent;
+import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
+import org.powernukkitx.entity.item.EntityFireworksRocket;
+import org.powernukkitx.item.Item;
+import org.powernukkitx.item.ItemID;
+import org.powernukkitx.math.Vector3;
+import org.powernukkitx.nbt.tag.CompoundTag;
+import org.powernukkitx.utils.ItemHelper;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class CelebrateSurviveExecutor implements IBehaviorExecutor {
+
+    protected final int duration;
+    protected final int minFireworkInterval;
+    protected final int fireworkIntervalSpread;
+    protected int currentTick = 0;
+    protected int nextFireworkTick = 0;
+
+    public CelebrateSurviveExecutor(int duration, int minFireworkInterval, int fireworkIntervalSpread) {
+        this.duration = duration;
+        this.minFireworkInterval = minFireworkInterval;
+        this.fireworkIntervalSpread = fireworkIntervalSpread;
+    }
+
+    @Override
+    public boolean execute(EntityIntelligent entity) {
+        if (currentTick >= nextFireworkTick) {
+            launchFirework(entity);
+            nextFireworkTick = currentTick + minFireworkInterval
+                    + ThreadLocalRandom.current().nextInt(fireworkIntervalSpread + 1);
+        }
+        return ++currentTick <= duration;
+    }
+
+    @Override
+    public void onStart(EntityIntelligent entity) {
+        currentTick = 0;
+        nextFireworkTick = 0;
+    }
+
+    @Override
+    public void onInterrupt(EntityIntelligent entity) {
+        stopCelebrating(entity);
+    }
+
+    @Override
+    public void onStop(EntityIntelligent entity) {
+        stopCelebrating(entity);
+    }
+
+    protected void stopCelebrating(EntityIntelligent entity) {
+        currentTick = 0;
+        nextFireworkTick = 0;
+        entity.getMemoryStorage().put(CoreMemoryTypes.CELEBRATING, false);
+    }
+
+    protected void launchFirework(EntityIntelligent entity) {
+        if (entity.chunk == null) {
+            return;
+        }
+        CompoundTag nbt = Entity.getDefaultNBT(
+                new Vector3(entity.getX(), entity.getY() + entity.getHeight(), entity.getZ()));
+        nbt.putCompound("FireworkItem", ItemHelper.write(Item.get(ItemID.FIREWORK_ROCKET)));
+        new EntityFireworksRocket(entity.chunk, nbt).spawnToAll();
+    }
+}

--- a/src/main/java/org/powernukkitx/entity/ai/executor/RaiderCelebrationExecutor.java
+++ b/src/main/java/org/powernukkitx/entity/ai/executor/RaiderCelebrationExecutor.java
@@ -1,0 +1,69 @@
+package org.powernukkitx.entity.ai.executor;
+
+import org.powernukkitx.entity.EntityIntelligent;
+import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
+import org.powernukkitx.level.Sound;
+import org.powernukkitx.math.Vector3;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class RaiderCelebrationExecutor implements IBehaviorExecutor {
+
+    protected final Sound sound;
+    protected final int duration;
+    protected final int minJumpInterval;
+    protected final int jumpIntervalSpread;
+    protected final int minSoundInterval;
+    protected final int soundIntervalSpread;
+    protected int currentTick = 0;
+    protected int nextJumpTick = 0;
+    protected int nextSoundTick = 0;
+
+    public RaiderCelebrationExecutor(Sound sound, int duration, int minJumpInterval, int jumpIntervalSpread,
+                                     int minSoundInterval, int soundIntervalSpread) {
+        this.sound = sound;
+        this.duration = duration;
+        this.minJumpInterval = minJumpInterval;
+        this.jumpIntervalSpread = jumpIntervalSpread;
+        this.minSoundInterval = minSoundInterval;
+        this.soundIntervalSpread = soundIntervalSpread;
+    }
+
+    @Override
+    public boolean execute(EntityIntelligent entity) {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        if (currentTick >= nextSoundTick) {
+            entity.level.addSound(entity, sound);
+            nextSoundTick = currentTick + minSoundInterval + random.nextInt(soundIntervalSpread + 1);
+        }
+        if (currentTick >= nextJumpTick && entity.isOnGround() && entity.riding == null) {
+            entity.setMotion(new Vector3(0, entity.getJumpingMotion(0.4), 0));
+            nextJumpTick = currentTick + minJumpInterval + random.nextInt(jumpIntervalSpread + 1);
+        }
+        return ++currentTick <= duration;
+    }
+
+    @Override
+    public void onStart(EntityIntelligent entity) {
+        currentTick = 0;
+        nextJumpTick = 0;
+        nextSoundTick = 0;
+    }
+
+    @Override
+    public void onInterrupt(EntityIntelligent entity) {
+        stopCelebrating(entity);
+    }
+
+    @Override
+    public void onStop(EntityIntelligent entity) {
+        stopCelebrating(entity);
+    }
+
+    protected void stopCelebrating(EntityIntelligent entity) {
+        currentTick = 0;
+        nextJumpTick = 0;
+        nextSoundTick = 0;
+        entity.getMemoryStorage().put(CoreMemoryTypes.CELEBRATING, false);
+    }
+}

--- a/src/main/java/org/powernukkitx/entity/ai/memory/CoreMemoryTypes.java
+++ b/src/main/java/org/powernukkitx/entity/ai/memory/CoreMemoryTypes.java
@@ -48,6 +48,8 @@ public interface CoreMemoryTypes {
 
     MemoryType<Boolean> HIDING_FROM_RAID = new MemoryType<>("minecraft:hiding_from_raid", false);
 
+    MemoryType<Boolean> CELEBRATING = new MemoryType<>("minecraft:celebrating", false);
+
     MemoryType<Boolean> FORCE_PERCHING = new MemoryType<>("minecraft:force_perching", false);
 
     MemoryType<Vector3> STAY_NEARBY = new MemoryType<>("minecraft:stay_nearby");

--- a/src/main/java/org/powernukkitx/entity/ai/memory/CoreMemoryTypes.java
+++ b/src/main/java/org/powernukkitx/entity/ai/memory/CoreMemoryTypes.java
@@ -44,6 +44,12 @@ public interface CoreMemoryTypes {
      */
     MemoryType<Vector3> MOVE_TARGET = new MemoryType<>("minecraft:move_target");
 
+    /**
+     * The village a raider was spawned to attack, which it walks to for as long as it has nothing
+     * closer to fight
+     */
+    MemoryType<Vector3> RAID_TARGET = new MemoryType<>("minecraft:raid_target");
+
     MemoryType<Boolean> FORCE_PERCHING = new MemoryType<>("minecraft:force_perching", false);
 
     MemoryType<Vector3> STAY_NEARBY = new MemoryType<>("minecraft:stay_nearby");

--- a/src/main/java/org/powernukkitx/entity/ai/memory/CoreMemoryTypes.java
+++ b/src/main/java/org/powernukkitx/entity/ai/memory/CoreMemoryTypes.java
@@ -44,11 +44,9 @@ public interface CoreMemoryTypes {
      */
     MemoryType<Vector3> MOVE_TARGET = new MemoryType<>("minecraft:move_target");
 
-    /**
-     * The village a raider was spawned to attack, which it walks to for as long as it has nothing
-     * closer to fight
-     */
     MemoryType<Vector3> RAID_TARGET = new MemoryType<>("minecraft:raid_target");
+
+    MemoryType<Boolean> HIDING_FROM_RAID = new MemoryType<>("minecraft:hiding_from_raid", false);
 
     MemoryType<Boolean> FORCE_PERCHING = new MemoryType<>("minecraft:force_perching", false);
 

--- a/src/main/java/org/powernukkitx/entity/effect/EffectRaidOmen.java
+++ b/src/main/java/org/powernukkitx/entity/effect/EffectRaidOmen.java
@@ -1,0 +1,25 @@
+package org.powernukkitx.entity.effect;
+
+import org.powernukkitx.Player;
+import org.powernukkitx.entity.Entity;
+
+import java.awt.*;
+
+/**
+ * Replaces the bad omen a player carries into a village. When it runs out the village they were
+ * standing in when they gained it is raided.
+ */
+public class EffectRaidOmen extends Effect {
+
+    public EffectRaidOmen() {
+        super(EffectType.RAID_OMEN, "%effect.raid_omen", new Color(222, 64, 88), true);
+    }
+
+    @Override
+    public void remove(Entity entity) {
+        super.remove(entity);
+        if (entity instanceof Player player && player.getLevel() != null) {
+            player.getLevel().getVillageManager().triggerRaid(player);
+        }
+    }
+}

--- a/src/main/java/org/powernukkitx/entity/effect/EffectType.java
+++ b/src/main/java/org/powernukkitx/entity/effect/EffectType.java
@@ -79,6 +79,8 @@ public record EffectType(String stringId, Integer id) {
 
     public static final EffectType INFESTED = new EffectType("infested", 35);
 
+    public static final EffectType RAID_OMEN = new EffectType("raid_omen", 36);
+
     public static EffectType get(String stringId) {
         return Registries.EFFECT.getType(stringId);
     }

--- a/src/main/java/org/powernukkitx/entity/mob/EntityEvocationIllager.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityEvocationIllager.java
@@ -25,6 +25,7 @@ import org.powernukkitx.entity.ai.executor.evocation.ColorConversionExecutor;
 import org.powernukkitx.entity.ai.executor.evocation.FangCircleExecutor;
 import org.powernukkitx.entity.ai.executor.evocation.FangLineExecutor;
 import org.powernukkitx.entity.ai.executor.evocation.VexSummonExecutor;
+import org.powernukkitx.entity.ai.executor.RaiderCelebrationExecutor;
 import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
 import org.powernukkitx.entity.ai.route.finder.impl.SimpleFlatAStarRouteFinder;
 import org.powernukkitx.entity.ai.route.posevaluator.WalkingPosEvaluator;
@@ -66,6 +67,8 @@ public class EntityEvocationIllager extends EntityIllager implements EntityWalka
     protected IBehaviorGroup requireBehaviorGroup() {
         return BehaviorGroup.builder(this)
                 .behaviors(
+                        new Behavior(new RaiderCelebrationExecutor(Sound.MOB_EVOCATION_ILLAGER_CELEBRATE, 30 * 20, 20, 50, 40, 100),
+                                entity -> getMemoryStorage().get(CoreMemoryTypes.CELEBRATING), 11, 1),
                         new Behavior(new PlaySoundExecutor(Sound.MOB_EVOCATION_ILLAGER_AMBIENT), new RandomSoundEvaluator(), 10, 1),
                         new Behavior(new FleeFromTargetExecutor(CoreMemoryTypes.NEAREST_SHARED_ENTITY, 0.5f, true, 9), all(
                                 new EntityCheckEvaluator(CoreMemoryTypes.NEAREST_SHARED_ENTITY),

--- a/src/main/java/org/powernukkitx/entity/mob/EntityEvocationIllager.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityEvocationIllager.java
@@ -12,12 +12,14 @@ import org.powernukkitx.entity.ai.controller.WalkController;
 import org.powernukkitx.entity.ai.evaluator.DistanceEvaluator;
 import org.powernukkitx.entity.ai.evaluator.EntityCheckEvaluator;
 import org.powernukkitx.entity.ai.evaluator.MemoryCheckEmptyEvaluator;
+import org.powernukkitx.entity.ai.evaluator.MemoryCheckNotEmptyEvaluator;
 import org.powernukkitx.entity.ai.evaluator.PassByTimeEvaluator;
 import org.powernukkitx.entity.ai.evaluator.RandomSoundEvaluator;
 import org.powernukkitx.entity.ai.executor.DoNothingExecutor;
 import org.powernukkitx.entity.ai.executor.FlatRandomRoamExecutor;
 import org.powernukkitx.entity.ai.executor.FleeFromTargetExecutor;
 import org.powernukkitx.entity.ai.executor.LookAtTargetExecutor;
+import org.powernukkitx.entity.ai.executor.MoveToTargetExecutor;
 import org.powernukkitx.entity.ai.executor.PlaySoundExecutor;
 import org.powernukkitx.entity.ai.executor.evocation.ColorConversionExecutor;
 import org.powernukkitx.entity.ai.executor.evocation.FangCircleExecutor;
@@ -145,6 +147,9 @@ public class EntityEvocationIllager extends EntityIllager implements EntityWalka
                                 entity -> !entity.getDataFlag(ActorFlags.CASTING)
                         ), 3, 1),
                         new Behavior(new DoNothingExecutor(), entity -> entity.getDataFlag(ActorFlags.CASTING), 2, 1),
+                        new Behavior(new MoveToTargetExecutor(CoreMemoryTypes.RAID_TARGET, 0.3f, true),
+                                all(new MemoryCheckNotEmptyEvaluator(CoreMemoryTypes.RAID_TARGET),
+                                        new MemoryCheckEmptyEvaluator(CoreMemoryTypes.ATTACK_TARGET)), 2, 1),
                         new Behavior(new FlatRandomRoamExecutor(0.3f, 12, 100, false, -1, true, 10), none(), 1, 1)
                 )
                 .sensors(

--- a/src/main/java/org/powernukkitx/entity/mob/EntityIllager.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityIllager.java
@@ -3,15 +3,115 @@ package org.powernukkitx.entity.mob;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityWalkable;
 import org.powernukkitx.entity.passive.EntityVillagerV2;
+import org.powernukkitx.item.Item;
+import org.powernukkitx.item.ItemID;
+import org.powernukkitx.item.enchantment.Enchantment;
+import org.powernukkitx.item.enchantment.EnchantmentHelper;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
+import org.powernukkitx.utils.Utils;
+import org.powernukkitx.utils.random.NukkitRandom;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * @author PikyCZ
  */
 public abstract class EntityIllager extends EntityMob implements EntityWalkable {
+    protected static final String[] RAID_GEAR = {
+            ItemID.IRON_PICKAXE, ItemID.IRON_AXE, ItemID.IRON_SHOVEL, ItemID.IRON_SWORD,
+            ItemID.IRON_HELMET, ItemID.IRON_CHESTPLATE, ItemID.IRON_LEGGINGS, ItemID.IRON_BOOTS
+    };
+
+    private boolean raiding;
+
     public EntityIllager(IChunk chunk, CompoundTag nbt) {
         super(chunk, nbt);
+    }
+
+    @Override
+    protected void initEntity() {
+        super.initEntity();
+        this.raiding = this.namedTag.getBoolean("Raiding");
+    }
+
+    @Override
+    public void saveNBT() {
+        super.saveNBT();
+        this.namedTag.putBoolean("Raiding", this.raiding);
+    }
+
+    /**
+     * @return whether this illager was spawned for a raid, which is what grants it the extra drops
+     */
+    public boolean isRaiding() {
+        return raiding;
+    }
+
+    public void setRaiding(boolean raiding) {
+        this.raiding = raiding;
+    }
+
+    /**
+     * The drops an illager killed during a raid hands out on top of its own.
+     *
+     * @param weapon the weapon it was killed with, for the looting enchantment
+     */
+    protected Item[] raidDrops(@NotNull Item weapon) {
+        if (!raiding) {
+            return Item.EMPTY_ARRAY;
+        }
+
+        int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
+        List<Item> drops = new ArrayList<>();
+        int emeralds = Utils.rand(0, 1) + Utils.rand(0, looting);
+        if (emeralds > 0) {
+            drops.add(Item.get(ItemID.EMERALD, 0, emeralds));
+        }
+
+        Item bonus = rollRaidBonus(looting);
+        if (bonus != null) {
+            drops.add(bonus);
+        }
+        return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private @Nullable Item rollRaidBonus(int looting) {
+        float chance = switch (getServer().getDifficulty()) {
+            case 0 -> 0f;
+            case 3 -> 0.8f;
+            default -> 0.65f;
+        };
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        if (random.nextFloat() >= chance) {
+            return null;
+        }
+
+        int roll = random.nextInt(156);
+        if (roll < 40) {
+            return Item.get(ItemID.EMERALD, 0, Utils.rand(0, 1) + Utils.rand(0, looting));
+        }
+        if (roll < 60) {
+            return Item.get(ItemID.EMERALD, 0, Utils.rand(2, 3) + Utils.rand(0, looting));
+        }
+        if (roll < 68) {
+            return Item.get(ItemID.EMERALD, 0, Utils.rand(4, 5) + Utils.rand(0, looting));
+        }
+        if (roll < 76) {
+            Item book = Item.get(ItemID.BOOK);
+            for (Enchantment enchantment : EnchantmentHelper.selectEnchantments(new NukkitRandom(), book, 30)) {
+                book.addEnchantment(enchantment);
+            }
+            return book;
+        }
+
+        Item gear = Item.get(RAID_GEAR[(roll - 76) / 10]);
+        gear.setDamage((int) (gear.getMaxDurability() * (0.3 + random.nextDouble() * 0.6)));
+        return enchantGear(gear, 0.5f);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityIllager.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityIllager.java
@@ -36,13 +36,13 @@ public abstract class EntityIllager extends EntityMob implements EntityWalkable 
     @Override
     protected void initEntity() {
         super.initEntity();
-        this.raiding = this.namedTag.getBoolean("Raiding");
+        this.raiding = this.nbt.getBoolean("Raiding");
     }
 
     @Override
     public void saveNBT() {
         super.saveNBT();
-        this.namedTag.putBoolean("Raiding", this.raiding);
+        this.nbt.putBoolean("Raiding", this.raiding);
     }
 
     /**

--- a/src/main/java/org/powernukkitx/entity/mob/EntityIllager.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityIllager.java
@@ -68,7 +68,7 @@ public abstract class EntityIllager extends EntityMob implements EntityWalkable 
 
         int looting = weapon.getEnchantmentLevel(Enchantment.ID_LOOTING);
         List<Item> drops = new ArrayList<>();
-        int emeralds = Utils.rand(0, 1) + Utils.rand(0, looting);
+        int emeralds = Utils.rand(0, 1) + lootingBonus(looting);
         if (emeralds > 0) {
             drops.add(Item.get(ItemID.EMERALD, 0, emeralds));
         }
@@ -78,6 +78,14 @@ public abstract class EntityIllager extends EntityMob implements EntityWalkable 
             drops.add(bonus);
         }
         return drops.toArray(Item.EMPTY_ARRAY);
+    }
+
+    private static int lootingBonus(int looting) {
+        int bonus = 0;
+        for (int level = 0; level < looting; level++) {
+            bonus += Utils.rand(0, 1);
+        }
+        return bonus;
     }
 
     private @Nullable Item rollRaidBonus(int looting) {
@@ -93,16 +101,16 @@ public abstract class EntityIllager extends EntityMob implements EntityWalkable 
 
         int roll = random.nextInt(156);
         if (roll < 40) {
-            return Item.get(ItemID.EMERALD, 0, Utils.rand(0, 1) + Utils.rand(0, looting));
+            return Item.get(ItemID.EMERALD, 0, Utils.rand(0, 1) + lootingBonus(looting));
         }
         if (roll < 60) {
-            return Item.get(ItemID.EMERALD, 0, Utils.rand(2, 3) + Utils.rand(0, looting));
+            return Item.get(ItemID.EMERALD, 0, Utils.rand(2, 3) + lootingBonus(looting));
         }
         if (roll < 68) {
-            return Item.get(ItemID.EMERALD, 0, Utils.rand(4, 5) + Utils.rand(0, looting));
+            return Item.get(ItemID.EMERALD, 0, Utils.rand(4, 5) + lootingBonus(looting));
         }
         if (roll < 76) {
-            Item book = Item.get(ItemID.BOOK);
+            Item book = Item.get(ItemID.ENCHANTED_BOOK);
             for (Enchantment enchantment : EnchantmentHelper.selectEnchantments(new NukkitRandom(), book, 30)) {
                 book.addEnchantment(enchantment);
             }

--- a/src/main/java/org/powernukkitx/entity/mob/EntityPillager.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityPillager.java
@@ -9,9 +9,12 @@ import org.powernukkitx.entity.ai.behaviorgroup.IBehaviorGroup;
 import org.powernukkitx.entity.ai.controller.LookController;
 import org.powernukkitx.entity.ai.controller.WalkController;
 import org.powernukkitx.entity.ai.evaluator.EntityCheckEvaluator;
+import org.powernukkitx.entity.ai.evaluator.MemoryCheckEmptyEvaluator;
+import org.powernukkitx.entity.ai.evaluator.MemoryCheckNotEmptyEvaluator;
 import org.powernukkitx.entity.ai.evaluator.RandomSoundEvaluator;
 import org.powernukkitx.entity.ai.executor.CrossBowShootExecutor;
 import org.powernukkitx.entity.ai.executor.FlatRandomRoamExecutor;
+import org.powernukkitx.entity.ai.executor.MoveToTargetExecutor;
 import org.powernukkitx.entity.ai.executor.PlaySoundExecutor;
 import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
 import org.powernukkitx.entity.ai.route.finder.impl.SimpleFlatAStarRouteFinder;
@@ -53,6 +56,9 @@ public class EntityPillager extends EntityIllager implements EntityWalkable {
                         new Behavior(new CrossBowShootExecutor(this::getItemInHand, CoreMemoryTypes.ATTACK_TARGET, 0.3f, 15, true, 30, 80), new EntityCheckEvaluator(CoreMemoryTypes.ATTACK_TARGET), 4, 1),
                         new Behavior(new CrossBowShootExecutor(this::getItemInHand, CoreMemoryTypes.NEAREST_PLAYER, 0.3f, 15, true, 30, 80), new EntityCheckEvaluator(CoreMemoryTypes.NEAREST_PLAYER), 3, 1),
                         new Behavior(new CrossBowShootExecutor(this::getItemInHand, CoreMemoryTypes.NEAREST_SUITABLE_ATTACK_TARGET, 0.3f, 15, true, 30, 80), new EntityCheckEvaluator(CoreMemoryTypes.NEAREST_SUITABLE_ATTACK_TARGET), 2, 1),
+                        new Behavior(new MoveToTargetExecutor(CoreMemoryTypes.RAID_TARGET, 0.3f, true),
+                                all(new MemoryCheckNotEmptyEvaluator(CoreMemoryTypes.RAID_TARGET),
+                                        new MemoryCheckEmptyEvaluator(CoreMemoryTypes.ATTACK_TARGET)), 2, 1),
                         new Behavior(new FlatRandomRoamExecutor(0.3f, 12, 100, false, -1, true, 10), none(), 1, 1)
                 )
                 .sensors(

--- a/src/main/java/org/powernukkitx/entity/mob/EntityPillager.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityPillager.java
@@ -16,6 +16,7 @@ import org.powernukkitx.entity.ai.executor.CrossBowShootExecutor;
 import org.powernukkitx.entity.ai.executor.FlatRandomRoamExecutor;
 import org.powernukkitx.entity.ai.executor.MoveToTargetExecutor;
 import org.powernukkitx.entity.ai.executor.PlaySoundExecutor;
+import org.powernukkitx.entity.ai.executor.RaiderCelebrationExecutor;
 import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
 import org.powernukkitx.entity.ai.route.finder.impl.SimpleFlatAStarRouteFinder;
 import org.powernukkitx.entity.ai.route.posevaluator.WalkingPosEvaluator;
@@ -52,6 +53,8 @@ public class EntityPillager extends EntityIllager implements EntityWalkable {
     public IBehaviorGroup requireBehaviorGroup() {
         return BehaviorGroup.builder(this)
                 .behaviors(
+                        new Behavior(new RaiderCelebrationExecutor(Sound.MOB_PILLAGER_CELEBRATE, 30 * 20, 20, 50, 40, 100),
+                                entity -> getMemoryStorage().get(CoreMemoryTypes.CELEBRATING), 6, 1),
                         new Behavior(new PlaySoundExecutor(Sound.MOB_PILLAGER_IDLE, 0.8f, 1.2f, 0.8f, 0.8f), new RandomSoundEvaluator(), 5, 1),
                         new Behavior(new CrossBowShootExecutor(this::getItemInHand, CoreMemoryTypes.ATTACK_TARGET, 0.3f, 15, true, 30, 80), new EntityCheckEvaluator(CoreMemoryTypes.ATTACK_TARGET), 4, 1),
                         new Behavior(new CrossBowShootExecutor(this::getItemInHand, CoreMemoryTypes.NEAREST_PLAYER, 0.3f, 15, true, 30, 80), new EntityCheckEvaluator(CoreMemoryTypes.NEAREST_PLAYER), 3, 1),
@@ -128,6 +131,7 @@ public class EntityPillager extends EntityIllager implements EntityWalkable {
             drops.add(Item.get(Item.ARROW, 0, arrows));
         }
 
+        drops.addAll(Arrays.asList(raidDrops(weapon)));
         return drops.toArray(Item.EMPTY_ARRAY);
     }
 }

--- a/src/main/java/org/powernukkitx/entity/mob/EntityRavager.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityRavager.java
@@ -8,8 +8,11 @@ import org.powernukkitx.entity.ai.behaviorgroup.IBehaviorGroup;
 import org.powernukkitx.entity.ai.controller.LookController;
 import org.powernukkitx.entity.ai.controller.WalkController;
 import org.powernukkitx.entity.ai.evaluator.EntityCheckEvaluator;
+import org.powernukkitx.entity.ai.evaluator.MemoryCheckEmptyEvaluator;
+import org.powernukkitx.entity.ai.evaluator.MemoryCheckNotEmptyEvaluator;
 import org.powernukkitx.entity.ai.executor.FlatRandomRoamExecutor;
 import org.powernukkitx.entity.ai.executor.MeleeAttackExecutor;
+import org.powernukkitx.entity.ai.executor.MoveToTargetExecutor;
 import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
 import org.powernukkitx.entity.ai.route.finder.impl.SimpleFlatAStarRouteFinder;
 import org.powernukkitx.entity.ai.route.posevaluator.WalkingPosEvaluator;
@@ -43,6 +46,9 @@ public class EntityRavager extends EntityMob implements EntityWalkable {
                 .behaviors(
                         new Behavior(new MeleeAttackExecutor(CoreMemoryTypes.ATTACK_TARGET, 0.2f, 40, true, 30), new EntityCheckEvaluator(CoreMemoryTypes.ATTACK_TARGET), 3, 1),
                         new Behavior(new MeleeAttackExecutor(CoreMemoryTypes.NEAREST_PLAYER, 0.2f, 40, false, 30), new EntityCheckEvaluator(CoreMemoryTypes.NEAREST_PLAYER), 2, 1),
+                        new Behavior(new MoveToTargetExecutor(CoreMemoryTypes.RAID_TARGET, 0.3f, true),
+                                all(new MemoryCheckNotEmptyEvaluator(CoreMemoryTypes.RAID_TARGET),
+                                        new MemoryCheckEmptyEvaluator(CoreMemoryTypes.ATTACK_TARGET)), 2, 1),
                         new Behavior(new FlatRandomRoamExecutor(0.3f, 12, 100, false, -1, true, 10), none(), 1, 1)
                 )
                 .sensors(new NearestPlayerSensor(40, 0, 20))

--- a/src/main/java/org/powernukkitx/entity/mob/EntityRavager.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityRavager.java
@@ -13,6 +13,7 @@ import org.powernukkitx.entity.ai.evaluator.MemoryCheckNotEmptyEvaluator;
 import org.powernukkitx.entity.ai.executor.FlatRandomRoamExecutor;
 import org.powernukkitx.entity.ai.executor.MeleeAttackExecutor;
 import org.powernukkitx.entity.ai.executor.MoveToTargetExecutor;
+import org.powernukkitx.entity.ai.executor.RaiderCelebrationExecutor;
 import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
 import org.powernukkitx.entity.ai.route.finder.impl.SimpleFlatAStarRouteFinder;
 import org.powernukkitx.entity.ai.route.posevaluator.WalkingPosEvaluator;
@@ -21,6 +22,7 @@ import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
 import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
+import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.nbt.tag.CompoundTag;
 
@@ -44,6 +46,8 @@ public class EntityRavager extends EntityMob implements EntityWalkable {
     public IBehaviorGroup requireBehaviorGroup() {
         return BehaviorGroup.builder(this)
                 .behaviors(
+                        new Behavior(new RaiderCelebrationExecutor(Sound.MOB_RAVAGER_CELEBRATE, 30 * 20, 20, 50, 40, 100),
+                                entity -> getMemoryStorage().get(CoreMemoryTypes.CELEBRATING), 6, 1),
                         new Behavior(new MeleeAttackExecutor(CoreMemoryTypes.ATTACK_TARGET, 0.2f, 40, true, 30), new EntityCheckEvaluator(CoreMemoryTypes.ATTACK_TARGET), 3, 1),
                         new Behavior(new MeleeAttackExecutor(CoreMemoryTypes.NEAREST_PLAYER, 0.2f, 40, false, 30), new EntityCheckEvaluator(CoreMemoryTypes.NEAREST_PLAYER), 2, 1),
                         new Behavior(new MoveToTargetExecutor(CoreMemoryTypes.RAID_TARGET, 0.3f, true),

--- a/src/main/java/org/powernukkitx/entity/mob/EntityRavager.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityRavager.java
@@ -20,15 +20,18 @@ import org.powernukkitx.entity.ai.route.posevaluator.WalkingPosEvaluator;
 import org.powernukkitx.entity.ai.sensor.NearestPlayerSensor;
 import org.powernukkitx.entity.components.HealthComponent;
 import org.powernukkitx.entity.components.MovementComponent;
+import org.powernukkitx.entity.components.RideableComponent;
 import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.item.Item;
 import org.powernukkitx.level.Sound;
 import org.powernukkitx.level.format.IChunk;
+import org.powernukkitx.math.Vector3f;
 import org.powernukkitx.nbt.tag.CompoundTag;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.Set;
 
 public class EntityRavager extends EntityMob implements EntityWalkable {
@@ -86,6 +89,30 @@ public class EntityRavager extends EntityMob implements EntityWalkable {
     protected @Nullable MovementComponent getComponentMovement() {
         // TODO: hostile movement logic
         return MovementComponent.value(0.4f);
+    }
+
+    @Override
+    public @Nullable RideableComponent getComponentRideable() {
+        return new RideableComponent(
+                0,
+                true,
+                RideableComponent.DismountMode.DEFAULT,
+                Set.of("pillager", "vindicator", "evocation_illager"),
+                null,
+                0.0f,
+                false,
+                false,
+                1,
+                List.of(new RideableComponent.Seat(
+                        0,
+                        1,
+                        new Vector3f(0.0f, 2.025f, -0.3f),
+                        null,
+                        null,
+                        null,
+                        null
+                ))
+        );
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/entity/mob/EntityVindicator.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityVindicator.java
@@ -17,6 +17,7 @@ import org.powernukkitx.entity.ai.executor.FlatRandomRoamExecutor;
 import org.powernukkitx.entity.ai.executor.MeleeAttackExecutor;
 import org.powernukkitx.entity.ai.executor.MoveToTargetExecutor;
 import org.powernukkitx.entity.ai.executor.PlaySoundExecutor;
+import org.powernukkitx.entity.ai.executor.RaiderCelebrationExecutor;
 import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
 import org.powernukkitx.entity.ai.memory.MemoryType;
 import org.powernukkitx.entity.ai.route.finder.impl.SimpleFlatAStarRouteFinder;
@@ -63,6 +64,8 @@ public class EntityVindicator extends EntityIllager implements EntityWalkable {
     public IBehaviorGroup requireBehaviorGroup() {
         return BehaviorGroup.builder(this)
                 .behaviors(
+                        new Behavior(new RaiderCelebrationExecutor(Sound.MOB_VINDICATOR_CELEBRATE, 30 * 20, 20, 50, 40, 100),
+                                entity -> getMemoryStorage().get(CoreMemoryTypes.CELEBRATING), 8, 1),
                         new Behavior(new PlaySoundExecutor(Sound.MOB_VINDICATOR_IDLE, isBaby() ? 1.3f : 0.8f, isBaby() ? 1.7f : 1.2f, 1, 1), new RandomSoundEvaluator(), 7, 1),
                         new Behavior(new VindicatorMeleeAttackExecutor(CoreMemoryTypes.ATTACK_TARGET, 0.5f, 40, true, 30), new EntityCheckEvaluator(CoreMemoryTypes.ATTACK_TARGET), 4, 1),
                         new Behavior(new VindicatorMeleeAttackExecutor(CoreMemoryTypes.NEAREST_PLAYER, 0.5f, 40, false, 30), new EntityCheckEvaluator(CoreMemoryTypes.NEAREST_PLAYER), 3, 1),
@@ -154,6 +157,7 @@ public class EntityVindicator extends EntityIllager implements EntityWalkable {
             }
         }
 
+        drops.addAll(Arrays.asList(raidDrops(weapon)));
         return drops.toArray(Item.EMPTY_ARRAY);
     }
 

--- a/src/main/java/org/powernukkitx/entity/mob/EntityVindicator.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityVindicator.java
@@ -10,9 +10,12 @@ import org.powernukkitx.entity.ai.behaviorgroup.IBehaviorGroup;
 import org.powernukkitx.entity.ai.controller.LookController;
 import org.powernukkitx.entity.ai.controller.WalkController;
 import org.powernukkitx.entity.ai.evaluator.EntityCheckEvaluator;
+import org.powernukkitx.entity.ai.evaluator.MemoryCheckEmptyEvaluator;
+import org.powernukkitx.entity.ai.evaluator.MemoryCheckNotEmptyEvaluator;
 import org.powernukkitx.entity.ai.evaluator.RandomSoundEvaluator;
 import org.powernukkitx.entity.ai.executor.FlatRandomRoamExecutor;
 import org.powernukkitx.entity.ai.executor.MeleeAttackExecutor;
+import org.powernukkitx.entity.ai.executor.MoveToTargetExecutor;
 import org.powernukkitx.entity.ai.executor.PlaySoundExecutor;
 import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
 import org.powernukkitx.entity.ai.memory.MemoryType;
@@ -64,6 +67,9 @@ public class EntityVindicator extends EntityIllager implements EntityWalkable {
                         new Behavior(new VindicatorMeleeAttackExecutor(CoreMemoryTypes.ATTACK_TARGET, 0.5f, 40, true, 30), new EntityCheckEvaluator(CoreMemoryTypes.ATTACK_TARGET), 4, 1),
                         new Behavior(new VindicatorMeleeAttackExecutor(CoreMemoryTypes.NEAREST_PLAYER, 0.5f, 40, false, 30), new EntityCheckEvaluator(CoreMemoryTypes.NEAREST_PLAYER), 3, 1),
                         new Behavior(new VindicatorMeleeAttackExecutor(CoreMemoryTypes.NEAREST_SUITABLE_ATTACK_TARGET, 0.5f, 40, true, 30), new EntityCheckEvaluator(CoreMemoryTypes.NEAREST_SUITABLE_ATTACK_TARGET), 2, 1),
+                        new Behavior(new MoveToTargetExecutor(CoreMemoryTypes.RAID_TARGET, 0.5f, true),
+                                all(new MemoryCheckNotEmptyEvaluator(CoreMemoryTypes.RAID_TARGET),
+                                        new MemoryCheckEmptyEvaluator(CoreMemoryTypes.ATTACK_TARGET)), 2, 1),
                         new Behavior(new FlatRandomRoamExecutor(0.5f, 12, 100, false, -1, true, 10), none(), 1, 1)
                 )
                 .sensors(new NearestTargetEntitySensor<>(0, 16, 20,

--- a/src/main/java/org/powernukkitx/entity/mob/EntityWitch.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityWitch.java
@@ -8,9 +8,11 @@ import org.powernukkitx.entity.ai.behaviorgroup.IBehaviorGroup;
 import org.powernukkitx.entity.ai.controller.LookController;
 import org.powernukkitx.entity.ai.controller.WalkController;
 import org.powernukkitx.entity.ai.evaluator.EntityCheckEvaluator;
+import org.powernukkitx.entity.ai.evaluator.MemoryCheckEmptyEvaluator;
 import org.powernukkitx.entity.ai.evaluator.MemoryCheckNotEmptyEvaluator;
 import org.powernukkitx.entity.ai.evaluator.RandomSoundEvaluator;
 import org.powernukkitx.entity.ai.executor.FlatRandomRoamExecutor;
+import org.powernukkitx.entity.ai.executor.MoveToTargetExecutor;
 import org.powernukkitx.entity.ai.executor.PlaySoundExecutor;
 import org.powernukkitx.entity.ai.executor.PotionThrowExecutor;
 import org.powernukkitx.entity.ai.executor.UsePotionExecutor;
@@ -54,6 +56,9 @@ public class EntityWitch extends EntityMob implements EntityWalkable {
         return BehaviorGroup.builder(this)
                 .coreBehaviors(
                         new Behavior(new PlaySoundExecutor(Sound.MOB_WITCH_AMBIENT), new RandomSoundEvaluator(), 2, 1),
+                        new Behavior(new MoveToTargetExecutor(CoreMemoryTypes.RAID_TARGET, 0.3f, true),
+                                all(new MemoryCheckNotEmptyEvaluator(CoreMemoryTypes.RAID_TARGET),
+                                        new MemoryCheckEmptyEvaluator(CoreMemoryTypes.ATTACK_TARGET)), 2, 1),
                         new Behavior(new FlatRandomRoamExecutor(0.3f, 12, 100, false, -1, true, 10), none(), 1, 1)
                 )
                 .behaviors(

--- a/src/main/java/org/powernukkitx/entity/mob/EntityWitch.java
+++ b/src/main/java/org/powernukkitx/entity/mob/EntityWitch.java
@@ -16,6 +16,7 @@ import org.powernukkitx.entity.ai.executor.MoveToTargetExecutor;
 import org.powernukkitx.entity.ai.executor.PlaySoundExecutor;
 import org.powernukkitx.entity.ai.executor.PotionThrowExecutor;
 import org.powernukkitx.entity.ai.executor.UsePotionExecutor;
+import org.powernukkitx.entity.ai.executor.RaiderCelebrationExecutor;
 import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
 import org.powernukkitx.entity.ai.route.finder.impl.SimpleFlatAStarRouteFinder;
 import org.powernukkitx.entity.ai.route.posevaluator.WalkingPosEvaluator;
@@ -62,6 +63,8 @@ public class EntityWitch extends EntityMob implements EntityWalkable {
                         new Behavior(new FlatRandomRoamExecutor(0.3f, 12, 100, false, -1, true, 10), none(), 1, 1)
                 )
                 .behaviors(
+                        new Behavior(new RaiderCelebrationExecutor(Sound.MOB_WITCH_CELEBRATE, 30 * 20, 20, 50, 40, 100),
+                                entity -> getMemoryStorage().get(CoreMemoryTypes.CELEBRATING), 9, 1),
                         new Behavior(new UsePotionExecutor(0.3f, 30, 20), all(
                                 new MemoryCheckNotEmptyEvaluator(CoreMemoryTypes.LAST_BE_ATTACKED_TIME),
                                 entity -> entity.getLevel().getTick() - getMemoryStorage().get(CoreMemoryTypes.LAST_BE_ATTACKED_TIME) <= 1

--- a/src/main/java/org/powernukkitx/entity/passive/EntityVillagerV2.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityVillagerV2.java
@@ -189,6 +189,10 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
                         new Behavior(new PlaySoundExecutor(Sound.MOB_VILLAGER_IDLE, isBaby() ? 1.3f : 0.8f, isBaby() ? 1.7f : 1.2f, 1, 1), new RandomSoundEvaluator(), 1, 1)
                 )
                 .behaviors(
+                        new Behavior(new MoveToTargetExecutor(CoreMemoryTypes.OCCUPIED_BED, 0.24f, true), all(
+                                entity -> getMemoryStorage().get(CoreMemoryTypes.HIDING_FROM_RAID),
+                                new MemoryCheckNotEmptyEvaluator(CoreMemoryTypes.OCCUPIED_BED)
+                        ), 10, 1),
                         new Behavior(entity -> {
                             setMoveTarget(null);
                             setLookTarget(getTradeInventory().getViewers().stream().findFirst().get());

--- a/src/main/java/org/powernukkitx/entity/passive/EntityVillagerV2.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityVillagerV2.java
@@ -21,6 +21,7 @@ import org.powernukkitx.entity.ai.evaluator.MemoryCheckNotEmptyEvaluator;
 import org.powernukkitx.entity.ai.evaluator.PassByTimeEvaluator;
 import org.powernukkitx.entity.ai.evaluator.RandomSoundEvaluator;
 import org.powernukkitx.entity.ai.executor.AnimalGrowExecutor;
+import org.powernukkitx.entity.ai.executor.CelebrateSurviveExecutor;
 import org.powernukkitx.entity.ai.executor.FlatRandomRoamExecutor;
 import org.powernukkitx.entity.ai.executor.FleeFromTargetExecutor;
 import org.powernukkitx.entity.ai.executor.MoveToTargetExecutor;
@@ -48,6 +49,7 @@ import org.powernukkitx.event.entity.EntityDamageByEntityEvent;
 import org.powernukkitx.event.entity.EntityDamageEvent;
 import org.powernukkitx.event.entity.EntityTransformEvent;
 import org.powernukkitx.inventory.EntityEquipmentInventory;
+import org.powernukkitx.inventory.request.CraftRecipeActionProcessor;
 import org.powernukkitx.inventory.InventoryHolder;
 import org.powernukkitx.inventory.InventorySlice;
 import org.powernukkitx.inventory.TradeInventory;
@@ -189,6 +191,8 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
                         new Behavior(new PlaySoundExecutor(Sound.MOB_VILLAGER_IDLE, isBaby() ? 1.3f : 0.8f, isBaby() ? 1.7f : 1.2f, 1, 1), new RandomSoundEvaluator(), 1, 1)
                 )
                 .behaviors(
+                        new Behavior(new CelebrateSurviveExecutor(30 * 20, 40, 100),
+                                entity -> getMemoryStorage().get(CoreMemoryTypes.CELEBRATING), 11, 1),
                         new Behavior(new MoveToTargetExecutor(CoreMemoryTypes.OCCUPIED_BED, 0.24f, true), all(
                                 entity -> getMemoryStorage().get(CoreMemoryTypes.HIDING_FROM_RAID),
                                 new MemoryCheckNotEmptyEvaluator(CoreMemoryTypes.OCCUPIED_BED)
@@ -927,7 +931,10 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
                 CompoundTag buyA = tag.getCompound("buyA").copy();
                 float multiplier = 0;
                 if (tag.contains("priceMultiplierA")) multiplier = tag.getFloat("priceMultiplierA");
-                buyA.putByte("Count", Math.max(buyA.getByte("Count") - (int) (reputation * multiplier), 1));
+                int base = buyA.getByte("Count");
+                int reduction = (int) (reputation * multiplier)
+                        + CraftRecipeActionProcessor.heroDiscount(player, base);
+                buyA.putByte("Count", Math.max(base - reduction, 1));
                 tag.putCompound("buyA", buyA);
             }
             if (tag.contains("buyB")) {

--- a/src/main/java/org/powernukkitx/entity/passive/EntityVillagerV2.java
+++ b/src/main/java/org/powernukkitx/entity/passive/EntityVillagerV2.java
@@ -933,7 +933,7 @@ public class EntityVillagerV2 extends EntityIntelligent implements InventoryHold
                 if (tag.contains("priceMultiplierA")) multiplier = tag.getFloat("priceMultiplierA");
                 int base = buyA.getByte("Count");
                 int reduction = (int) (reputation * multiplier)
-                        + CraftRecipeActionProcessor.heroDiscount(player, base);
+                        + CraftRecipeActionProcessor.heroDiscount(player, buyA);
                 buyA.putByte("Count", Math.max(base - reduction, 1));
                 tag.putCompound("buyA", buyA);
             }

--- a/src/main/java/org/powernukkitx/inventory/request/CraftRecipeActionProcessor.java
+++ b/src/main/java/org/powernukkitx/inventory/request/CraftRecipeActionProcessor.java
@@ -12,6 +12,7 @@ import org.powernukkitx.inventory.InputInventory;
 import org.powernukkitx.inventory.Inventory;
 import org.powernukkitx.inventory.SmithingInventory;
 import org.powernukkitx.item.Item;
+import org.powernukkitx.item.ItemID;
 import org.powernukkitx.item.enchantment.Enchantment;
 import org.powernukkitx.item.enchantment.EnchantmentHelper;
 import org.powernukkitx.nbt.tag.CompoundTag;
@@ -55,16 +56,21 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
     public static final String GRID_CONSUMED_KEY = "grid_consumed";
 
     /**
-     * How many items the hero of the village effect takes off the first item of a trade. The first
-     * level is worth 30 percent of the price and every level past it another sixteenth, and the
-     * discount is never smaller than a single item.
+     * How many emeralds the hero of the village effect takes off the first item of a trade. The
+     * first level is worth 30 percent of the price and every level past it another sixteenth, and
+     * the discount is never smaller than a single emerald. A trade the villager pays for is left
+     * alone, only the price the player hands over is discounted.
      *
      * @param player the player trading
-     * @param price  the price the trade asks for
-     * @return the number of items to take off, zero when the player is not a hero
+     * @param buy    the first item of the trade, the one the player hands over
+     * @return the number of emeralds to take off, zero when the player is not a hero
      */
-    public static int heroDiscount(Player player, int price) {
+    public static int heroDiscount(Player player, CompoundTag buy) {
+        if (!ItemID.EMERALD.equals(buy.getString("Name"))) {
+            return 0;
+        }
         Effect hero = player.getEffect(EffectType.VILLAGE_HERO);
+        int price = buy.getByte("Count");
         if (hero == null || price <= 0) {
             return 0;
         }
@@ -160,7 +166,7 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
 
             int reductionA = (int) (reputation * (tradeRecipe.containsFloat("priceMultiplierA") ? tradeRecipe.getFloat("priceMultiplierA") : 0));
             if (ca) {
-                reductionA += heroDiscount(player, tradeRecipe.getCompound("buyA").getByte("Count"));
+                reductionA += heroDiscount(player, tradeRecipe.getCompound("buyA"));
             }
             int reductionB = (int) (reputation * (tradeRecipe.containsFloat("priceMultiplierB") ? tradeRecipe.getFloat("priceMultiplierB") : 0));
 

--- a/src/main/java/org/powernukkitx/inventory/request/CraftRecipeActionProcessor.java
+++ b/src/main/java/org/powernukkitx/inventory/request/CraftRecipeActionProcessor.java
@@ -1,6 +1,8 @@
 package org.powernukkitx.inventory.request;
 
 import org.powernukkitx.Player;
+import org.powernukkitx.entity.effect.Effect;
+import org.powernukkitx.entity.effect.EffectType;
 import org.powernukkitx.Server;
 import org.powernukkitx.entity.passive.EntityVillagerV2;
 import org.powernukkitx.event.inventory.CraftItemEvent;
@@ -51,6 +53,23 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
     public static final String RECIPE_DATA_KEY = "recipe";
     public static final String ENCH_RECIPE_KEY = "ench_recipe";
     public static final String GRID_CONSUMED_KEY = "grid_consumed";
+
+    /**
+     * How many items the hero of the village effect takes off the first item of a trade. The first
+     * level is worth 30 percent of the price and every level past it another sixteenth, and the
+     * discount is never smaller than a single item.
+     *
+     * @param player the player trading
+     * @param price  the price the trade asks for
+     * @return the number of items to take off, zero when the player is not a hero
+     */
+    public static int heroDiscount(Player player, int price) {
+        Effect hero = player.getEffect(EffectType.VILLAGE_HERO);
+        if (hero == null || price <= 0) {
+            return 0;
+        }
+        return Math.max(1, (int) Math.floor(price * (0.0625 * (hero.getLevel() - 1) + 0.3)));
+    }
 
     public boolean checkTrade(CompoundTag recipeInput, Item input, int subtract) {
         String id = input.getId();
@@ -140,6 +159,9 @@ public class CraftRecipeActionProcessor implements ItemStackRequestActionProcess
             boolean cb = tradeRecipe.contains("buyB");
 
             int reductionA = (int) (reputation * (tradeRecipe.containsFloat("priceMultiplierA") ? tradeRecipe.getFloat("priceMultiplierA") : 0));
+            if (ca) {
+                reductionA += heroDiscount(player, tradeRecipe.getCompound("buyA").getByte("Count"));
+            }
             int reductionB = (int) (reputation * (tradeRecipe.containsFloat("priceMultiplierB") ? tradeRecipe.getFloat("priceMultiplierB") : 0));
 
             if (ca && cb) {

--- a/src/main/java/org/powernukkitx/level/Level.java
+++ b/src/main/java/org/powernukkitx/level/Level.java
@@ -1639,6 +1639,8 @@ public class Level implements Metadatable {
                 this.checkSleep();
             }
 
+            this.villageManager.tick(currentTick);
+
             if (!this.chunkPackets.isEmpty()) {
                 for (var entry : this.chunkPackets.entrySet()) {
                     long index = entry.getKey();

--- a/src/main/java/org/powernukkitx/level/format/leveldb/LevelDBStorage.java
+++ b/src/main/java/org/powernukkitx/level/format/leveldb/LevelDBStorage.java
@@ -11,6 +11,7 @@ import org.powernukkitx.level.village.VillageDwellers;
 import org.powernukkitx.level.village.VillageInfo;
 import org.powernukkitx.level.village.VillagePlayers;
 import org.powernukkitx.level.village.VillagePois;
+import org.powernukkitx.level.village.VillageRaid;
 import org.powernukkitx.nbt.tag.CompoundTag;
 import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.nbt.NbtUtils;
@@ -159,7 +160,8 @@ public final class LevelDBStorage {
                         VillageDwellers.fromCompound(data.get("DWELLERS")),
                         VillageInfo.fromCompound(data.get("INFO")),
                         VillagePlayers.fromCompound(data.get("PLAYERS")),
-                        VillagePois.fromCompound(data.get("POI")), null));
+                        VillagePois.fromCompound(data.get("POI")),
+                        data.containsKey("RAID") ? VillageRaid.fromCompound(data.get("RAID")) : null));
             }
         });
         return villages;
@@ -186,6 +188,9 @@ public final class LevelDBStorage {
                 batch.put(getVillageKey(villagePrefix, "INFO"), writeLittleEndianCompound(village.info().toCompound()));
                 batch.put(getVillageKey(villagePrefix, "POI"), writeLittleEndianCompound(village.pois().toCompound()));
                 batch.put(getVillageKey(villagePrefix, "PLAYERS"), writeLittleEndianCompound(village.players().toCompound()));
+                if (village.raid() != null) {
+                    batch.put(getVillageKey(villagePrefix, "RAID"), writeLittleEndianCompound(village.raid().toCompound()));
+                }
             }
             this.db.write(batch, new WriteOptions().sync(false));
         } catch (IOException e) {

--- a/src/main/java/org/powernukkitx/level/village/Village.java
+++ b/src/main/java/org/powernukkitx/level/village/Village.java
@@ -11,7 +11,7 @@ public final class Village {
     private VillageInfo info;
     private final VillagePlayers players;
     private final VillagePois pois;
-    private final @Nullable VillageRaid raid;
+    private @Nullable VillageRaid raid;
 
     public Village(UUID uuid, VillageDwellers dwellers, VillageInfo info, VillagePlayers players,
                    VillagePois pois, @Nullable VillageRaid raid) {
@@ -31,6 +31,7 @@ public final class Village {
     public @Nullable VillageRaid raid() { return raid; }
 
     public void setInfo(VillageInfo info) { this.info = info; }
+    public void setRaid(@Nullable VillageRaid raid) { this.raid = raid; }
     public long population() {
         return dwellers.dwellers().stream().mapToLong(dweller -> dweller.actors().size()).sum();
     }

--- a/src/main/java/org/powernukkitx/level/village/Village.java
+++ b/src/main/java/org/powernukkitx/level/village/Village.java
@@ -1,5 +1,7 @@
 package org.powernukkitx.level.village;
 
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import org.powernukkitx.math.BlockVector3;
 
 import javax.annotation.Nullable;
@@ -12,6 +14,8 @@ public final class Village {
     private final VillagePlayers players;
     private final VillagePois pois;
     private @Nullable VillageRaid raid;
+    private long bellRingTick;
+    private final Long2ObjectMap<BlockVector3> raiderPositions = new Long2ObjectOpenHashMap<>();
 
     public Village(UUID uuid, VillageDwellers dwellers, VillageInfo info, VillagePlayers players,
                    VillagePois pois, @Nullable VillageRaid raid) {
@@ -32,6 +36,20 @@ public final class Village {
 
     public void setInfo(VillageInfo info) { this.info = info; }
     public void setRaid(@Nullable VillageRaid raid) { this.raid = raid; }
+
+    /**
+     * @return the tick the bells of this village are due to ring again while a raid is being prepared
+     */
+    public long bellRingTick() { return bellRingTick; }
+
+    public void setBellRingTick(long bellRingTick) { this.bellRingTick = bellRingTick; }
+
+    /**
+     * @return the last position each raider of the running raid was seen at, used to tell a raider
+     * that died from one that only left the loaded chunks
+     */
+    public Long2ObjectMap<BlockVector3> raiderPositions() { return raiderPositions; }
+
     public long population() {
         return dwellers.dwellers().stream().mapToLong(dweller -> dweller.actors().size()).sum();
     }

--- a/src/main/java/org/powernukkitx/level/village/VillageInfo.java
+++ b/src/main/java/org/powernukkitx/level/village/VillageInfo.java
@@ -6,16 +6,15 @@ import org.powernukkitx.nbt.tag.CompoundTag;
 public record VillageInfo(long breedingCooldownTime, long golemSpawnCooldownTime, boolean initialized,
                           long mergeTick, long playerDetectionTick, BlockVector3 raidBoundsMin,
                           BlockVector3 raidBoundsMax, long tick, byte version, BlockVector3 boundsMin,
-                          BlockVector3 boundsMax, long villageHeroTime) {
+                          BlockVector3 boundsMax) {
 
     /**
-     * @param villageHeroTime the level time the last won raid keeps rewarding those who stand in
-     *                        the village until
+     * @param raidBoundsMin the corner the raid taking place in this village reaches to
+     * @param raidBoundsMax the opposite corner
      */
-    public VillageInfo withVillageHeroTime(long villageHeroTime) {
+    public VillageInfo withRaidBounds(BlockVector3 raidBoundsMin, BlockVector3 raidBoundsMax) {
         return new VillageInfo(breedingCooldownTime, golemSpawnCooldownTime, initialized, mergeTick,
-                playerDetectionTick, raidBoundsMin, raidBoundsMax, tick, version, boundsMin, boundsMax,
-                villageHeroTime);
+                playerDetectionTick, raidBoundsMin, raidBoundsMax, tick, version, boundsMin, boundsMax);
     }
 
     public static VillageInfo fromCompound(CompoundTag tag) {
@@ -25,8 +24,7 @@ public record VillageInfo(long breedingCooldownTime, long golemSpawnCooldownTime
                 new BlockVector3(tag.getInt("RX1"), tag.getInt("RY1"), tag.getInt("RZ1")),
                 tag.getLong("Tick"), tag.getByte("Version"),
                 new BlockVector3(tag.getInt("X0"), tag.getInt("Y0"), tag.getInt("Z0")),
-                new BlockVector3(tag.getInt("X1"), tag.getInt("Y1"), tag.getInt("Z1")),
-                tag.getLong("VHTime"));
+                new BlockVector3(tag.getInt("X1"), tag.getInt("Y1"), tag.getInt("Z1")));
     }
 
     public CompoundTag toCompound() {
@@ -38,7 +36,6 @@ public record VillageInfo(long breedingCooldownTime, long golemSpawnCooldownTime
                 .putInt("RX1", raidBoundsMax.x).putInt("RY1", raidBoundsMax.y).putInt("RZ1", raidBoundsMax.z)
                 .putLong("Tick", tick).putByte("Version", version)
                 .putInt("X0", boundsMin.x).putInt("Y0", boundsMin.y).putInt("Z0", boundsMin.z)
-                .putInt("X1", boundsMax.x).putInt("Y1", boundsMax.y).putInt("Z1", boundsMax.z)
-                .putLong("VHTime", villageHeroTime);
+                .putInt("X1", boundsMax.x).putInt("Y1", boundsMax.y).putInt("Z1", boundsMax.z);
     }
 }

--- a/src/main/java/org/powernukkitx/level/village/VillageInfo.java
+++ b/src/main/java/org/powernukkitx/level/village/VillageInfo.java
@@ -6,7 +6,17 @@ import org.powernukkitx.nbt.tag.CompoundTag;
 public record VillageInfo(long breedingCooldownTime, long golemSpawnCooldownTime, boolean initialized,
                           long mergeTick, long playerDetectionTick, BlockVector3 raidBoundsMin,
                           BlockVector3 raidBoundsMax, long tick, byte version, BlockVector3 boundsMin,
-                          BlockVector3 boundsMax) {
+                          BlockVector3 boundsMax, long villageHeroTime) {
+
+    /**
+     * @param villageHeroTime the level time the last won raid keeps rewarding those who stand in
+     *                        the village until
+     */
+    public VillageInfo withVillageHeroTime(long villageHeroTime) {
+        return new VillageInfo(breedingCooldownTime, golemSpawnCooldownTime, initialized, mergeTick,
+                playerDetectionTick, raidBoundsMin, raidBoundsMax, tick, version, boundsMin, boundsMax,
+                villageHeroTime);
+    }
 
     public static VillageInfo fromCompound(CompoundTag tag) {
         return new VillageInfo(tag.getLong("BDTime"), tag.getLong("GDTime"), tag.getBoolean("Initialized"),
@@ -15,7 +25,8 @@ public record VillageInfo(long breedingCooldownTime, long golemSpawnCooldownTime
                 new BlockVector3(tag.getInt("RX1"), tag.getInt("RY1"), tag.getInt("RZ1")),
                 tag.getLong("Tick"), tag.getByte("Version"),
                 new BlockVector3(tag.getInt("X0"), tag.getInt("Y0"), tag.getInt("Z0")),
-                new BlockVector3(tag.getInt("X1"), tag.getInt("Y1"), tag.getInt("Z1")));
+                new BlockVector3(tag.getInt("X1"), tag.getInt("Y1"), tag.getInt("Z1")),
+                tag.getLong("VHTime"));
     }
 
     public CompoundTag toCompound() {
@@ -27,6 +38,7 @@ public record VillageInfo(long breedingCooldownTime, long golemSpawnCooldownTime
                 .putInt("RX1", raidBoundsMax.x).putInt("RY1", raidBoundsMax.y).putInt("RZ1", raidBoundsMax.z)
                 .putLong("Tick", tick).putByte("Version", version)
                 .putInt("X0", boundsMin.x).putInt("Y0", boundsMin.y).putInt("Z0", boundsMin.z)
-                .putInt("X1", boundsMax.x).putInt("Y1", boundsMax.y).putInt("Z1", boundsMax.z);
+                .putInt("X1", boundsMax.x).putInt("Y1", boundsMax.y).putInt("Z1", boundsMax.z)
+                .putLong("VHTime", villageHeroTime);
     }
 }

--- a/src/main/java/org/powernukkitx/level/village/VillageManager.java
+++ b/src/main/java/org/powernukkitx/level/village/VillageManager.java
@@ -12,6 +12,7 @@ import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
 import org.powernukkitx.entity.data.profession.Profession;
 import org.powernukkitx.entity.effect.Effect;
 import org.powernukkitx.entity.effect.EffectType;
+import org.powernukkitx.entity.mob.EntityIllager;
 import org.powernukkitx.entity.passive.EntityVillagerV2;
 import org.powernukkitx.event.entity.CreatureSpawnEvent;
 import org.powernukkitx.level.Level;
@@ -348,6 +349,7 @@ public final class VillageManager {
     private @Nullable VillageRaid tickRaid(Village village, VillageRaid raid) {
         if (raid.isFinished()) {
             removeBossBars(village);
+            expireRaiders(raid, raid.status() == VillageRaid.STATUS_LOSS);
             village.raiderPositions().clear();
             return null;
         }
@@ -517,6 +519,21 @@ public final class VillageManager {
                 && player.getZ() > min.z && player.getZ() < max.z;
     }
 
+    private void expireRaiders(VillageRaid raid, boolean celebrating) {
+        for (long raiderId : raid.raiders()) {
+            Entity raider = level.getEntity(raiderId);
+            if (raider == null) {
+                continue;
+            }
+            if (!raider.hasCustomName()) {
+                raider.setPersistent(false);
+            }
+            if (celebrating && raider instanceof EntityIntelligent intelligent) {
+                intelligent.getMemoryStorage().put(CoreMemoryTypes.CELEBRATING, true);
+            }
+        }
+    }
+
     private void celebrate(Village village) {
         for (VillageDwellers.Dweller dweller : village.dwellers().dwellers()) {
             for (VillageDwellers.Actor actor : dweller.actors()) {
@@ -611,6 +628,9 @@ public final class VillageManager {
 
                 if (raider instanceof EntityIntelligent intelligent) {
                     intelligent.getMemoryStorage().put(CoreMemoryTypes.RAID_TARGET, target);
+                }
+                if (raider instanceof EntityIllager illager) {
+                    illager.setRaiding(true);
                 }
                 raider.setPersistent(true);
                 raider.spawnToAll();

--- a/src/main/java/org/powernukkitx/level/village/VillageManager.java
+++ b/src/main/java/org/powernukkitx/level/village/VillageManager.java
@@ -13,6 +13,7 @@ import org.powernukkitx.entity.data.profession.Profession;
 import org.powernukkitx.entity.effect.Effect;
 import org.powernukkitx.entity.effect.EffectType;
 import org.powernukkitx.entity.mob.EntityIllager;
+import org.powernukkitx.entity.mob.EntityRavager;
 import org.powernukkitx.entity.passive.EntityVillagerV2;
 import org.powernukkitx.event.entity.CreatureSpawnEvent;
 import org.powernukkitx.level.Level;
@@ -87,6 +88,8 @@ public final class VillageManager {
             {5, 2, 0, 0, 1},
             {0, 6, 1, 1, 3}
     };
+
+    private static final int[] RAID_GROUP_RIDERS = {-1, -1, -1, -1, 0, -1, 4};
 
     private final Level level;
     private final ConcurrentHashMap<UUID, Village> villages = new ConcurrentHashMap<>();
@@ -610,6 +613,8 @@ public final class VillageManager {
         BlockVector3 center = village.center();
         Vector3 target = new Vector3(center.x + 0.5, center.y, center.z + 0.5);
         List<Long> raiders = new ArrayList<>();
+        List<EntityRavager> mounts = new ArrayList<>();
+        List<Entity> riders = new ArrayList<>();
         for (int type = 0; type < RAIDER_TYPES.length; type++) {
             for (int spawned = 0; spawned < group[type]; spawned++) {
                 Entity raider = Entity.createEntity(RAIDER_TYPES[type], spawnPosition);
@@ -635,7 +640,16 @@ public final class VillageManager {
                 raider.setPersistent(true);
                 raider.spawnToAll();
                 raiders.add(raider.runtimeId());
+                if (raider instanceof EntityRavager ravager) {
+                    mounts.add(ravager);
+                } else if (type == RAID_GROUP_RIDERS[Math.min(raid.groupNumber(), RAID_GROUP_RIDERS.length - 1)]) {
+                    riders.add(raider);
+                }
             }
+        }
+
+        for (int i = 0; i < Math.min(mounts.size(), riders.size()); i++) {
+            mounts.get(i).mountEntity(riders.get(i));
         }
         return raiders;
     }

--- a/src/main/java/org/powernukkitx/level/village/VillageManager.java
+++ b/src/main/java/org/powernukkitx/level/village/VillageManager.java
@@ -64,7 +64,9 @@ public final class VillageManager {
     public static final int RAID_BOSS_BAR_VERTICAL_RADIUS = 44;
     public static final int RAID_SPAWN_MIN_RADIUS = 24;
     public static final int RAID_SPAWN_MAX_RADIUS = 64;
-    public static final int VILLAGE_HERO_DURATION = 40 * 60 * 20;
+    public static final int VILLAGE_HERO_DURATION = 260;
+    public static final int VILLAGE_HERO_TIME = 3 * Level.TIME_FULL;
+    public static final int VILLAGE_HERO_REFRESH_INTERVAL = 20;
     public static final int CELEBRATION_DURATION = 30 * 20;
     public static final int CELEBRATION_FIREWORK_INTERVAL = 90;
 
@@ -174,7 +176,7 @@ public final class VillageManager {
         BlockVector3 max = center.add(INITIAL_HORIZONTAL_RADIUS, INITIAL_VERTICAL_RADIUS,
                 INITIAL_HORIZONTAL_RADIUS);
         long tick = level.getCurrentTick();
-        VillageInfo info = new VillageInfo(0, 0, true, tick, tick, min, max, tick, (byte) 1, min, max);
+        VillageInfo info = new VillageInfo(0, 0, true, tick, tick, min, max, tick, (byte) 1, min, max, 0);
         Village village = new Village(UUID.randomUUID(), discoverDwellers(min, max, tick), info,
                 new VillagePlayers(new ListTag<Tag>()), discoverPois(min, max), null);
         villages.put(village.uuid(), village);
@@ -285,6 +287,9 @@ public final class VillageManager {
             return;
         }
         for (Village village : villages.values()) {
+            if (currentTick % VILLAGE_HERO_REFRESH_INTERVAL == 0) {
+                rewardVillageHeroes(village);
+            }
             VillageRaid raid = village.raid();
             if (raid == null) {
                 if (currentTick % 20 == 0) {
@@ -392,14 +397,9 @@ public final class VillageManager {
 
     private VillageRaid awardRewards(Village village, VillageRaid raid) {
         if (raid.ticks() == 0) {
-            BlockVector3 center = village.center();
-            for (Player player : level.getPlayers().values()) {
-                if (isInsideBossBarRange(center, player)) {
-                    player.addEffect(Effect.get(EffectType.VILLAGE_HERO)
-                            .setDuration(VILLAGE_HERO_DURATION)
-                            .setVisible(true));
-                }
-            }
+            long time = level.getTime();
+            village.setInfo(village.info().withVillageHeroTime(
+                    time - time % Level.TIME_FULL + Level.TIME_FULL + VILLAGE_HERO_TIME));
         }
 
         celebrate(village, raid.ticks());
@@ -407,6 +407,32 @@ public final class VillageManager {
         return ticks < CELEBRATION_DURATION
                 ? raid.withTicks(ticks)
                 : raid.withStatus(VillageRaid.STATUS_VICTORY);
+    }
+
+    /**
+     * Hands the reward of the last won raid to whoever stands in the village, until the three days it
+     * lasts are over. The effect is short lived and kept alive from here, so walking away drops it.
+     */
+    private void rewardVillageHeroes(Village village) {
+        long villageHeroTime = village.info().villageHeroTime();
+        if (villageHeroTime == 0) {
+            return;
+        }
+        if (level.getTime() >= villageHeroTime) {
+            village.setInfo(village.info().withVillageHeroTime(0));
+            return;
+        }
+        BlockVector3 min = village.info().raidBoundsMin();
+        BlockVector3 max = village.info().raidBoundsMax();
+        for (Player player : level.getPlayers().values()) {
+            if (player.getX() > min.x && player.getX() < max.x
+                    && player.getY() > min.y && player.getY() < max.y
+                    && player.getZ() > min.z && player.getZ() < max.z) {
+                player.addEffect(Effect.get(EffectType.VILLAGE_HERO)
+                        .setDuration(VILLAGE_HERO_DURATION)
+                        .setVisible(true));
+            }
+        }
     }
 
     private void celebrate(Village village, long ticks) {
@@ -891,7 +917,8 @@ public final class VillageManager {
 
     private static VillageInfo withBounds(VillageInfo info, BlockVector3 min, BlockVector3 max) {
         return new VillageInfo(info.breedingCooldownTime(), info.golemSpawnCooldownTime(), info.initialized(),
-                info.mergeTick(), info.playerDetectionTick(), min, max, info.tick(), info.version(), min, max);
+                info.mergeTick(), info.playerDetectionTick(), min, max, info.tick(), info.version(), min, max,
+                info.villageHeroTime());
     }
 
     private static boolean isInsideExpansionRange(VillageInfo info, BlockVector3 position) {

--- a/src/main/java/org/powernukkitx/level/village/VillageManager.java
+++ b/src/main/java/org/powernukkitx/level/village/VillageManager.java
@@ -74,16 +74,17 @@ public final class VillageManager {
 
     /**
      * How many of each {@link #RAIDER_TYPES} every group is made of, the first row being the first
-     * group. Easy stops after three groups, normal after five, hard runs the seven.
+     * group. Easy stops after three groups, normal after five, hard runs the seven. The two
+     * ravagers that carry a rider in the last groups count as a ravager plus the rider on foot.
      */
     private static final int[][] RAID_GROUPS = {
             {4, 0, 0, 0, 0},
             {3, 2, 0, 0, 0},
-            {3, 4, 1, 0, 0},
-            {3, 2, 0, 3, 1},
-            {5, 6, 1, 0, 1},
-            {0, 0, 2, 1, 0},
-            {0, 0, 1, 1, 2}
+            {3, 0, 1, 0, 0},
+            {3, 0, 0, 3, 0},
+            {1, 4, 2, 0, 1},
+            {5, 2, 0, 0, 1},
+            {0, 6, 1, 1, 3}
     };
 
     private final Level level;

--- a/src/main/java/org/powernukkitx/level/village/VillageManager.java
+++ b/src/main/java/org/powernukkitx/level/village/VillageManager.java
@@ -1,11 +1,19 @@
 package org.powernukkitx.level.village;
 
+import org.powernukkitx.Player;
 import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockBed;
 import org.powernukkitx.block.BlockBell;
+import org.powernukkitx.entity.Entity;
+import org.powernukkitx.entity.EntityID;
+import org.powernukkitx.entity.EntityIntelligent;
+import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
 import org.powernukkitx.entity.data.profession.Profession;
+import org.powernukkitx.entity.effect.Effect;
+import org.powernukkitx.entity.effect.EffectType;
 import org.powernukkitx.entity.passive.EntityVillagerV2;
 import org.powernukkitx.level.Level;
+import org.powernukkitx.level.Position;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.math.BlockFace;
 import org.powernukkitx.math.BlockVector3;
@@ -16,12 +24,15 @@ import org.powernukkitx.nbt.tag.Tag;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
@@ -37,8 +48,44 @@ public final class VillageManager {
     public static final int HORIZONTAL_EXPANSION_RANGE = 32;
     public static final int VERTICAL_EXPANSION_RANGE = 52;
 
+    /**
+     * How long a raid waits before its first group, once a player carrying bad omen has walked in.
+     */
+    public static final int RAID_PREPARATION_TIME = 600;
+    /**
+     * The lull between a group being wiped out and the next one being placed.
+     */
+    public static final int GROUP_COMPLETE_DELAY = 100;
+    public static final int ALLOWED_SPAWN_FAILURES = 3;
+    public static final int RAID_TRIGGER_HORIZONTAL_RADIUS = 32;
+    public static final int RAID_TRIGGER_VERTICAL_RADIUS = 11;
+    public static final int RAID_BOSS_BAR_HORIZONTAL_RADIUS = 64;
+    public static final int RAID_BOSS_BAR_VERTICAL_RADIUS = 44;
+    public static final int RAID_SPAWN_MIN_RADIUS = 24;
+    public static final int RAID_SPAWN_MAX_RADIUS = 64;
+    public static final int VILLAGE_HERO_DURATION = 40 * 60 * 20;
+
+    private static final String[] RAIDER_TYPES = {
+            EntityID.PILLAGER, EntityID.VINDICATOR, EntityID.RAVAGER, EntityID.WITCH, EntityID.EVOCATION_ILLAGER
+    };
+
+    /**
+     * How many of each {@link #RAIDER_TYPES} every group is made of, the first row being the first
+     * group. Easy stops after three groups, normal after five, hard runs the seven.
+     */
+    private static final int[][] RAID_GROUPS = {
+            {4, 0, 0, 0, 0},
+            {3, 2, 0, 0, 0},
+            {3, 4, 1, 0, 0},
+            {3, 2, 0, 3, 1},
+            {5, 6, 1, 0, 1},
+            {0, 0, 2, 1, 0},
+            {0, 0, 1, 1, 2}
+    };
+
     private final Level level;
     private final ConcurrentHashMap<UUID, Village> villages = new ConcurrentHashMap<>();
+    private final Map<UUID, Map<UUID, Long>> raidBossBars = new HashMap<>();
     private record JobSiteCache(Set<String> ids, int version) {
     }
 
@@ -222,6 +269,237 @@ public final class VillageManager {
     public void load(Collection<Village> villages) {
         this.villages.clear();
         villages.forEach(village -> this.villages.put(village.uuid(), village));
+    }
+
+    /**
+     * Advances the raids of this level. A raid starts when a player carrying bad omen walks into a
+     * village, then each group is placed in turn, watched until it is wiped out, and the rewards
+     * are handed out once the last one falls.
+     */
+    public void tick(long currentTick) {
+        if (villages.isEmpty()) {
+            return;
+        }
+        for (Village village : villages.values()) {
+            VillageRaid raid = village.raid();
+            if (raid == null) {
+                if (currentTick % 20 == 0) {
+                    tryStartRaid(village, currentTick);
+                }
+                continue;
+            }
+            village.setRaid(tickRaid(village, raid));
+            updateBossBars(village);
+        }
+    }
+
+    private void tryStartRaid(Village village, long currentTick) {
+        if (level.getServer().getDifficulty() == 0 || !village.isValid()) {
+            return;
+        }
+        BlockVector3 center = village.center();
+        for (Player player : level.getPlayers().values()) {
+            if (player.getEffect(EffectType.BAD_OMEN) == null || !isInsideRaidTrigger(center, player)) {
+                continue;
+            }
+            player.removeEffect(EffectType.BAD_OMEN);
+            village.setRaid(VillageRaid.starting(currentTick, groupCount(),
+                    new Vector3(center.x + 0.5, center.y, center.z + 0.5)));
+            return;
+        }
+    }
+
+    private int groupCount() {
+        return switch (level.getServer().getDifficulty()) {
+            case 1 -> 3;
+            case 2 -> 5;
+            default -> 7;
+        };
+    }
+
+    private @Nullable VillageRaid tickRaid(Village village, VillageRaid raid) {
+        if (raid.isFinished()) {
+            removeBossBars(village);
+            return null;
+        }
+        if (!village.isValid()) {
+            return raid.withStatus(VillageRaid.STATUS_LOSS);
+        }
+        return switch (raid.state()) {
+            case VillageRaid.STATE_PREPARATION -> tickPreparation(raid);
+            case VillageRaid.STATE_PICKING_SPAWN_POINT -> tickPickingSpawnPoint(village, raid);
+            case VillageRaid.STATE_SPAWNING_GROUP -> tickSpawningGroup(village, raid);
+            case VillageRaid.STATE_GROUP_IN_PLAY -> tickGroupInPlay(raid);
+            case VillageRaid.STATE_AWARDING_REWARDS -> awardRewards(village, raid);
+            default -> raid.withStatus(VillageRaid.STATUS_STOPPED);
+        };
+    }
+
+    private VillageRaid tickPreparation(VillageRaid raid) {
+        long ticks = raid.ticks() + 1;
+        return ticks >= RAID_PREPARATION_TIME
+                ? raid.withState(VillageRaid.STATE_PICKING_SPAWN_POINT)
+                : raid.withTicks(ticks);
+    }
+
+    private VillageRaid tickPickingSpawnPoint(Village village, VillageRaid raid) {
+        Vector3 spawnPoint = findSpawnPoint(village);
+        if (spawnPoint != null) {
+            return raid.withSpawnPoint(spawnPoint, 0).withState(VillageRaid.STATE_SPAWNING_GROUP);
+        }
+        int spawnFails = raid.spawnFails() + 1;
+        return spawnFails > ALLOWED_SPAWN_FAILURES
+                ? raid.withStatus(VillageRaid.STATUS_STOPPED)
+                : raid.withSpawnPoint(raid.spawnPosition(), spawnFails);
+    }
+
+    private VillageRaid tickSpawningGroup(Village village, VillageRaid raid) {
+        List<Long> raiders = spawnGroup(village, raid);
+        if (!raiders.isEmpty()) {
+            return raid.withGroup(raid.groupNumber() + 1, raiders, totalMaxHealth(raiders));
+        }
+        int spawnFails = raid.spawnFails() + 1;
+        return spawnFails > ALLOWED_SPAWN_FAILURES
+                ? raid.withStatus(VillageRaid.STATUS_STOPPED)
+                : raid.withSpawnPoint(raid.spawnPosition(), spawnFails)
+                        .withState(VillageRaid.STATE_PICKING_SPAWN_POINT);
+    }
+
+    private VillageRaid tickGroupInPlay(VillageRaid raid) {
+        List<Long> alive = new ArrayList<>();
+        for (long raiderId : raid.raiders()) {
+            Entity raider = level.getEntity(raiderId);
+            if (raider != null && !raider.isClosed() && raider.isAlive()) {
+                alive.add(raiderId);
+            }
+        }
+        if (!alive.isEmpty()) {
+            return raid.withRaiders(alive);
+        }
+        long ticks = raid.ticks() + 1;
+        if (ticks < GROUP_COMPLETE_DELAY) {
+            return raid.withRaiders(alive).withTicks(ticks);
+        }
+        return raid.withRaiders(alive).withState(raid.groupNumber() < raid.numberOfGroups()
+                ? VillageRaid.STATE_PICKING_SPAWN_POINT
+                : VillageRaid.STATE_AWARDING_REWARDS);
+    }
+
+    private VillageRaid awardRewards(Village village, VillageRaid raid) {
+        BlockVector3 center = village.center();
+        for (Player player : level.getPlayers().values()) {
+            if (isInsideBossBarRange(center, player)) {
+                player.addEffect(Effect.get(EffectType.VILLAGE_HERO)
+                        .setDuration(VILLAGE_HERO_DURATION)
+                        .setVisible(true));
+            }
+        }
+        return raid.withStatus(VillageRaid.STATUS_VICTORY);
+    }
+
+    private @Nullable Vector3 findSpawnPoint(Village village) {
+        BlockVector3 center = village.center();
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        for (int attempt = 0; attempt < 16; attempt++) {
+            double angle = random.nextDouble() * Math.PI * 2;
+            int distance = random.nextInt(RAID_SPAWN_MIN_RADIUS, RAID_SPAWN_MAX_RADIUS + 1);
+            int x = center.x + (int) (Math.cos(angle) * distance);
+            int z = center.z + (int) (Math.sin(angle) * distance);
+            if (level.getChunkIfLoaded(x >> 4, z >> 4) == null) {
+                continue;
+            }
+            int y = level.getHighestBlockAt(x, z) + 1;
+            if (level.getBlock(x, y, z, false).isAir()) {
+                return new Vector3(x + 0.5, y, z + 0.5);
+            }
+        }
+        return null;
+    }
+
+    private List<Long> spawnGroup(Village village, VillageRaid raid) {
+        int[] group = RAID_GROUPS[Math.min(raid.groupNumber(), RAID_GROUPS.length - 1)];
+        Position spawnPosition = Position.fromObject(raid.spawnPosition(), level);
+        BlockVector3 center = village.center();
+        Vector3 target = new Vector3(center.x + 0.5, center.y, center.z + 0.5);
+        List<Long> raiders = new ArrayList<>();
+        for (int type = 0; type < RAIDER_TYPES.length; type++) {
+            for (int spawned = 0; spawned < group[type]; spawned++) {
+                Entity raider = Entity.createEntity(RAIDER_TYPES[type], spawnPosition);
+                if (raider == null) {
+                    continue;
+                }
+                if (raider instanceof EntityIntelligent intelligent) {
+                    intelligent.getMemoryStorage().put(CoreMemoryTypes.RAID_TARGET, target);
+                }
+                raider.spawnToAll();
+                raiders.add(raider.getId());
+            }
+        }
+        return raiders;
+    }
+
+    private float totalMaxHealth(List<Long> raiders) {
+        float total = 0f;
+        for (long raiderId : raiders) {
+            Entity raider = level.getEntity(raiderId);
+            if (raider != null) {
+                total += raider.getMaxHealth();
+            }
+        }
+        return total;
+    }
+
+    private void updateBossBars(Village village) {
+        VillageRaid raid = village.raid();
+        if (raid == null) {
+            return;
+        }
+        Map<UUID, Long> bars = raidBossBars.computeIfAbsent(village.uuid(), uuid -> new HashMap<>());
+        BlockVector3 center = village.center();
+        int length = (int) (raid.bossBarProgress() * 100);
+        for (Player player : level.getPlayers().values()) {
+            UUID playerUuid = player.getUniqueId();
+            if (!isInsideBossBarRange(center, player)) {
+                Long removed = bars.remove(playerUuid);
+                if (removed != null) {
+                    player.removeBossBar(removed);
+                }
+                continue;
+            }
+            Long bossBarId = bars.get(playerUuid);
+            if (bossBarId == null) {
+                bars.put(playerUuid, player.createBossBar("%event.raid", length));
+            } else {
+                player.updateBossBar("%event.raid", length, bossBarId);
+            }
+        }
+    }
+
+    private void removeBossBars(Village village) {
+        Map<UUID, Long> bars = raidBossBars.remove(village.uuid());
+        if (bars == null) {
+            return;
+        }
+        for (Player player : level.getPlayers().values()) {
+            Long bossBarId = bars.get(player.getUniqueId());
+            if (bossBarId != null) {
+                player.removeBossBar(bossBarId);
+            }
+        }
+    }
+
+    private static boolean isInsideRaidTrigger(BlockVector3 center, Player player) {
+        return isInsideRange(center, player, RAID_TRIGGER_HORIZONTAL_RADIUS, RAID_TRIGGER_VERTICAL_RADIUS);
+    }
+
+    private static boolean isInsideBossBarRange(BlockVector3 center, Player player) {
+        return isInsideRange(center, player, RAID_BOSS_BAR_HORIZONTAL_RADIUS, RAID_BOSS_BAR_VERTICAL_RADIUS);
+    }
+
+    private static boolean isInsideRange(BlockVector3 center, Player player, int horizontal, int vertical) {
+        return Math.abs(player.getX() - center.x) <= horizontal
+                && Math.abs(player.getY() - center.y) <= vertical
+                && Math.abs(player.getZ() - center.z) <= horizontal;
     }
 
     public synchronized void onBlockChange(Block previous, Block current) {

--- a/src/main/java/org/powernukkitx/level/village/VillageManager.java
+++ b/src/main/java/org/powernukkitx/level/village/VillageManager.java
@@ -4,6 +4,7 @@ import org.powernukkitx.Player;
 import org.powernukkitx.block.Block;
 import org.powernukkitx.block.BlockBed;
 import org.powernukkitx.block.BlockBell;
+import org.powernukkitx.event.block.BellRingEvent;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.entity.EntityID;
 import org.powernukkitx.entity.EntityIntelligent;
@@ -11,12 +12,9 @@ import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
 import org.powernukkitx.entity.data.profession.Profession;
 import org.powernukkitx.entity.effect.Effect;
 import org.powernukkitx.entity.effect.EffectType;
-import org.powernukkitx.entity.item.EntityFireworksRocket;
 import org.powernukkitx.entity.passive.EntityVillagerV2;
 import org.powernukkitx.event.entity.CreatureSpawnEvent;
 import org.powernukkitx.level.Level;
-import org.powernukkitx.item.Item;
-import org.powernukkitx.item.ItemID;
 import org.powernukkitx.level.Position;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.math.BlockFace;
@@ -25,8 +23,9 @@ import org.powernukkitx.math.Vector3;
 import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.nbt.tag.ListTag;
 import org.powernukkitx.nbt.tag.Tag;
+import org.powernukkitx.command.utils.RawText;
 import org.powernukkitx.registry.Registries;
-import org.powernukkitx.utils.ItemHelper;
+import org.cloudburstmc.protocol.bedrock.data.SoundEvent;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,20 +54,19 @@ public final class VillageManager {
     public static final int HORIZONTAL_EXPANSION_RANGE = 32;
     public static final int VERTICAL_EXPANSION_RANGE = 52;
 
-    public static final int RAID_PREPARATION_TIME = 600;
-    public static final int GROUP_COMPLETE_DELAY = 100;
-    public static final int ALLOWED_SPAWN_FAILURES = 3;
-    public static final int RAID_TRIGGER_HORIZONTAL_RADIUS = 32;
-    public static final int RAID_TRIGGER_VERTICAL_RADIUS = 11;
-    public static final int RAID_BOSS_BAR_HORIZONTAL_RADIUS = 64;
-    public static final int RAID_BOSS_BAR_VERTICAL_RADIUS = 44;
-    public static final int RAID_SPAWN_MIN_RADIUS = 24;
-    public static final int RAID_SPAWN_MAX_RADIUS = 64;
-    public static final int VILLAGE_HERO_DURATION = 260;
-    public static final int VILLAGE_HERO_TIME = 3 * Level.TIME_FULL;
-    public static final int VILLAGE_HERO_REFRESH_INTERVAL = 20;
+    public static final int RAID_OMEN_DURATION = 600;
+    public static final int BELL_RING_MIN_INTERVAL = 60;
+    public static final int BELL_RING_INTERVAL_SPREAD = 40;
+    public static final int RAID_PREPARATION_TIME = 300;
+    public static final int GROUP_COMPLETE_DELAY = 40;
+    public static final int ALLOWED_SPAWN_FAILURES = 5;
+    public static final int RAID_BOUNDS_PADDING = 32;
+    public static final int RAID_TIMEOUT = 48000;
+    public static final int RAID_SPAWN_MIN_RADIUS = 32;
+    public static final int RAID_SPAWN_MAX_RADIUS = 48;
+    public static final int RAID_SPAWN_ATTEMPTS = 10;
+    public static final int VILLAGE_HERO_DURATION = 40 * 60 * 20;
     public static final int CELEBRATION_DURATION = 30 * 20;
-    public static final int CELEBRATION_FIREWORK_INTERVAL = 90;
 
     private static final String[] RAIDER_TYPES = {
             EntityID.PILLAGER, EntityID.VINDICATOR, EntityID.RAVAGER, EntityID.WITCH, EntityID.EVOCATION_ILLAGER
@@ -176,7 +174,7 @@ public final class VillageManager {
         BlockVector3 max = center.add(INITIAL_HORIZONTAL_RADIUS, INITIAL_VERTICAL_RADIUS,
                 INITIAL_HORIZONTAL_RADIUS);
         long tick = level.getCurrentTick();
-        VillageInfo info = new VillageInfo(0, 0, true, tick, tick, min, max, tick, (byte) 1, min, max, 0);
+        VillageInfo info = new VillageInfo(0, 0, true, tick, tick, min, max, tick, (byte) 1, min, max);
         Village village = new Village(UUID.randomUUID(), discoverDwellers(min, max, tick), info,
                 new VillagePlayers(new ListTag<Tag>()), discoverPois(min, max), null);
         villages.put(village.uuid(), village);
@@ -287,13 +285,10 @@ public final class VillageManager {
             return;
         }
         for (Village village : villages.values()) {
-            if (currentTick % VILLAGE_HERO_REFRESH_INTERVAL == 0) {
-                rewardVillageHeroes(village);
-            }
             VillageRaid raid = village.raid();
             if (raid == null) {
                 if (currentTick % 20 == 0) {
-                    tryStartRaid(village, currentTick);
+                    gainRaidOmen(village);
                 }
                 continue;
             }
@@ -303,20 +298,43 @@ public final class VillageManager {
         }
     }
 
-    private void tryStartRaid(Village village, long currentTick) {
-        if (level.getServer().getDifficulty() == 0 || !village.isValid()) {
-            return;
-        }
+    private void gainRaidOmen(Village village) {
         BlockVector3 center = village.center();
         for (Player player : level.getPlayers().values()) {
-            if (player.getEffect(EffectType.BAD_OMEN) == null || !isInsideRaidTrigger(center, player)) {
+            if (player.getEffect(EffectType.BAD_OMEN) == null
+                    || player.getEffect(EffectType.RAID_OMEN) != null
+                    || !isInside(village.info(), player.asBlockVector3())) {
                 continue;
             }
             player.removeEffect(EffectType.BAD_OMEN);
-            village.setRaid(VillageRaid.starting(currentTick, groupCount(),
-                    new Vector3(center.x + 0.5, center.y, center.z + 0.5)));
+            player.addEffect(Effect.get(EffectType.RAID_OMEN)
+                    .setDuration(RAID_OMEN_DURATION)
+                    .setVisible(true));
+
+            player.sendEffectAnimation(EffectType.RAID_OMEN);
+        }
+    }
+
+    /**
+     * Raids the village the player stands in, if it can be raided at all. Called when the omen that
+     * precedes a raid runs out.
+     */
+    public void triggerRaid(Player player) {
+        if (level.getServer().getDifficulty() == 0) {
             return;
         }
+        Village village = getVillageAt(player.asBlockVector3()).orElse(null);
+        if (village == null || !village.isValid() || village.raid() != null) {
+            return;
+        }
+        VillageInfo info = village.info();
+        village.setInfo(info.withRaidBounds(
+                info.boundsMin().add(-RAID_BOUNDS_PADDING, -RAID_BOUNDS_PADDING, -RAID_BOUNDS_PADDING),
+                info.boundsMax().add(RAID_BOUNDS_PADDING, RAID_BOUNDS_PADDING, RAID_BOUNDS_PADDING)));
+
+        BlockVector3 center = village.center();
+        village.setRaid(VillageRaid.starting(level.getCurrentTick(), groupCount(),
+                new Vector3(center.x + 0.5, center.y, center.z + 0.5)));
     }
 
     private int groupCount() {
@@ -330,23 +348,60 @@ public final class VillageManager {
     private @Nullable VillageRaid tickRaid(Village village, VillageRaid raid) {
         if (raid.isFinished()) {
             removeBossBars(village);
+            village.raiderPositions().clear();
             return null;
         }
         if (!village.isValid()) {
             return raid.withStatus(VillageRaid.STATUS_LOSS);
         }
+        if (!hasPlayerInRaidBounds(village)) {
+            return raid;
+        }
         return switch (raid.state()) {
-            case VillageRaid.STATE_PREPARATION -> tickPreparation(raid);
+            case VillageRaid.STATE_PREPARATION -> tickPreparation(village, raid);
             case VillageRaid.STATE_PICKING_SPAWN_POINT -> tickPickingSpawnPoint(village, raid);
             case VillageRaid.STATE_SPAWNING_GROUP -> tickSpawningGroup(village, raid);
-            case VillageRaid.STATE_GROUP_IN_PLAY -> tickGroupInPlay(raid);
+            case VillageRaid.STATE_GROUP_IN_PLAY -> tickGroupInPlay(village, raid);
             case VillageRaid.STATE_AWARDING_REWARDS -> awardRewards(village, raid);
             default -> raid.withStatus(VillageRaid.STATUS_STOPPED);
         };
     }
 
-    private VillageRaid tickPreparation(VillageRaid raid) {
+    private void playRaidHorn(Village village) {
+        BlockVector3 center = village.center();
+        level.addLevelSoundEvent(new Vector3(center.x + 0.5, center.y, center.z + 0.5),
+                SoundEvent.RAID_HORN);
+    }
+
+    private void ringBells(Village village) {
+        for (VillagePoiGroup group : village.pois().poi()) {
+            for (VillagePoi poi : group.instances()) {
+                if (poi.type() != PoiType.MEETING) {
+                    continue;
+                }
+                BlockVector3 position = poi.position();
+                if (level.getChunkIfLoaded(position.x >> 4, position.z >> 4) == null) {
+                    continue;
+                }
+                if (level.getBlock(position.x, position.y, position.z, false) instanceof BlockBell bell) {
+                    bell.ring(null, BellRingEvent.RingCause.UNKNOWN,
+                            BlockFace.fromIndex(ThreadLocalRandom.current().nextInt(2, 6)));
+                }
+            }
+        }
+    }
+
+    private VillageRaid tickPreparation(Village village, VillageRaid raid) {
         long ticks = raid.ticks() + 1;
+        if (ticks == 1) {
+            playRaidHorn(village);
+        }
+        long currentTick = level.getCurrentTick();
+        if (currentTick > village.bellRingTick()) {
+            village.setBellRingTick(currentTick + BELL_RING_MIN_INTERVAL
+                    + ThreadLocalRandom.current().nextInt(BELL_RING_INTERVAL_SPREAD));
+            ringBells(village);
+        }
         return ticks >= RAID_PREPARATION_TIME
                 ? raid.withState(VillageRaid.STATE_PICKING_SPAWN_POINT)
                 : raid.withTicks(ticks);
@@ -375,34 +430,65 @@ public final class VillageManager {
                         .withState(VillageRaid.STATE_PICKING_SPAWN_POINT);
     }
 
-    private VillageRaid tickGroupInPlay(VillageRaid raid) {
+    private VillageRaid tickGroupInPlay(Village village, VillageRaid raid) {
         List<Long> alive = new ArrayList<>();
         for (long raiderId : raid.raiders()) {
             Entity raider = level.getEntity(raiderId);
-            if (raider != null && !raider.isClosed() && raider.isAlive()) {
+            if (raider != null) {
+                if (raider.isClosed() || !raider.isAlive()) {
+                    village.raiderPositions().remove(raiderId);
+                    continue;
+                }
+                village.raiderPositions().put(raiderId, raider.asBlockVector3());
                 alive.add(raiderId);
+                continue;
             }
+            BlockVector3 last = village.raiderPositions().get(raiderId);
+            if (last == null || level.getChunkIfLoaded(last.x >> 4, last.z >> 4) == null) {
+                alive.add(raiderId);
+                continue;
+            }
+            village.raiderPositions().remove(raiderId);
         }
         if (!alive.isEmpty()) {
-            return raid.withRaiders(alive);
+            long inPlay = raid.ticks() + 1;
+            if (inPlay < RAID_TIMEOUT) {
+                return raid.withRaiders(alive).withTicks(inPlay);
+            }
+            for (Player player : level.getPlayers().values()) {
+                if (isInsideRaidBounds(village, player)) {
+                    player.sendRawTextMessage(RawText.fromRawText(
+                            "{\"rawtext\":[{\"translate\":\"raid.expiry\"}]}"));
+                }
+            }
+            return raid.withStatus(VillageRaid.STATUS_STOPPED);
+        }
+        if (!raid.raiders().isEmpty()) {
+            return raid.withRaiders(alive).withTicks(0);
         }
         long ticks = raid.ticks() + 1;
         if (ticks < GROUP_COMPLETE_DELAY) {
             return raid.withRaiders(alive).withTicks(ticks);
         }
         return raid.withRaiders(alive).withState(raid.groupNumber() < raid.numberOfGroups()
-                ? VillageRaid.STATE_PICKING_SPAWN_POINT
+                ? VillageRaid.STATE_PREPARATION
                 : VillageRaid.STATE_AWARDING_REWARDS);
     }
 
     private VillageRaid awardRewards(Village village, VillageRaid raid) {
         if (raid.ticks() == 0) {
-            long time = level.getTime();
-            village.setInfo(village.info().withVillageHeroTime(
-                    time - time % Level.TIME_FULL + Level.TIME_FULL + VILLAGE_HERO_TIME));
+            playRaidHorn(village);
+            for (Player player : level.getPlayers().values()) {
+                if (isInsideRaidBounds(village, player)) {
+                    player.addEffect(Effect.get(EffectType.VILLAGE_HERO)
+                            .setDuration(VILLAGE_HERO_DURATION)
+                            .setVisible(true));
+                    player.sendEffectAnimation(EffectType.VILLAGE_HERO);
+                }
+            }
+            celebrate(village);
         }
 
-        celebrate(village, raid.ticks());
         long ticks = raid.ticks() + 1;
         return ticks < CELEBRATION_DURATION
                 ? raid.withTicks(ticks)
@@ -413,50 +499,66 @@ public final class VillageManager {
      * Hands the reward of the last won raid to whoever stands in the village, until the three days it
      * lasts are over. The effect is short lived and kept alive from here, so walking away drops it.
      */
-    private void rewardVillageHeroes(Village village) {
-        long villageHeroTime = village.info().villageHeroTime();
-        if (villageHeroTime == 0) {
-            return;
-        }
-        if (level.getTime() >= villageHeroTime) {
-            village.setInfo(village.info().withVillageHeroTime(0));
-            return;
-        }
-        BlockVector3 min = village.info().raidBoundsMin();
-        BlockVector3 max = village.info().raidBoundsMax();
+
+    private boolean hasPlayerInRaidBounds(Village village) {
         for (Player player : level.getPlayers().values()) {
-            if (player.getX() > min.x && player.getX() < max.x
-                    && player.getY() > min.y && player.getY() < max.y
-                    && player.getZ() > min.z && player.getZ() < max.z) {
-                player.addEffect(Effect.get(EffectType.VILLAGE_HERO)
-                        .setDuration(VILLAGE_HERO_DURATION)
-                        .setVisible(true));
+            if (isInsideRaidBounds(village, player)) {
+                return true;
             }
         }
+        return false;
     }
 
-    private void celebrate(Village village, long ticks) {
+    private static boolean isInsideRaidBounds(Village village, Player player) {
+        BlockVector3 min = village.info().raidBoundsMin();
+        BlockVector3 max = village.info().raidBoundsMax();
+        return player.getX() > min.x && player.getX() < max.x
+                && player.getY() > min.y && player.getY() < max.y
+                && player.getZ() > min.z && player.getZ() < max.z;
+    }
+
+    private void celebrate(Village village) {
         for (VillageDwellers.Dweller dweller : village.dwellers().dwellers()) {
             for (VillageDwellers.Actor actor : dweller.actors()) {
-                if (!(level.getEntity(actor.id()) instanceof EntityVillagerV2 villager)
-                        || (ticks + villager.runtimeId()) % CELEBRATION_FIREWORK_INTERVAL != 0) {
-                    continue;
+                if (level.getEntity(actor.id()) instanceof EntityVillagerV2 villager) {
+                    villager.getMemoryStorage().put(CoreMemoryTypes.CELEBRATING, true);
                 }
-                CompoundTag nbt = Entity.getDefaultNBT(villager.add(0, villager.getEyeHeight(), 0));
-                nbt.putCompound("FireworkItem", ItemHelper.write(Item.get(ItemID.FIREWORK_ROCKET)));
-                new EntityFireworksRocket(villager.getChunk(), nbt).spawnToAll();
             }
         }
     }
 
     private @Nullable Vector3 findSpawnPoint(Village village) {
+        Player anchor = findSpawnAnchor(village);
+        if (anchor == null) {
+            return null;
+        }
         BlockVector3 center = village.center();
+        double awayX = anchor.getX() - (center.x + 0.5);
+        double awayZ = anchor.getZ() - (center.z + 0.5);
+        double length = Math.sqrt(awayX * awayX + awayZ * awayZ);
+        if (length < 1.0E-4) {
+            awayX = 0;
+            awayZ = 0;
+        } else {
+            awayX /= length;
+            awayZ /= length;
+        }
+
         ThreadLocalRandom random = ThreadLocalRandom.current();
-        for (int attempt = 0; attempt < 16; attempt++) {
+        for (int attempt = 0; attempt < RAID_SPAWN_ATTEMPTS; attempt++) {
             double angle = random.nextDouble() * Math.PI * 2;
-            int distance = random.nextInt(RAID_SPAWN_MIN_RADIUS, RAID_SPAWN_MAX_RADIUS + 1);
-            int x = center.x + (int) (Math.cos(angle) * distance);
-            int z = center.z + (int) (Math.sin(angle) * distance);
+            double distance = RAID_SPAWN_MIN_RADIUS
+                    + random.nextDouble() * (RAID_SPAWN_MAX_RADIUS - RAID_SPAWN_MIN_RADIUS);
+            double offsetX = Math.cos(angle) * distance;
+            double offsetZ = Math.sin(angle) * distance;
+            double dot = offsetX * awayX + offsetZ * awayZ;
+            if (dot < 0) {
+                offsetX -= awayX * dot * 2;
+                offsetZ -= awayZ * dot * 2;
+            }
+
+            int x = (int) Math.floor(anchor.getX() + offsetX);
+            int z = (int) Math.floor(anchor.getZ() + offsetZ);
             if (level.getChunkIfLoaded(x >> 4, z >> 4) == null) {
                 continue;
             }
@@ -466,6 +568,23 @@ public final class VillageManager {
             }
         }
         return null;
+    }
+
+    private @Nullable Player findSpawnAnchor(Village village) {
+        BlockVector3 center = village.center();
+        Player closest = null;
+        double closestDistance = Double.MAX_VALUE;
+        for (Player player : level.getPlayers().values()) {
+            if (!isInsideRaidBounds(village, player)) {
+                continue;
+            }
+            double distance = player.distanceSquared(new Vector3(center.x + 0.5, center.y, center.z + 0.5));
+            if (distance < closestDistance) {
+                closestDistance = distance;
+                closest = player;
+            }
+        }
+        return closest;
     }
 
     private List<Long> spawnGroup(Village village, VillageRaid raid) {
@@ -523,7 +642,7 @@ public final class VillageManager {
         int length = (int) (raid.bossBarProgress() * 100);
         for (Player player : level.getPlayers().values()) {
             UUID playerUuid = player.getUniqueId();
-            if (!isInsideBossBarRange(center, player)) {
+            if (!isInsideRaidBounds(village, player)) {
                 Long removed = bars.remove(playerUuid);
                 if (removed != null) {
                     player.removeBossBar(removed);
@@ -550,9 +669,12 @@ public final class VillageManager {
     }
 
     private static String bossBarTitle(VillageRaid raid) {
+        if (raid.status() == VillageRaid.STATUS_LOSS) {
+            return "%raid.name - %raid.defeat";
+        }
         return switch (raid.state()) {
-            case VillageRaid.STATE_GROUP_IN_PLAY -> "%raid.progress " + raid.raiders().size();
-            case VillageRaid.STATE_AWARDING_REWARDS -> "%raid.victory";
+            case VillageRaid.STATE_GROUP_IN_PLAY -> "%raid.name - %raid.progress " + raid.raiders().size();
+            case VillageRaid.STATE_AWARDING_REWARDS -> "%raid.name - %raid.victory";
             default -> "%raid.name";
         };
     }
@@ -568,20 +690,6 @@ public final class VillageManager {
                 player.removeBossBar(bossBarId);
             }
         }
-    }
-
-    private static boolean isInsideRaidTrigger(BlockVector3 center, Player player) {
-        return isInsideRange(center, player, RAID_TRIGGER_HORIZONTAL_RADIUS, RAID_TRIGGER_VERTICAL_RADIUS);
-    }
-
-    private static boolean isInsideBossBarRange(BlockVector3 center, Player player) {
-        return isInsideRange(center, player, RAID_BOSS_BAR_HORIZONTAL_RADIUS, RAID_BOSS_BAR_VERTICAL_RADIUS);
-    }
-
-    private static boolean isInsideRange(BlockVector3 center, Player player, int horizontal, int vertical) {
-        return Math.abs(player.getX() - center.x) <= horizontal
-                && Math.abs(player.getY() - center.y) <= vertical
-                && Math.abs(player.getZ() - center.z) <= horizontal;
     }
 
     public synchronized void onBlockChange(Block previous, Block current) {
@@ -917,8 +1025,7 @@ public final class VillageManager {
 
     private static VillageInfo withBounds(VillageInfo info, BlockVector3 min, BlockVector3 max) {
         return new VillageInfo(info.breedingCooldownTime(), info.golemSpawnCooldownTime(), info.initialized(),
-                info.mergeTick(), info.playerDetectionTick(), min, max, info.tick(), info.version(), min, max,
-                info.villageHeroTime());
+                info.mergeTick(), info.playerDetectionTick(), min, max, info.tick(), info.version(), min, max);
     }
 
     private static boolean isInsideExpansionRange(VillageInfo info, BlockVector3 position) {

--- a/src/main/java/org/powernukkitx/level/village/VillageManager.java
+++ b/src/main/java/org/powernukkitx/level/village/VillageManager.java
@@ -11,15 +11,22 @@ import org.powernukkitx.entity.ai.memory.CoreMemoryTypes;
 import org.powernukkitx.entity.data.profession.Profession;
 import org.powernukkitx.entity.effect.Effect;
 import org.powernukkitx.entity.effect.EffectType;
+import org.powernukkitx.entity.item.EntityFireworksRocket;
 import org.powernukkitx.entity.passive.EntityVillagerV2;
+import org.powernukkitx.event.entity.CreatureSpawnEvent;
 import org.powernukkitx.level.Level;
+import org.powernukkitx.item.Item;
+import org.powernukkitx.item.ItemID;
 import org.powernukkitx.level.Position;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.math.BlockFace;
 import org.powernukkitx.math.BlockVector3;
 import org.powernukkitx.math.Vector3;
+import org.powernukkitx.nbt.tag.CompoundTag;
 import org.powernukkitx.nbt.tag.ListTag;
 import org.powernukkitx.nbt.tag.Tag;
+import org.powernukkitx.registry.Registries;
+import org.powernukkitx.utils.ItemHelper;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -48,13 +55,7 @@ public final class VillageManager {
     public static final int HORIZONTAL_EXPANSION_RANGE = 32;
     public static final int VERTICAL_EXPANSION_RANGE = 52;
 
-    /**
-     * How long a raid waits before its first group, once a player carrying bad omen has walked in.
-     */
     public static final int RAID_PREPARATION_TIME = 600;
-    /**
-     * The lull between a group being wiped out and the next one being placed.
-     */
     public static final int GROUP_COMPLETE_DELAY = 100;
     public static final int ALLOWED_SPAWN_FAILURES = 3;
     public static final int RAID_TRIGGER_HORIZONTAL_RADIUS = 32;
@@ -64,6 +65,8 @@ public final class VillageManager {
     public static final int RAID_SPAWN_MIN_RADIUS = 24;
     public static final int RAID_SPAWN_MAX_RADIUS = 64;
     public static final int VILLAGE_HERO_DURATION = 40 * 60 * 20;
+    public static final int CELEBRATION_DURATION = 30 * 20;
+    public static final int CELEBRATION_FIREWORK_INTERVAL = 90;
 
     private static final String[] RAIDER_TYPES = {
             EntityID.PILLAGER, EntityID.VINDICATOR, EntityID.RAVAGER, EntityID.WITCH, EntityID.EVOCATION_ILLAGER
@@ -289,6 +292,7 @@ public final class VillageManager {
                 continue;
             }
             village.setRaid(tickRaid(village, raid));
+            setDwellersHiding(village, village.raid() != null);
             updateBossBars(village);
         }
     }
@@ -386,15 +390,36 @@ public final class VillageManager {
     }
 
     private VillageRaid awardRewards(Village village, VillageRaid raid) {
-        BlockVector3 center = village.center();
-        for (Player player : level.getPlayers().values()) {
-            if (isInsideBossBarRange(center, player)) {
-                player.addEffect(Effect.get(EffectType.VILLAGE_HERO)
-                        .setDuration(VILLAGE_HERO_DURATION)
-                        .setVisible(true));
+        if (raid.ticks() == 0) {
+            BlockVector3 center = village.center();
+            for (Player player : level.getPlayers().values()) {
+                if (isInsideBossBarRange(center, player)) {
+                    player.addEffect(Effect.get(EffectType.VILLAGE_HERO)
+                            .setDuration(VILLAGE_HERO_DURATION)
+                            .setVisible(true));
+                }
             }
         }
-        return raid.withStatus(VillageRaid.STATUS_VICTORY);
+
+        celebrate(village, raid.ticks());
+        long ticks = raid.ticks() + 1;
+        return ticks < CELEBRATION_DURATION
+                ? raid.withTicks(ticks)
+                : raid.withStatus(VillageRaid.STATUS_VICTORY);
+    }
+
+    private void celebrate(Village village, long ticks) {
+        for (VillageDwellers.Dweller dweller : village.dwellers().dwellers()) {
+            for (VillageDwellers.Actor actor : dweller.actors()) {
+                if (!(level.getEntity(actor.id()) instanceof EntityVillagerV2 villager)
+                        || (ticks + villager.runtimeId()) % CELEBRATION_FIREWORK_INTERVAL != 0) {
+                    continue;
+                }
+                CompoundTag nbt = Entity.getDefaultNBT(villager.add(0, villager.getEyeHeight(), 0));
+                nbt.putCompound("FireworkItem", ItemHelper.write(Item.get(ItemID.FIREWORK_ROCKET)));
+                new EntityFireworksRocket(villager.getChunk(), nbt).spawnToAll();
+            }
+        }
     }
 
     private @Nullable Vector3 findSpawnPoint(Village village) {
@@ -428,11 +453,22 @@ public final class VillageManager {
                 if (raider == null) {
                     continue;
                 }
+
+                CreatureSpawnEvent event = new CreatureSpawnEvent(
+                        Registries.ENTITY.getEntityNetworkId(RAIDER_TYPES[type]), spawnPosition,
+                        new CompoundTag(), CreatureSpawnEvent.SpawnReason.VILLAGE_INVASION);
+                level.getServer().getPluginManager().callEvent(event);
+                if (event.isCancelled()) {
+                    raider.close();
+                    continue;
+                }
+
                 if (raider instanceof EntityIntelligent intelligent) {
                     intelligent.getMemoryStorage().put(CoreMemoryTypes.RAID_TARGET, target);
                 }
+                raider.setPersistent(true);
                 raider.spawnToAll();
-                raiders.add(raider.getId());
+                raiders.add(raider.runtimeId());
             }
         }
         return raiders;
@@ -456,6 +492,7 @@ public final class VillageManager {
         }
         Map<UUID, Long> bars = raidBossBars.computeIfAbsent(village.uuid(), uuid -> new HashMap<>());
         BlockVector3 center = village.center();
+        String title = bossBarTitle(raid);
         int length = (int) (raid.bossBarProgress() * 100);
         for (Player player : level.getPlayers().values()) {
             UUID playerUuid = player.getUniqueId();
@@ -468,11 +505,29 @@ public final class VillageManager {
             }
             Long bossBarId = bars.get(playerUuid);
             if (bossBarId == null) {
-                bars.put(playerUuid, player.createBossBar("%event.raid", length));
+                bars.put(playerUuid, player.createBossBar(title, length));
             } else {
-                player.updateBossBar("%event.raid", length, bossBarId);
+                player.updateBossBar(title, length, bossBarId);
             }
         }
+    }
+
+    private void setDwellersHiding(Village village, boolean hiding) {
+        for (VillageDwellers.Dweller dweller : village.dwellers().dwellers()) {
+            for (VillageDwellers.Actor actor : dweller.actors()) {
+                if (level.getEntity(actor.id()) instanceof EntityVillagerV2 villager) {
+                    villager.getMemoryStorage().put(CoreMemoryTypes.HIDING_FROM_RAID, hiding);
+                }
+            }
+        }
+    }
+
+    private static String bossBarTitle(VillageRaid raid) {
+        return switch (raid.state()) {
+            case VillageRaid.STATE_GROUP_IN_PLAY -> "%raid.progress " + raid.raiders().size();
+            case VillageRaid.STATE_AWARDING_REWARDS -> "%raid.victory";
+            default -> "%raid.name";
+        };
     }
 
     private void removeBossBars(Village village) {

--- a/src/main/java/org/powernukkitx/level/village/VillageRaid.java
+++ b/src/main/java/org/powernukkitx/level/village/VillageRaid.java
@@ -10,18 +10,9 @@ import java.util.List;
 public record VillageRaid(long gameTick, byte groupNumber, byte numberOfGroups, byte numberOfRaiders,
                           List<Long> raiders, byte spawnFails, Vector3 spawnPosition, int state, int status,
                           long ticks, float totalMaxHealth) {
-    /**
-     * The raid waits for the players to gather before its first group shows up.
-     */
     public static final int STATE_PREPARATION = 0;
-    /**
-     * A spawn point is being looked for, outside the village and away from the players.
-     */
     public static final int STATE_PICKING_SPAWN_POINT = 1;
     public static final int STATE_SPAWNING_GROUP = 2;
-    /**
-     * The group is alive and the raid waits for it to be wiped out.
-     */
     public static final int STATE_GROUP_IN_PLAY = 3;
     public static final int STATE_AWARDING_REWARDS = 4;
     public static final int STATE_FINISHED = 5;

--- a/src/main/java/org/powernukkitx/level/village/VillageRaid.java
+++ b/src/main/java/org/powernukkitx/level/village/VillageRaid.java
@@ -10,8 +10,96 @@ import java.util.List;
 public record VillageRaid(long gameTick, byte groupNumber, byte numberOfGroups, byte numberOfRaiders,
                           List<Long> raiders, byte spawnFails, Vector3 spawnPosition, int state, int status,
                           long ticks, float totalMaxHealth) {
+    /**
+     * The raid waits for the players to gather before its first group shows up.
+     */
+    public static final int STATE_PREPARATION = 0;
+    /**
+     * A spawn point is being looked for, outside the village and away from the players.
+     */
+    public static final int STATE_PICKING_SPAWN_POINT = 1;
+    public static final int STATE_SPAWNING_GROUP = 2;
+    /**
+     * The group is alive and the raid waits for it to be wiped out.
+     */
+    public static final int STATE_GROUP_IN_PLAY = 3;
+    public static final int STATE_AWARDING_REWARDS = 4;
+    public static final int STATE_FINISHED = 5;
+
+    public static final int STATUS_ONGOING = 0;
+    public static final int STATUS_VICTORY = 1;
+    public static final int STATUS_LOSS = 2;
+    public static final int STATUS_STOPPED = 3;
+
     public VillageRaid {
         raiders = List.copyOf(raiders);
+    }
+
+    /**
+     * Creates the raid a village starts with, before its first group has been placed.
+     *
+     * @param gameTick      the tick the raid started on
+     * @param groupCount    how many groups the difficulty calls for
+     * @param spawnPosition the village center, until a spawn point is picked
+     */
+    public static VillageRaid starting(long gameTick, int groupCount, Vector3 spawnPosition) {
+        return new VillageRaid(gameTick, (byte) 0, (byte) groupCount, (byte) 0, List.of(), (byte) 0,
+                spawnPosition, STATE_PREPARATION, STATUS_ONGOING, 0L, 0f);
+    }
+
+    public boolean isFinished() {
+        return state == STATE_FINISHED;
+    }
+
+    /**
+     * @return how full the boss bar is, from 0 to 1: the preparation running out, then the share of
+     * the current group still standing
+     */
+    public float bossBarProgress() {
+        return switch (state) {
+            case STATE_PREPARATION -> Math.clamp(ticks / (float) VillageManager.RAID_PREPARATION_TIME, 0f, 1f);
+            case STATE_PICKING_SPAWN_POINT, STATE_SPAWNING_GROUP -> 1f;
+            case STATE_GROUP_IN_PLAY -> numberOfRaiders <= 0
+                    ? 0f
+                    : Math.clamp(raiders.size() / (float) numberOfRaiders, 0f, 1f);
+            default -> 0f;
+        };
+    }
+
+    public VillageRaid withState(int state) {
+        return new VillageRaid(gameTick, groupNumber, numberOfGroups, numberOfRaiders, raiders, spawnFails,
+                spawnPosition, state, status, 0L, totalMaxHealth);
+    }
+
+    public VillageRaid withStatus(int status) {
+        return new VillageRaid(gameTick, groupNumber, numberOfGroups, numberOfRaiders, raiders, spawnFails,
+                spawnPosition, STATE_FINISHED, status, ticks, totalMaxHealth);
+    }
+
+    public VillageRaid withTicks(long ticks) {
+        return new VillageRaid(gameTick, groupNumber, numberOfGroups, numberOfRaiders, raiders, spawnFails,
+                spawnPosition, state, status, ticks, totalMaxHealth);
+    }
+
+    public VillageRaid withRaiders(List<Long> raiders) {
+        return new VillageRaid(gameTick, groupNumber, numberOfGroups, numberOfRaiders, raiders, spawnFails,
+                spawnPosition, state, status, ticks, totalMaxHealth);
+    }
+
+    /**
+     * @param spawnFails how many times in a row no room was found for the current group
+     */
+    public VillageRaid withSpawnPoint(Vector3 spawnPosition, int spawnFails) {
+        return new VillageRaid(gameTick, groupNumber, numberOfGroups, numberOfRaiders, raiders, (byte) spawnFails,
+                spawnPosition, state, status, ticks, totalMaxHealth);
+    }
+
+    /**
+     * Records a group that has just been placed, and moves the raid on to watching it.
+     */
+    public VillageRaid withGroup(int groupNumber, List<Long> raiders, float totalMaxHealth) {
+        return new VillageRaid(gameTick, (byte) groupNumber, numberOfGroups, (byte) raiders.size(), raiders,
+                (byte) 0, spawnPosition, STATE_GROUP_IN_PLAY, status, 0L, totalMaxHealth);
     }
 
     public static VillageRaid fromCompound(CompoundTag root) {

--- a/src/main/java/org/powernukkitx/registry/EffectRegistry.java
+++ b/src/main/java/org/powernukkitx/registry/EffectRegistry.java
@@ -47,12 +47,13 @@ public class EffectRegistry implements IRegistry<EffectType, Effect, Class<? ext
         // Effects that cannot be realized at the moment
         register0(EffectType.BAD_OMEN, EffectBadOmen.class);
         register0(EffectType.TRIAL_OMEN, EffectTrialOmen.class);
-        //register0(EffectType.VILLAGE_HERO, VillageHeroEffect.class);
+        register0(EffectType.VILLAGE_HERO, EffectVillageHero.class);
         register0(EffectType.DARKNESS, EffectDarkness.class);
         register0(EffectType.WIND_CHARGED, EffectWindCharged.class);
         register0(EffectType.WEAVING, EffectWeaving.class);
         register0(EffectType.OOZING, EffectOozing.class);
         register0(EffectType.INFESTED, EffectInfested.class);
+        register0(EffectType.RAID_OMEN, EffectRaidOmen.class);
     }
 
     @Override

--- a/src/main/java/org/powernukkitx/utils/DummyBossBar.java
+++ b/src/main/java/org/powernukkitx/utils/DummyBossBar.java
@@ -28,6 +28,7 @@ public class DummyBossBar {
     private static final BossBarColor DEFAULT_NETWORK_COLOR = BossBarColor.PINK;
     private static final BossBarOverlay DEFAULT_OVERLAY = BossBarOverlay.PROGRESS;
     private static final float ENTITY_Y = -74f;
+    private static final float MINIMUM_ENTITY_HEALTH = 1f;
 
     private final Player player;
     private final long bossBarId;
@@ -190,7 +191,7 @@ public class DummyBossBar {
     private void sendAttributes() {
         final Attribute attr = Attribute.getAttribute(Attribute.HEALTH);
         attr.setMaxValue(100f);
-        attr.setValue(Math.max(0f, Math.min(100f, this.length)));
+        attr.setValue(Math.max(MINIMUM_ENTITY_HEALTH, Math.min(100f, this.length)));
 
         final UpdateAttributesPacket packet = new UpdateAttributesPacket();
         packet.setRuntimeID(this.bossBarId);


### PR DESCRIPTION

## What does this PR do?
It implements village raids.

It also implement:
- `Player.sendEffectAnimation(EffectType)` sends the on screen animation of an effect.
- `CelebrateSurviveExecutor`, the villager behaviour that throws fireworks after a won
  raid.
- `RaiderCelebrationExecutor`, the raiders behaviour that make raiders jump and play sound after a lost
  raid.
- `EffectVillageHero`
- The `raider_drops` table when illager die during a raid.
## Why?
Raids didn not exist..

Sources:
[player.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/entities/player.json)
for the bad omen to raid omen chain,
[raid_group_0 to raid_group_6](https://github.com/Mojang/bedrock-samples/tree/main/behavior_pack/spawn_groups)
for the seven waves,
[villager_v2.json](https://github.com/Mojang/bedrock-samples/blob/main/behavior_pack/entities/villager_v2.json)
for `celebrate_survive`, and
[Minecraft Wiki](https://minecraft.wiki/w/Raid) for the trade discount formula.

## Type of change

- [ ] Bug Fix
- [x] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:**  c9e1b9b7d.
- **Bedrock client version:** 26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. Did a entire raid in vanilla, wrote in notebook EVERY information
2. Claude reproduced maths, me did the rest.
3. Did a entire raid in PNX

- [x] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|  Claude Opus 5     |   Browsed minecraft wiki, did the javadocs, did the waves array (RAID_GROUPS), did the maths, also gived me a implementation plan (plan mode), did commits for me        |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
