### PR TITLE
feat: Pre-work on uniqueId implementation

### DIFF
--- a/src/main/resources/language/bra/lang.json
+++ b/src/main/resources/language/bra/lang.json
@@ -1109,7 +1109,7 @@
   "nukkit.level.updating": "Dados antigos do mundo \"{%0}\" encontrados, convertendo para o novo formato",
   "nukkit.player.invalidEntity": "{%0} tentou atacar uma entidade inválida",
   "nukkit.player.invalidMove": "{%0} moveu erradamente!",
-  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] entrou com o id de entidade {%3} em ({%4}, {%5}, {%6}, {%7})",
+  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] entrou com o uniqueId de entidade {%3} em ({%4}, {%5}, {%6}, {%7})",
   "nukkit.player.logOut": "{%0}[/{%1}:{%2}] saiu devido a {%3}",
   "nukkit.plugin.aliasError": "Não foi possível carregar apelido de comando {%0} para o plugin {%1}",
   "nukkit.plugin.circularDependency": "Dependência circular detectada",

--- a/src/main/resources/language/chs/lang.json
+++ b/src/main/resources/language/chs/lang.json
@@ -1113,7 +1113,7 @@
   "nukkit.level.updating": "发现旧的世界 \"{%0}\"，正在转换格式",
   "nukkit.player.invalidEntity": "{%0} 尝试攻击一个无效的实体",
   "nukkit.player.invalidMove": "{%0} 行动可疑！",
-  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] 登入游戏，实体 ID 为 {%3}，坐标位于 ({%4}, {%5}, {%6}, {%7})",
+  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] 登入游戏，实体 uniqueId 为 {%3}，坐标位于 ({%4}, {%5}, {%6}, {%7})",
   "nukkit.player.logOut": "{%0}[/{%1}:{%2}] 登出游戏，原因：{%3}",
   "nukkit.plugin.aliasError": "无法读取 {%1} 插件的 {%0} 别名",
   "nukkit.plugin.circularDependency": "检测到循环依赖",

--- a/src/main/resources/language/cht/lang.json
+++ b/src/main/resources/language/cht/lang.json
@@ -1113,7 +1113,7 @@
   "nukkit.level.updating": "發現舊的地圖 \"{%0}\"，正在轉換格式",
   "nukkit.player.invalidEntity": "{%0} 嘗試攻擊一個無效的實體",
   "nukkit.player.invalidMove": "{%0} 行動可疑！",
-  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] 登入遊戲，ID 為 {%3} 座標位於 ({%4}, {%5}, {%6}, {%7})",
+  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] 登入遊戲，uniqueId 為 {%3} 座標位於 ({%4}, {%5}, {%6}, {%7})",
   "nukkit.player.logOut": "{%0}[/{%1}:{%2}] 登出遊戲，原因：{%3}",
   "nukkit.plugin.aliasError": "無法讀取 {%1} 插件的 {%0} 別名",
   "nukkit.plugin.circularDependency": "檢測出迴圈依賴",

--- a/src/main/resources/language/cze/lang.json
+++ b/src/main/resources/language/cze/lang.json
@@ -1108,7 +1108,7 @@
   "nukkit.level.updating": "Byla nalezena stará data o \"{%0}\", převádění formátu",
   "nukkit.player.invalidEntity": "{%0} se pokusil zaútočit na neplatnou entitu",
   "nukkit.player.invalidMove": "Nesprávný přesun {%0}!",
-  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] se přihlásil s ID {%3} na ({%4}, {%5}, {%6}, {%7})",
+  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] se přihlásil s uniqueId {%3} na ({%4}, {%5}, {%6}, {%7})",
   "nukkit.player.logOut": "{%0}[/{%1}:{%2}] odhlášen kvůli {%3}",
   "nukkit.plugin.aliasError": "Nemůžu načíst alias {%0} pro plugin {%1}",
   "nukkit.plugin.circularDependency": "Zjištěna kruhová závislost",

