### PR TITLE
fix: tp a player to coordinates in their own world

### DIFF
--- a/src/main/java/org/powernukkitx/command/defaults/TeleportCommand.java
+++ b/src/main/java/org/powernukkitx/command/defaults/TeleportCommand.java
@@ -4,6 +4,7 @@ import org.powernukkitx.command.CommandSender;
 import org.powernukkitx.command.data.CommandEnum;
 import org.powernukkitx.command.data.CommandParameter;
 import org.powernukkitx.command.tree.ParamList;
+import org.powernukkitx.command.tree.node.PositionNode;
 import org.powernukkitx.command.utils.CommandLogger;
 import org.powernukkitx.entity.Entity;
 import org.powernukkitx.level.Location;
@@ -154,7 +155,7 @@ public class TeleportCommand extends VanillaCommand {
                     log.addNoTargetMatch().output();
                     return 0;
                 }
-                Position pos = list.getResult(1);
+                PositionNode posNode = (PositionNode) list.get(1);
                 boolean hasYRot = list.hasResult(2);
                 boolean hasXRot = list.hasResult(3);
                 double yRot = hasYRot ? list.getResult(2) : 0;
@@ -162,21 +163,30 @@ public class TeleportCommand extends VanillaCommand {
                 boolean checkForBlocks = list.hasResult(4) ? list.getResult(4) : false;
 
                 String message = victims.stream().map(v -> v.getViewableName(sender)).collect(Collectors.joining(", "));
-                Location target = Location.fromObject(pos, pos.level);
 
-                if (isUnsafe(target, checkForBlocks)) {
-                    log.addError("commands.tp.safeTeleportFail", message, NukkitMath.round(target.getX(), 2) + ", " + NukkitMath.round(target.getY(), 2) + ", " + NukkitMath.round(target.getZ(), 2)).output();
-                    return 0;
-                }
-
+                Location displayTarget = null;
+                int count = 0;
                 for (Entity victim : victims) {
+                    Position pos = posNode.clonePosition(victim.getLocation());
                     Location destination = getTeleportLocation(victim, pos);
                     if (hasYRot) destination.setYaw(yRot).setHeadYaw(yRot);
                     if (hasXRot) destination.setPitch(xRot);
+
+                    if (isUnsafe(destination, checkForBlocks)) {
+                        log.addError("commands.tp.safeTeleportFail", victim.getViewableName(sender), NukkitMath.round(destination.getX(), 2) + ", " + NukkitMath.round(destination.getY(), 2) + ", " + NukkitMath.round(destination.getZ(), 2)).output();
+                        continue;
+                    }
+
                     victim.teleport(destination);
+                    if (displayTarget == null) displayTarget = destination;
+                    count++;
                 }
-                log.addSuccess("commands.tp.success.coordinates", message, String.valueOf(NukkitMath.round(target.getX(), 2)), String.valueOf(NukkitMath.round(target.getY(), 2)), String.valueOf(NukkitMath.round(target.getZ(), 2))).output(true);
-                return 1;
+
+                if (displayTarget == null) {
+                    return 0;
+                }
+                log.addSuccess("commands.tp.success.coordinates", message, String.valueOf(NukkitMath.round(displayTarget.getX(), 2)), String.valueOf(NukkitMath.round(displayTarget.getY(), 2)), String.valueOf(NukkitMath.round(displayTarget.getZ(), 2))).output(true);
+                return count;
             }
             case "Entity->Pos(FacingPos)" -> {
                 List<Entity> victims = list.getResult(0);

--- a/src/main/java/org/powernukkitx/command/tree/node/PositionNode.java
+++ b/src/main/java/org/powernukkitx/command/tree/node/PositionNode.java
@@ -79,6 +79,14 @@ public abstract class PositionNode extends ParamNode<Position> {
         return (E) this.value;
     }
 
+    public Position clonePosition(Position basePos) {
+        if (this.value == null) return null;
+        double x = this.getRelative(0) ? this.value.x + basePos.getX() : this.value.x;
+        double y = this.getRelative(1) ? this.value.y + basePos.getY() : this.value.y;
+        double z = this.getRelative(2) ? this.value.z + basePos.getZ() : this.value.z;
+        return new Position(x, y, z, basePos.getLevel());
+    }
+
     @Override
     public int getUsedArgs() {
         return 3;


### PR DESCRIPTION
## What does this PR do?

Makes /tp <player> <x> <y> <z> teleport the target within its own world instead of the sender's

## Why?

From the console, /tp <player> <x> <y> <z> sent the player to the default world instead of the world they were in

## Type of change

- [X] Bug Fix
- [ ] New Feature
- [ ] Performance
- [ ] Refactor (no behaviour change)
- [ ] Documentation
- [ ] Build / CI / dependencies

## How was this tested?

- **Server build tested:** 2bd0347
- **Bedrock client version:** 26.45
- **Plugins loaded:** none

**Steps performed and results:**

1. /world tp test and /tp 0 100 0 
2. and from console type /tp <name> 0 100 0

- [X] I built the server and ran it with this change
- [X] I reproduced the original problem and confirmed this fixes it (bug fixes)
- [ ] Existing unit tests pass (`gradlew test`)
- [ ] I added tests for the new logic, or explained below why that isn't practical

## Breaking changes / API impact

None

## Performance notes

N/A

## AI usage disclosure

| Model | What it did |
|-------|-------------|
|       |             |

- [x] The disclosure above covers **all** AI use in this PR - code, tests, Javadoc, commit messages, config, and research
- [x] I have read every line of this diff myself and can explain any of it
- [x] This PR description and any review replies are written by me, not generated

## Checklist

- [x] My change follows the existing code style
- [x] The PR is one logical change, with no unrelated reformatting or refactors
- [x] Public API additions/changes have Javadoc
- [x] No dead code, commented-out blocks, or debug logging left behind
- [x] Commit messages follow Conventional Commits
- [x] My contribution is licensed under LGPL-3.0, and any third-party code is attributed
- [x] "Allow maintainer edits" is enabled
