### PR TITLE
fix(command): compare against the right objective in execute if score

### DIFF
--- a/src/main/java/org/powernukkitx/command/defaults/ExecuteCommand.java
+++ b/src/main/java/org/powernukkitx/command/defaults/ExecuteCommand.java
@@ -539,7 +539,7 @@ public class ExecuteCommand extends VanillaCommand {
                     log.addError("commands.scoreboard.objectiveNotFound", sourceObjectiveName).output();
                     return 0;
                 }
-                var sourceScoreboard = manager.getScoreboards().get(targetObjectiveName);
+                var sourceScoreboard = manager.getScoreboards().get(sourceObjectiveName);
 
                 if (!sourceScoreboard.getLines().containsKey(sourceScorer)) {
                     log.addError("commands.scoreboard.players.operation.notFound", sourceObjectiveName, sourceScorer.getName()).output();


### PR DESCRIPTION
## What does this PR do?
It fix that "execute if/unless score" read the source's score from the TARGET objective instead of the SOURCE objective.

## Why?

Every comparaison with 2 obejctives were false..
Closes #

## Type of change

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?


- **Server build tested:** 6ea123524
- **Bedrock client version:** 26.45
- **Plugins loaded:** none

**Steps performed and results:**

1.
2.

- [x] I built the server and ran it with this change
- [x] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [x] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure


- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