--- a/src/main/resources/language/deu/lang.json
+++ b/src/main/resources/language/deu/lang.json
@@ -1109,7 +1109,7 @@
   "nukkit.level.updating": "\"{%0}\" nutzt noch das alte Weltenformat, konvertiere zum neuen Format...",
   "nukkit.player.invalidEntity": "{%0} versuchte ein fehlerhaftes Entity anzugreifen",
   "nukkit.player.invalidMove": "{%0} bewegte sich fehlerhaft!",
-  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] hat sich mit der ID {%3} bei ({%4}, {%5}, {%6}, {%7}) angemeldet",
+  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] hat sich mit der uniqueId {%3} bei ({%4}, {%5}, {%6}, {%7}) angemeldet",
   "nukkit.player.logOut": "{%0}[/{%1}:{%2}] hat sich ausgeloggt {%3}",
   "nukkit.plugin.aliasError": "Der Alias {%0} vom Plugin {%1} konnte nicht geladen werden.",
   "nukkit.plugin.circularDependency": "Ringabhängigkeit erkannt",

--- a/src/main/resources/language/eng/lang.json
+++ b/src/main/resources/language/eng/lang.json
@@ -1217,7 +1217,7 @@
   "nukkit.level.updating": "Old level data found for \"{%0}\", converting format",
   "nukkit.player.invalidEntity": "{%0} tried to attack an invalid entity",
   "nukkit.player.invalidMove": "{%0} moved wrongly!",
-  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] logged in with entity id {%3} at ({%4}, {%5}, {%6}, {%7})",
+  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] logged in with entity uniqueId {%3} at ({%4}, {%5}, {%6}, {%7})",
   "nukkit.player.logOut": "{%0}[/{%1}:{%2}] logged out due to {%3}",
   "nukkit.plugin.aliasError": "Could not load alias {%0} for plugin {%1}",
   "nukkit.plugin.circularDependency": "Circular dependency detected",

--- a/src/main/resources/language/fil/lang.json
+++ b/src/main/resources/language/fil/lang.json
@@ -1098,7 +1098,7 @@
   "nukkit.level.updating": "Natagpuan ang lumang datos ng antas para sa \"{%0}\", pag-convert format",
   "nukkit.player.invalidEntity": "Sinubukan ni {%0} na atakehin ang isang hindi wastong entity",
   "nukkit.player.invalidMove": "Maling inilipat si {%0}!",
-  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] naka-log in gamit ang entity id na {%3} sa ({%4}, {%5}, {%6}, {%7})",
+  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] naka-log in gamit ang entity uniqueId na {%3} sa ({%4}, {%5}, {%6}, {%7})",
   "nukkit.player.logOut": "{%0}[/{%1}:{%2}] naka-log out dahil sa {%3}",
   "nukkit.plugin.aliasError": "Hindi ma-load ang alias {%0} para sa plugin {%1}",
   "nukkit.plugin.circularDependency": "Nakita ang pabilog na dependency",

--- a/src/main/resources/language/fin/lang.json
+++ b/src/main/resources/language/fin/lang.json
@@ -1109,7 +1109,7 @@
   "nukkit.level.updating": "Vanhat maailman tiedot löytyivät maailmalle \"{%0}\", muutetaan formaattia",
   "nukkit.player.invalidEntity": "{%0} koitti vahingoittaa virheellistä oliota",
   "nukkit.player.invalidMove": "{%0} liikkui väärin!",
-  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] kirjautui sisään (olion tunnus {%3}) sijainnissa ({%4}, {%5}, {%6}, {%7})",
+  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] kirjautui sisään (uniqueId {%3}) sijainnissa ({%4}, {%5}, {%6}, {%7})",
   "nukkit.player.logOut": "{%0}[/{%1}:{%2}] logged out due to {%3}",
   "nukkit.plugin.aliasError": "Ei voitu ladata aliasta {%0} lisäosalle {%1}",
   "nukkit.plugin.circularDependency": "Pyöreä riippuvuus havaittu",

