### PR TITLE
fix: setworldspawn command not updating level when using coords

### DIFF
--- a/src/main/java/org/powernukkitx/command/defaults/SetWorldSpawnCommand.java
+++ b/src/main/java/org/powernukkitx/command/defaults/SetWorldSpawnCommand.java
@@ -29,15 +29,10 @@ public class SetWorldSpawnCommand extends VanillaCommand {
 
     @Override
     public int execute(CommandSender sender, String commandLabel, Map.Entry<String, ParamList> result, CommandLogger log) {
-        Level level;
-        Vector3 pos;
-        if (!result.getValue().hasResult(0)) {
-            level = sender.getPosition().level;
-            pos = sender.getPosition().round();
-        } else {
-            level = sender.getServer().getDefaultLevel();
-            pos = result.getValue().getResult(0);
-        }
+        Level level = sender.getPosition().level;
+        Vector3 pos = result.getValue().hasResult(0)
+                ? result.getValue().getResult(0)
+                : sender.getPosition().round();
         level.setSpawnLocation(pos);
         DecimalFormat round2 = new DecimalFormat("##0.00");
         log.addSuccess("commands.setworldspawn.success", round2.format(pos.x),


### PR DESCRIPTION
## What does this PR do?

Fix setworldspawn command not updating level when using coordinates.

## Why?

If the previous worldspawn of the player is different, it would update only the coordinates.

Closes #

## Type of change

<!-- Tick what applies. -->

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

<!--
  REQUIRED. Every PR must be tested by a human on a running server.
  "Tested" or "works fine" is not a test report. Be specific:
  what you did, what you saw, what you compared it against.
-->

- **Server build tested:** 7a7ce82e5f39405eea113d54e9902b9a70ba2adf
- **Bedrock client version:** 26.45
- **Plugins loaded:** none

**Steps performed and results:**

1.
2.

- [X] I built the server and ran it with this change
- [ ] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

<!-- Any public API changed, removed, or deprecated? Any config or save-format change? Write "None" if none. -->

None

## Performance notes

<!-- Only for performance-sensitive changes: benchmark numbers, before/after TPS, profiling notes. Otherwise, write "N/A". -->

N/A

## AI usage disclosure

<!--
  REQUIRED. See the "AI Tool Usage" section in CONTRIBUTING.md.
  Name the exact model per task - "Claude" or "AI" is not a model name.
  If no AI was involved at any stage, delete the table and write "No AI used."
-->

| Model | What it did |
|-------|-------------|
|       |             |

- [X] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [X] I have read every line of this diff myself and can explain any of it
- [X] This PR description and any review replies are written by me, not generated

## Checklist

- [X] My change follows the existing code style
- [X] The PR is one logical change, with no unrelated reformatting or refactors
- [ ] Public API additions/changes have Javadoc
- [X] No dead code, commented-out blocks, or debug logging left behind
- [X] Commit messages follow Conventional Commits
- [X] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [X] "Allow maintainer edits" is enabled
