### PR TITLE
fix: Duplicate command paths

### DIFF
--- a/src/main/java/org/powernukkitx/command/data/CommandParameter.java
+++ b/src/main/java/org/powernukkitx/command/data/CommandParameter.java
@@ -12,6 +12,8 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -53,6 +55,9 @@ import java.util.concurrent.atomic.AtomicLong;
 public class CommandParameter {
 
     private static final AtomicLong ENUM_COUNTER = new AtomicLong();
+    private static final Map<EnumSignature, String> ENUM_NAMES = new ConcurrentHashMap<>();
+
+    private record EnumSignature(String name, List<String> values) {}
 
     /**
      * An empty array of CommandParameter, used for commands with no arguments.
@@ -214,7 +219,7 @@ public class CommandParameter {
      * @see #newEnum(String, boolean, CommandEnum)
      */
     public static CommandParameter newEnum(String name, boolean optional, String[] values) {
-        return newEnum(name, optional, new CommandEnum(name + "Enums_" + ENUM_COUNTER.incrementAndGet(), values));
+        return newEnum(name, optional, values, false);
     }
 
     /**
@@ -228,7 +233,9 @@ public class CommandParameter {
      * @see #newEnum(String, boolean, CommandEnum)
      */
     public static CommandParameter newEnum(String name, boolean optional, String[] values, boolean soft) {
-        return newEnum(name, optional, new CommandEnum(name + "Enums_" + ENUM_COUNTER.incrementAndGet(), Arrays.asList(values), soft));
+        String enumName = soft ? name + "Enums_" + ENUM_COUNTER.incrementAndGet()
+                : ENUM_NAMES.computeIfAbsent(new EnumSignature(name, List.copyOf(Arrays.asList(values))), ignored -> name + "Enums_" + ENUM_COUNTER.incrementAndGet());
+        return newEnum(name, optional, new CommandEnum(enumName, Arrays.asList(values), soft));
     }
 
     /**

--- a/src/main/java/org/powernukkitx/command/tree/node/PositionNode.java
+++ b/src/main/java/org/powernukkitx/command/tree/node/PositionNode.java
@@ -105,6 +105,10 @@ public abstract class PositionNode extends ParamNode<Position> {
             try {
                 Location loc = sender.getLocation();
                 for (String s : TMP) {
+                    if (index >= coordinate.length) {
+                        this.error();
+                        return;
+                    }
                     if (s.charAt(0) == '~') {
                         this.setRelative(index);
                         String relativeCoordinate = s.substring(1);
@@ -171,6 +175,7 @@ public abstract class PositionNode extends ParamNode<Position> {
     public void reset() {
         super.reset();
         this.relative = 0b0000;
+        this.index = 0;
     }
 
     public void setRelative(byte index) {

--- a/src/test/java/org/powernukkitx/command/data/CommandParameterTest.java
+++ b/src/test/java/org/powernukkitx/command/data/CommandParameterTest.java
@@ -63,6 +63,13 @@ class CommandParameterTest {
     }
 
     @Test
+    void newEnumFromIdenticalValuesReusesEnumName() {
+        CommandParameter first = CommandParameter.newEnum("mode", new String[]{"easy"});
+        CommandParameter second = CommandParameter.newEnum("mode", new String[]{"easy"});
+        assertEquals(first.enumData.getName(), second.enumData.getName());
+    }
+
+    @Test
     void newEnumWithSoftFlagGeneratesUniqueEnumNames() {
         CommandParameter first = CommandParameter.newEnum("mode", false, new String[]{"easy"}, true);
         CommandParameter second = CommandParameter.newEnum("mode", false, new String[]{"hard"}, true);


### PR DESCRIPTION
## What does this PR do?

Fix the duplicated paths in command tree.

## Why?

Commands with different paths end up generating duplicating predictions.

Closes #

## Type of change

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** 7a7ce82e5f39405eea113d54e9902b9a70ba2adf
- **Bedrock client version:** 26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. Type any command that would generate multiple paths (/tickingarea...)
2.

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [X] Existing unit tests pass (`gradlew test`)
- [X] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
|       |             |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [ ] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