--- a/src/main/resources/language/fra/lang.json
+++ b/src/main/resources/language/fra/lang.json
@@ -1109,7 +1109,7 @@
   "nukkit.level.updating": "Données de l\u0027ancien monde trouvées pour \"{%0}\", conversion du format",
   "nukkit.player.invalidEntity": "{%0} a essayé d\u0027attaquer une entité non valide",
   "nukkit.player.invalidMove": "{%0} s\u0027est mal déplacé !",
-  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] connecté avec l\u0027identifiant {%3} à ({%4}, {%5}, {%6}, {%7})",
+  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] connecté avec l\u0027uniqueId {%3} à ({%4}, {%5}, {%6}, {%7})",
   "nukkit.player.logOut": "{%0}[/{%1}:{%2}] déconnecté à cause de {%3}",
   "nukkit.plugin.aliasError": "Impossible de charger l\u0027alias {%0} pour le plugin {%1}",
   "nukkit.plugin.circularDependency": "Détection d\u0027une dépendance circulaire",

--- a/src/main/resources/language/idn/lang.json
+++ b/src/main/resources/language/idn/lang.json
@@ -1109,7 +1109,7 @@
   "nukkit.level.updating": "Data level lama ditemukan untuk \"{%0}\", converting format",
   "nukkit.player.invalidEntity": "{%0} mencoba menyerang entity yang tidak valid",
   "nukkit.player.invalidMove": "{%0} salah bergerak!",
-  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] masuk dengan id entity {%3} di ({%4}, {%5}, {%6}, {%7})",
+  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] masuk dengan uniqueId entity {%3} di ({%4}, {%5}, {%6}, {%7})",
   "nukkit.player.logOut": "{%0}[/{%1}:{%2}] keluar karena {%3}",
   "nukkit.plugin.aliasError": "Tidak dapat memuat perintah alias {%0} dari plugin {%1}",
   "nukkit.plugin.circularDependency": "Dependensi melingkar terdeteksi",

--- a/src/main/resources/language/jpn/lang.json
+++ b/src/main/resources/language/jpn/lang.json
@@ -1109,7 +1109,7 @@
   "nukkit.level.updating": "古いレベルのデータが見つかりました \"{%0}\" フォーマットを変換しています。",
   "nukkit.player.invalidEntity": "{%0} は無効なエンティティに攻撃しました",
   "nukkit.player.invalidMove": "{%0} が正しく移動できませんでした！",
-  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] がエンティティID {%3} として ({%4}, {%5}, {%6}, {%7})にログインしました",
+  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] がエンティティuniqueId {%3} として ({%4}, {%5}, {%6}, {%7})にログインしました",
   "nukkit.player.logOut": "{%0}[/{%1}:{%2}] は {%3} でログアウト",
   "nukkit.plugin.aliasError": "プラグイン {%1} で、コマンド{%0} に対するエイリアスを登録できませんでした",
   "nukkit.plugin.circularDependency": "循環依存が検出されました",

--- a/src/main/resources/language/kor/lang.json
+++ b/src/main/resources/language/kor/lang.json
@@ -1109,7 +1109,7 @@
   "nukkit.level.updating": "\"{%0}\"의 레벨 데이터가 오래되었습니다, 포맷을 변환합니다",
   "nukkit.player.invalidEntity": "{%0}이(가) 잘못된 개체를 공격하려고 시도했습니다",
   "nukkit.player.invalidMove": "{%0}이(가) 잘못된 움직임을 보였습니다!",
-  "nukkit.player.logIn": "{%0}[/{%1}:{%2}]이(가) 개체 ID {%3}(으)로 ({%4}, {%5}, {%6}, {%7})에 로그인했습니다",
+  "nukkit.player.logIn": "{%0}[/{%1}:{%2}]이(가) 개체 uniqueId {%3}(으)로 ({%4}, {%5}, {%6}, {%7})에 로그인했습니다",
   "nukkit.player.logOut": "{%0}[/{%1}:{%2}]이(가) {%3}(으)로 인해 로그아웃되었습니다",
   "nukkit.plugin.aliasError": "{%0} 별칭을 {%1} 플러그인에서 불러올 수 없습니다",
   "nukkit.plugin.circularDependency": "순환적 의존이 감지되었습니다",

