### PR TITLE
fix: race condition on windows

### DIFF
--- a/src/main/java/org/powernukkitx/level/format/leveldb/LevelDBStorage.java
+++ b/src/main/java/org/powernukkitx/level/format/leveldb/LevelDBStorage.java
@@ -1,5 +1,9 @@
 package org.powernukkitx.level.format.leveldb;
 
+import org.iq80.leveldb.env.Env;
+import org.iq80.leveldb.fileenv.EnvImpl;
+import org.iq80.leveldb.fileenv.MmapLimiter;
+import org.iq80.leveldb.impl.DbImpl;
 import org.powernukkitx.level.format.Chunk;
 import org.powernukkitx.level.format.IChunk;
 import org.powernukkitx.level.format.LevelProvider;
@@ -65,7 +69,16 @@ public final class LevelDBStorage {
 
         File dbFolder = path.resolve("db").toFile();
         if (!dbFolder.exists()) dbFolder.mkdirs();
-        db = new Iq80DBFactory().open(dbFolder, options);
+        db = openDb(dbFolder, options);
+    }
+
+    private static DB openDb(File dbFolder, Options options) throws IOException {
+        boolean windows = System.getProperty("os.name", "").toLowerCase().contains("win");
+        if (!windows) {
+            return new Iq80DBFactory().open(dbFolder, options);
+        }
+        Env env = EnvImpl.createEnv(MmapLimiter.newLimiter(0));
+        return new DbImpl(options, dbFolder.getAbsolutePath(), env);
     }
 
     public synchronized void incrementRefCount() {


### PR DESCRIPTION
## What does this PR do?

On Windows, LevelDB worlds are now opened without memory-mapped files (mmap disabled via an environment variable with MmapLimiter set to 0)

## Why?

On Windows, the Java implementation of LevelDB closes the file handle immediately after mapping it to memory. When a background compaction subsequently calls MappedByteBuffer.force(), the native flush fails with ERROR_INVALID_HANDLE, the compaction thread terminates, and the exception is rethrown at every createWriteBatch() call, so no further chunk saves are processed.

## Type of change

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 97ed46b
- **Bedrock client version:** 26.45
- **Plugins loaded:** PNX-Terra

**Steps performed and results:**

1. just fly like 10 minutes

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|       |             |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