--- a/src/main/resources/language/ltu/lang.json
+++ b/src/main/resources/language/ltu/lang.json
@@ -1109,7 +1109,7 @@
   "nukkit.level.updating": "Rastas pasenęs pasaulis pavadinimu \"{%0}\", atnaujinamas formatas",
   "nukkit.player.invalidEntity": "{%0} bandė atakuoti klaidingą būtybę",
   "nukkit.player.invalidMove": "{%0} neteisingai pajudėjo!",
-  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] prisijungė su būtybės id {%3} koordinatėse ({%4}, {%5}, {%6}, {%7})",
+  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] prisijungė su būtybės uniqueId {%3} koordinatėse ({%4}, {%5}, {%6}, {%7})",
   "nukkit.player.logOut": "{%0}[/{%1}:{%2}] atsijungė dėl {%3}",
   "nukkit.plugin.aliasError": "Neįmanoma įkelti alternatyvos {%0} įskiepiui {%1}",
   "nukkit.plugin.circularDependency": "Aptikta skritulinė priklausomybė",

--- a/src/main/resources/language/pol/lang.json
+++ b/src/main/resources/language/pol/lang.json
@@ -1109,7 +1109,7 @@
   "nukkit.level.updating": "Znaleziono informacje o poziomie dla \"{%0}\", zmiana formatu",
   "nukkit.player.invalidEntity": "{%0} probowal zaatakowac niepoprawny byt",
   "nukkit.player.invalidMove": "{%0} poruszyl sie nieprawidlowo!",
-  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] zalogowal sie z id bytu {%3} na wspolrzednych ({%4}, {%5}, {%6}, {%7})",
+  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] zalogowal sie z uniqueId bytu {%3} na wspolrzednych ({%4}, {%5}, {%6}, {%7})",
   "nukkit.player.logOut": "{%0}[/{%1}:{%2}] rozlaczyl sie z powodu {%3}",
   "nukkit.plugin.aliasError": "Nie udalo sie wczytac aliasu {%0} dla pluginu {%1}",
   "nukkit.plugin.circularDependency": "Wykryto zapetlona zaleznosc",

--- a/src/main/resources/language/rus/lang.json
+++ b/src/main/resources/language/rus/lang.json
@@ -1109,7 +1109,7 @@
   "nukkit.level.updating": "Мир \"{%0}\" использует старый формат, конвертация",
   "nukkit.player.invalidEntity": "{%0} попытался атаковать неправильную сущность",
   "nukkit.player.invalidMove": "{%0} некорректно передвинулся!",
-  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] вошел с id сущности {%3} на ({%4}, {%5}, {%6}, {%7})",
+  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] вошел с uniqueId сущности {%3} на ({%4}, {%5}, {%6}, {%7})",
   "nukkit.player.logOut": "{%0}[/{%1}:{%2}] отключился: {%3}",
   "nukkit.plugin.aliasError": "Не удалось загрузить псевдоним {%0} для плагина {%1}",
   "nukkit.plugin.circularDependency": "Обнаружена круговая зависимость",

--- a/src/main/resources/language/spa/lang.json
+++ b/src/main/resources/language/spa/lang.json
@@ -1109,7 +1109,7 @@
   "nukkit.level.updating": "\"{%0}\" de datos de nivel antiguos encontrados, convirtiendo formato",
   "nukkit.player.invalidEntity": "{%0} Intentó atacar una entidad invalida",
   "nukkit.player.invalidMove": "{%0} movido incorrectamente!",
-  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] Conectado con el nombre {%3} en ({%4}, {%5}, {%6}, {%7})",
+  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] Conectado con el uniqueId {%3} en ({%4}, {%5}, {%6}, {%7})",
   "nukkit.player.logOut": "{%0}[/{%1}:{%2}] Desconectado por {%3}",
   "nukkit.plugin.aliasError": "no se puede cargar el alias {%0} para el complemeto {%1}",
   "nukkit.plugin.circularDependency": "Dependencia circular detectada",

--- a/src/main/resources/language/tur/lang.json
+++ b/src/main/resources/language/tur/lang.json
@@ -1109,7 +1109,7 @@
   "nukkit.level.updating": "\"{%0}\" için eski dünya verisi bulundu, format dönüştürülüyor",
   "nukkit.player.invalidEntity": "{%0} bilinmeyen bir varlığa saldırmayı denedi",
   "nukkit.player.invalidMove": "{%0} geçersiz hareket etti!",
-  "nukkit.player.logIn": "{%0}[/{%1}:{%2}], {%3} Entity ID\u0027si ile ({%4}, {%5}, {%6}, {%7})\u0027da giriş yaptı",
+  "nukkit.player.logIn": "{%0}[/{%1}:{%2}], {%3} Entity uniqueId\u0027si ile ({%4}, {%5}, {%6}, {%7})\u0027da giriş yaptı",
   "nukkit.player.logOut": "{%0}[/{%1}:{%2}], {%3} sebebiyle çıkış yaptı",
   "nukkit.plugin.aliasError": "{%1} {%0} yüklenemedi",
   "nukkit.plugin.circularDependency": "Döngüsel bağımlılık algılandı",

--- a/src/main/resources/language/ukr/lang.json
+++ b/src/main/resources/language/ukr/lang.json
@@ -1109,7 +1109,7 @@
   "nukkit.level.updating": "Old level data found for \"{%0}\", converting format",
   "nukkit.player.invalidEntity": "{%0} намагався атакувати невірну сутність",
   "nukkit.player.invalidMove": "{%0} неправильно рухався!",
-  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] увішов з id сутності {%3} на ({%4}, {%5}, {%6}, {%7})",
+  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] увішов з uniqueId сутності {%3} на ({%4}, {%5}, {%6}, {%7})",
   "nukkit.player.logOut": "{%0}[/{%1}:{%2}] вийшов по причині {%3}",
   "nukkit.plugin.aliasError": "Не вдалось завантажити альтернативу команді {%0} для плагіну {%1}",
   "nukkit.plugin.circularDependency": "Знайдена кругова залежність",

--- a/src/main/resources/language/vie/lang.json
+++ b/src/main/resources/language/vie/lang.json
@@ -1109,7 +1109,7 @@
   "nukkit.level.updating": "Kiểu định dạng thế giỡi cũ \"{%0}\", đang chuyển sang định dạng mới",
   "nukkit.player.invalidEntity": "{%0} tried to attack an invalid entity",
   "nukkit.player.invalidMove": "{%0} di chuyển sai!",
-  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] đã đăng nhập bằng entity id {%3} tại ({%4}, {%5}, {%6}, {%7})",
+  "nukkit.player.logIn": "{%0}[/{%1}:{%2}] đã đăng nhập bằng entity uniqueId {%3} tại ({%4}, {%5}, {%6}, {%7})",
   "nukkit.player.logOut": "{%0}[/{%1}:{%2}] đăng xuất bởi {%3}",
   "nukkit.plugin.aliasError": "Không thể tải alias {%0} cho plugin {%1}",
   "nukkit.plugin.circularDependency": "Circular dependency detected",


### PR DESCRIPTION
## What does this PR do?

Pre-work on uniqueId implementation, changed lang files

## Why?

Reduce the levelDB parity size.

Closes #

## Type of change

<!-- Tick what applies. -->

- [ ] Bug Fix
- [X] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** 7a7ce82e5f39405eea113d54e9902b9a70ba2adf
- **Bedrock client version:** 26.45
- **Plugins loaded:** none

**Steps performed and results:**

1.
2.

- [X] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
|       |             |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [ ] Public API additions/changes have Javadoc
- [ ] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
